### PR TITLE
feat(skills): add dynamic skill fetching to all router skills

### DIFF
--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -22,3 +22,12 @@ Match the user's request to the appropriate feature skill below.
 1. If the user mentions AI monitoring, LLM tracing, or instrumenting an AI SDK → load `sentry-setup-ai-monitoring`.
 2. If the user mentions OpenTelemetry, OTel Collector, or multi-service telemetry routing → load `sentry-otel-exporter-setup`.
 3. If the user mentions alerts, notifications, on-call, Slack/PagerDuty integration, or workflow rules → load `sentry-create-alert`.
+
+## Dynamic Skill Fetching
+
+If the matched skill is **not installed locally**, fetch it directly from the repository:
+
+1. Build the raw URL: `https://raw.githubusercontent.com/getsentry/sentry-for-ai/main/skills/<skill-name>/SKILL.md`
+2. Fetch the file contents (e.g. `curl -sL <url>`) and follow its instructions.
+
+The [Skill Tree](../../SKILL_TREE.md) lists every available skill with its path — use it as the source of truth for valid skill names and paths.

--- a/skills/sentry-sdk-setup/SKILL.md
+++ b/skills/sentry-sdk-setup/SKILL.md
@@ -30,3 +30,12 @@ Detect the user's platform from project files (e.g. `package.json`, `go.mod`, `G
 3. If Next.js is detected, prefer `sentry-nextjs-sdk` over `sentry-react-sdk`.
 4. If React Native is detected, prefer `sentry-react-native-sdk` over `sentry-react-sdk`.
 5. If no match is found, direct the user to https://docs.sentry.io/platforms/ to find their platform.
+
+## Dynamic Skill Fetching
+
+If the matched SDK skill is **not installed locally**, fetch it directly from the repository:
+
+1. Build the raw URL: `https://raw.githubusercontent.com/getsentry/sentry-for-ai/main/skills/<skill-name>/SKILL.md`
+2. Fetch the file contents (e.g. `curl -sL <url>`) and follow its instructions.
+
+The [Skill Tree](../../SKILL_TREE.md) lists every available skill with its path — use it as the source of truth for valid skill names and paths.

--- a/skills/sentry-workflow/SKILL.md
+++ b/skills/sentry-workflow/SKILL.md
@@ -23,3 +23,12 @@ Match the user's intent to the appropriate workflow skill below.
 2. If the user mentions Sentry bot comments, PR review comments from Sentry, or `sentry[bot]` → load `sentry-code-review`.
 3. If the user mentions Seer, bug prediction, or reviewing PRs for predicted issues → load `sentry-pr-code-review`.
 4. When unclear, ask whether the task involves live production issues (MCP) or PR review comments.
+
+## Dynamic Skill Fetching
+
+If the matched skill is **not installed locally**, fetch it directly from the repository:
+
+1. Build the raw URL: `https://raw.githubusercontent.com/getsentry/sentry-for-ai/main/skills/<skill-name>/SKILL.md`
+2. Fetch the file contents (e.g. `curl -sL <url>`) and follow its instructions.
+
+The [Skill Tree](../../SKILL_TREE.md) lists every available skill with its path — use it as the source of truth for valid skill names and paths.


### PR DESCRIPTION
## Summary

When an agent matches a skill via a router but doesn't have it installed locally, the router now instructs it to fetch the `SKILL.md` directly from GitHub using the raw content URL:

```
https://raw.githubusercontent.com/getsentry/sentry-for-ai/main/skills/<skill-name>/SKILL.md
```

This means agents that only have the three router skills installed can still access the full library of SDK, workflow, and feature skills on-demand — no local clone required. The [Skill Tree](SKILL_TREE.md) is referenced as the source of truth for valid skill names and paths.

## Changes

Added a **Dynamic Skill Fetching** section to all three router skills:

- `sentry-sdk-setup` — SDK setup wizard routing
- `sentry-workflow` — issue fixing, code review routing
- `sentry-feature-setup` — AI monitoring, OTel, alerts routing

## Validation

- `scripts/build-skill-tree.sh --check` passes with 0 errors