### PR TITLE
fix: remove unsupported 'logo' key from plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,7 +6,6 @@
     "name": "Sentry"
   },
   "keywords": ["sentry", "debugging", "monitoring", "error-tracking"],
-  "logo": "assets/logo.svg",
   "license": "MIT",
   "repository": "https://github.com/getsentry/sentry-for-ai",
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Remove the `logo` key from `.claude-plugin/plugin.json` which is not recognized by Claude Code's plugin manifest validator

## Problem

Installing the Sentry plugin in Claude Code fails with:

```
Plugin has an invalid manifest file. Validation errors: : Unrecognized key: "logo"
```

This affects both:
- Direct install from the `sentry-plugin-marketplace`
- Install via `claude-plugins-official`

## Fix

Remove the `"logo": "assets/logo.svg"` line from `plugin.json`. The `logo` key is not part of Claude Code's plugin manifest schema.

Fixes #11