### PR TITLE
fix: remove unrecognized "logo" key from plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Sentry"
   },
   "keywords": ["sentry", "debugging", "monitoring", "error-tracking"],
-  "logo": "assets/logo.svg",
   "license": "MIT",
   "repository": "https://github.com/getsentry/sentry-for-ai",
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Removes the `"logo"` key from `.claude-plugin/plugin.json`, which is not part of the [Claude Code plugin manifest schema](https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/plugin-structure/references/manifest-reference.md)
- This unrecognized key causes plugin installation to fail with: `Validation errors: : Unrecognized key: "logo"`

## Test plan

- [x] Run `/plugin` in Claude Code and install the sentry plugin - should install without errors
- [x] Verify MCP server connection works after installation

Fixes #11