### PR TITLE
feat(skills): Add sentry-otel-exporter skill

### DIFF
--- a/skills/sentry-otel-exporter/SKILL.md
+++ b/skills/sentry-otel-exporter/SKILL.md
@@ -246,8 +246,8 @@ The exporter respects Sentry rate limits automatically:
 | Component                 | Value                         |
 | ------------------------- | ----------------------------- |
 | Exporter                  | `sentry` (in otelcol-contrib) |
-| OTLP gRPC                 | `localhost:4317`              |
-| OTLP HTTP                 | `http://localhost:4318`       |
+| OTLP gRPC port            | `4317`                        |
+| OTLP HTTP port            | `4318`                        |
 | Default routing attribute | `service.name`                |
 | Auto-create default       | `false`                       |
 | Stability                 | Alpha (traces, logs)          |


### PR DESCRIPTION
Add Claude Code skill for configuring the OpenTelemetry Collector with
the Sentry Exporter. Enables multi-project routing from a single
collector instance using org-level authentication.

This skill guides users through:
- Creating a Sentry Internal Integration with required permissions
- Configuring the OTel Collector with the `sentry` exporter
- Setting up routing by `service.name` or custom attributes
- Auto-creating projects for dynamic environments (Kubernetes, serverless)
- Self-hosted Sentry configuration with TLS
- Troubleshooting common issues

Aligned with:
- [otelcol-contrib sentryexporter spec](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/sentryexporter)
- [Sentry Exporter docs PR](https://github.com/getsentry/sentry-docs/pull/16165)

The skill follows the existing sentry-for-claude skill format and stays under 500 lines.

Made with [Cursor](https://cursor.com)