### PR TITLE
fix(ci): Pass WARDEN_SENTRY_DSN in warden workflow

### DIFF
--- a/.github/workflows/warden.yml
+++ b/.github/workflows/warden.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       WARDEN_ANTHROPIC_API_KEY: ${{ secrets.WARDEN_ANTHROPIC_API_KEY }}
       WARDEN_MODEL: ${{ secrets.WARDEN_MODEL }}
+      WARDEN_SENTRY_DSN: ${{ secrets.WARDEN_SENTRY_DSN }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Adds the `WARDEN_SENTRY_DSN` secret as an environment variable in the warden CI workflow so that Sentry error reporting is available during warden runs.


Agent transcript: https://claudescope.sentry.dev/share/KI5jmHEtEYcBgH7VOBA-OSyfX2eyFETuotJf7IBXh-g