### PR TITLE
docs(sentry-nestjs-sdk): Add DI wrappers, config-driven init, BullMQ WorkerHost

### DIFF
--- a/skills/sentry-nestjs-sdk/SKILL.md
+++ b/skills/sentry-nestjs-sdk/SKILL.md
@@ -41,6 +41,15 @@ grep -i sentry package.json 2>/dev/null
 ls src/instrument.ts 2>/dev/null
 grep -r "Sentry.init\|@sentry" src/main.ts src/instrument.ts 2>/dev/null
 
+# Check for existing Sentry DI wrapper (common in enterprise NestJS)
+grep -rE "SENTRY.*TOKEN|SentryProxy|SentryService" src/ libs/ 2>/dev/null
+
+# Check for config-class-based init (vs env-var-based)
+grep -rE "class SentryConfig|SentryConfig" src/ libs/ 2>/dev/null
+
+# Check if SentryModule.forRoot() is already registered in a shared module
+grep -rE "SentryModule\.forRoot|SentryProxyModule" src/ libs/ 2>/dev/null
+
 # Detect HTTP adapter (default is Express)
 grep -E "FastifyAdapter|@nestjs/platform-fastify" package.json src/main.ts 2>/dev/null
 
@@ -54,7 +63,7 @@ grep '"@nestjs/microservices"' package.json 2>/dev/null
 grep -E '"@nestjs/websockets"|"socket.io"' package.json 2>/dev/null
 
 # Detect task queues / scheduled jobs
-grep -E '"@nestjs/bull"|"@nestjs/schedule"|"bullmq"|"bull"' package.json 2>/dev/null
+grep -E '"@nestjs/bull"|"@nestjs/bullmq"|"@nestjs/schedule"|"bullmq"|"bull"' package.json 2>/dev/null
 
 # Detect databases
 grep -E '"@prisma/client"|"typeorm"|"mongoose"|"pg"|"mysql2"' package.json 2>/dev/null
@@ -67,7 +76,11 @@ ls -d ../frontend ../web ../client ../ui 2>/dev/null
 ```
 
 **What to note:**
+
 - Is `@sentry/nestjs` already installed? If yes, check if `instrument.ts` exists and `Sentry.init()` is called — may just need feature config.
+- **Sentry DI wrapper detected?** → The project wraps Sentry behind a DI token (e.g. `SENTRY_PROXY_TOKEN`) for testability. Use the injected proxy for all runtime Sentry calls (`startSpan`, `captureException`, `withIsolationScope`) instead of importing `@sentry/nestjs` directly in controllers, services, and processors. Only `instrument.ts` should import `@sentry/nestjs` directly.
+- **Config class detected?** → The project uses a typed config class for `Sentry.init()` options (e.g. loaded from YAML or `@nestjs/config`). Any new SDK options must be added to the config type — do not hardcode values that should be configurable per environment.
+- **`SentryModule.forRoot()` already registered?** → If it's in a shared module (e.g. a Sentry proxy module), do not add it again in `AppModule` — this causes duplicate interceptor registration.
 - Express (default) or Fastify adapter? Express is fully supported; Fastify works but has known edge cases.
 - GraphQL detected? → `SentryGlobalFilter` handles it natively.
 - Microservices detected? → Recommend RPC exception filter.
@@ -83,10 +96,12 @@ ls -d ../frontend ../web ../client ../ui 2>/dev/null
 Based on what you found, present a concrete proposal. Don't ask open-ended questions — lead with a recommendation:
 
 **Always recommended (core coverage):**
+
 - ✅ **Error Monitoring** — captures unhandled exceptions across HTTP, GraphQL, RPC, and WebSocket contexts
 - ✅ **Tracing** — auto-instruments middleware, guards, pipes, interceptors, filters, and route handlers
 
 **Recommend when detected:**
+
 - ✅ **Profiling** — production apps where CPU performance matters (`@sentry/profiling-node`)
 - ✅ **Logging** — structured Sentry Logs + optional console capture
 - ✅ **Crons** — `@nestjs/schedule`, Bull, or BullMQ detected
@@ -95,17 +110,17 @@ Based on what you found, present a concrete proposal. Don't ask open-ended quest
 
 **Recommendation matrix:**
 
-| Feature | Recommend when... | Reference |
-|---------|------------------|-----------|
-| Error Monitoring | **Always** — non-negotiable baseline | `${SKILL_ROOT}/references/error-monitoring.md` |
-| Tracing | **Always** — NestJS lifecycle is auto-instrumented | `${SKILL_ROOT}/references/tracing.md` |
-| Profiling | Production + CPU-sensitive workloads | `${SKILL_ROOT}/references/profiling.md` |
-| Logging | Always; enhanced for structured log aggregation | `${SKILL_ROOT}/references/logging.md` |
-| Metrics | Custom business KPIs or SLO tracking | `${SKILL_ROOT}/references/metrics.md` |
-| Crons | `@nestjs/schedule`, Bull, or BullMQ detected | `${SKILL_ROOT}/references/crons.md` |
-| AI Monitoring | OpenAI/Anthropic/LangChain/etc. detected | `${SKILL_ROOT}/references/ai-monitoring.md` |
+| Feature          | Recommend when...                                  | Reference                                      |
+| ---------------- | -------------------------------------------------- | ---------------------------------------------- |
+| Error Monitoring | **Always** — non-negotiable baseline               | `${SKILL_ROOT}/references/error-monitoring.md` |
+| Tracing          | **Always** — NestJS lifecycle is auto-instrumented | `${SKILL_ROOT}/references/tracing.md`          |
+| Profiling        | Production + CPU-sensitive workloads               | `${SKILL_ROOT}/references/profiling.md`        |
+| Logging          | Always; enhanced for structured log aggregation    | `${SKILL_ROOT}/references/logging.md`          |
+| Metrics          | Custom business KPIs or SLO tracking               | `${SKILL_ROOT}/references/metrics.md`          |
+| Crons            | `@nestjs/schedule`, Bull, or BullMQ detected       | `${SKILL_ROOT}/references/crons.md`            |
+| AI Monitoring    | OpenAI/Anthropic/LangChain/etc. detected           | `${SKILL_ROOT}/references/ai-monitoring.md`    |
 
-Propose: *"I recommend Error Monitoring + Tracing + Logging. Want Profiling, Crons, or AI Monitoring too?"*
+Propose: _"I recommend Error Monitoring + Tracing + Logging. Want Profiling, Crons, or AI Monitoring too?"_
 
 ---
 
@@ -126,6 +141,12 @@ npm install @sentry/nestjs @sentry/profiling-node
 ### Three-File Setup (Required)
 
 NestJS requires a specific three-file initialization pattern because the Sentry SDK must patch Node.js modules (via OpenTelemetry) **before** NestJS loads them.
+
+> **Before creating new files**, check Phase 1 results:
+>
+> - If `instrument.ts` already exists → modify it, don't create a new one.
+> - If a config class drives `Sentry.init()` → read options from the config instead of hardcoding env vars.
+> - If a Sentry DI wrapper exists → use it for runtime calls instead of importing `@sentry/nestjs` directly in services/controllers.
 
 #### Step 1: Create `src/instrument.ts`
 
@@ -152,6 +173,28 @@ Sentry.init({
   enableLogs: true,
 });
 ```
+
+**Config-driven `Sentry.init()`:** If Phase 1 found a typed config class (e.g. `SentryConfig`), read options from it instead of using raw `process.env`. This is common in NestJS apps that use `@nestjs/config` or custom config loaders:
+
+```typescript
+import * as Sentry from "@sentry/nestjs";
+import { loadConfiguration } from "./config";
+
+const config = loadConfiguration();
+
+Sentry.init({
+  dsn: config.sentry.dsn,
+  environment: config.sentry.environment ?? "production",
+  release: config.sentry.release,
+  sendDefaultPii: config.sentry.sendDefaultPii ?? true,
+  tracesSampleRate: config.sentry.tracesSampleRate ?? 1.0,
+  profileSessionSampleRate: config.sentry.profilesSampleRate ?? 1.0,
+  profileLifecycle: "trace",
+  enableLogs: true,
+});
+```
+
+When adding new SDK options (e.g. `sendDefaultPii`, `profileSessionSampleRate`), add them to the config type so they can be configured per environment.
 
 #### Step 2: Import `instrument.ts` FIRST in `src/main.ts`
 
@@ -186,14 +229,14 @@ import { AppService } from "./app.service";
 
 @Module({
   imports: [
-    SentryModule.forRoot(),  // Registers SentryTracingInterceptor globally
+    SentryModule.forRoot(), // Registers SentryTracingInterceptor globally
   ],
   controllers: [AppController],
   providers: [
     AppService,
     {
       provide: APP_FILTER,
-      useClass: SentryGlobalFilter,  // Captures all unhandled exceptions
+      useClass: SentryGlobalFilter, // Captures all unhandled exceptions
     },
   ],
 })
@@ -201,10 +244,14 @@ export class AppModule {}
 ```
 
 **What each piece does:**
+
 - `SentryModule.forRoot()` — registers `SentryTracingInterceptor` as a global `APP_INTERCEPTOR`, enabling HTTP transaction naming
 - `SentryGlobalFilter` — extends `BaseExceptionFilter`; captures exceptions across HTTP, GraphQL (rethrows `HttpException` without reporting), and RPC contexts
 
+> ⚠️ **Do NOT register `SentryModule.forRoot()` twice.** If Phase 1 found it already imported in a shared library module (e.g. a `SentryProxyModule` or `AnalyticsModule`), do not add it again in `AppModule`. Duplicate registration causes every span to be intercepted twice, bloating trace data.
+
 > ⚠️ **Two entrypoints, different imports:**
+>
 > - `@sentry/nestjs` → SDK init, capture APIs, decorators (`SentryTraced`, `SentryCron`, `SentryExceptionCaptured`)
 > - `@sentry/nestjs/setup` → NestJS DI constructs (`SentryModule`, `SentryGlobalFilter`)
 >
@@ -234,6 +281,7 @@ Sentry.init({
 ```
 
 Or via environment:
+
 ```bash
 NODE_OPTIONS="--import ./instrument.mjs" npm run start
 ```
@@ -254,7 +302,7 @@ import { SentryExceptionCaptured } from "@sentry/nestjs";
 
 @Catch()
 export class YourExistingFilter implements ExceptionFilter {
-  @SentryExceptionCaptured()  // Wraps catch() to auto-report exceptions
+  @SentryExceptionCaptured() // Wraps catch() to auto-report exceptions
   catch(exception: unknown, host: ArgumentsHost): void {
     // Your existing error handling continues unchanged
   }
@@ -324,10 +372,11 @@ import { SentryCron } from "@sentry/nestjs";
 @Injectable()
 export class ReportService {
   @Cron("0 * * * *")
-  @SentryCron("hourly-report", {  // @SentryCron must come AFTER @Cron
+  @SentryCron("hourly-report", {
+    // @SentryCron must come AFTER @Cron
     schedule: { type: "crontab", value: "0 * * * *" },
-    checkinMargin: 2,    // Minutes before marking missed
-    maxRuntime: 10,      // Max runtime in minutes
+    checkinMargin: 2, // Minutes before marking missed
+    maxRuntime: 10, // Max runtime in minutes
     timezone: "UTC",
   })
   async generateReport() {
@@ -359,6 +408,36 @@ export class JobService {
 
 Apply `withIsolationScope` to: `@Cron()`, `@Interval()`, `@OnEvent()`, `@Processor()`, and any code outside the request lifecycle.
 
+### Working with Sentry DI Wrappers
+
+Some NestJS projects wrap Sentry behind a dependency injection token (e.g. `SENTRY_PROXY_TOKEN`) for testability and decoupling. If Phase 1 detected this pattern, **use the injected service for all runtime Sentry calls** — do not import `@sentry/nestjs` directly in controllers, services, or processors.
+
+```typescript
+import { Controller, Inject } from "@nestjs/common";
+import { SENTRY_PROXY_TOKEN, type SentryProxyService } from "./sentry-proxy";
+
+@Controller("orders")
+export class OrderController {
+  constructor(
+    @Inject(SENTRY_PROXY_TOKEN) private readonly sentry: SentryProxyService,
+    private readonly orderService: OrderService,
+  ) {}
+
+  @Post()
+  async createOrder(@Body() dto: CreateOrderDto) {
+    return this.sentry.startSpan(
+      { name: "createOrder", op: "http" },
+      async () => this.orderService.create(dto),
+    );
+  }
+}
+```
+
+**Where direct `@sentry/nestjs` import is still correct:**
+
+- `instrument.ts` — always uses `import * as Sentry from "@sentry/nestjs"` for `Sentry.init()`
+- Standalone scripts and exception filters that run outside the DI container
+
 ### Verification
 
 Add a test endpoint to confirm events reach Sentry:
@@ -389,15 +468,15 @@ Hit `GET /debug-sentry` and check the Sentry Issues dashboard within seconds.
 
 Walk through features one at a time. Load the reference, follow its steps, verify before moving on:
 
-| Feature | Reference file | Load when... |
-|---------|---------------|-------------|
-| Error Monitoring | `${SKILL_ROOT}/references/error-monitoring.md` | Always (baseline) |
-| Tracing | `${SKILL_ROOT}/references/tracing.md` | Always (NestJS routes are auto-traced) |
-| Profiling | `${SKILL_ROOT}/references/profiling.md` | CPU-intensive production apps |
-| Logging | `${SKILL_ROOT}/references/logging.md` | Structured log aggregation needed |
-| Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom KPIs / SLO tracking |
-| Crons | `${SKILL_ROOT}/references/crons.md` | Scheduled jobs or task queues |
-| AI Monitoring | `${SKILL_ROOT}/references/ai-monitoring.md` | OpenAI/Anthropic/LangChain detected |
+| Feature          | Reference file                                 | Load when...                           |
+| ---------------- | ---------------------------------------------- | -------------------------------------- |
+| Error Monitoring | `${SKILL_ROOT}/references/error-monitoring.md` | Always (baseline)                      |
+| Tracing          | `${SKILL_ROOT}/references/tracing.md`          | Always (NestJS routes are auto-traced) |
+| Profiling        | `${SKILL_ROOT}/references/profiling.md`        | CPU-intensive production apps          |
+| Logging          | `${SKILL_ROOT}/references/logging.md`          | Structured log aggregation needed      |
+| Metrics          | `${SKILL_ROOT}/references/metrics.md`          | Custom KPIs / SLO tracking             |
+| Crons            | `${SKILL_ROOT}/references/crons.md`            | Scheduled jobs or task queues          |
+| AI Monitoring    | `${SKILL_ROOT}/references/ai-monitoring.md`    | OpenAI/Anthropic/LangChain detected    |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
 
@@ -407,65 +486,65 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 
 ### Key `Sentry.init()` Options
 
-| Option | Type | Default | Purpose |
-|--------|------|---------|---------|
-| `dsn` | `string` | — | SDK disabled if empty; env: `SENTRY_DSN` |
-| `environment` | `string` | `"production"` | e.g., `"staging"`; env: `SENTRY_ENVIRONMENT` |
-| `release` | `string` | — | e.g., `"myapp@1.0.0"`; env: `SENTRY_RELEASE` |
-| `sendDefaultPii` | `boolean` | `false` | Include IP addresses and request headers |
-| `tracesSampleRate` | `number` | — | Transaction sample rate; `undefined` disables tracing |
-| `tracesSampler` | `function` | — | Custom per-transaction sampling (overrides rate) |
-| `tracePropagationTargets` | `Array<string\|RegExp>` | — | URLs to propagate `sentry-trace`/`baggage` headers to |
-| `profileSessionSampleRate` | `number` | — | Continuous profiling session rate (SDK ≥ 10.27.0) |
-| `profileLifecycle` | `"trace"\|"manual"` | `"trace"` | `"trace"` = auto-start profiler with spans; `"manual"` = call `startProfiler()`/`stopProfiler()` |
-| `enableLogs` | `boolean` | `false` | Send structured logs to Sentry (SDK ≥ 9.41.0) |
-| `ignoreErrors` | `Array<string\|RegExp>` | `[]` | Error message patterns to suppress |
-| `ignoreTransactions` | `Array<string\|RegExp>` | `[]` | Transaction name patterns to suppress |
-| `beforeSend` | `function` | — | Hook to mutate or drop error events |
-| `beforeSendTransaction` | `function` | — | Hook to mutate or drop transaction events |
-| `beforeSendLog` | `function` | — | Hook to mutate or drop log events |
-| `debug` | `boolean` | `false` | Verbose SDK debug output |
-| `maxBreadcrumbs` | `number` | `100` | Max breadcrumbs per event |
+| Option                     | Type                    | Default        | Purpose                                                                                          |
+| -------------------------- | ----------------------- | -------------- | ------------------------------------------------------------------------------------------------ |
+| `dsn`                      | `string`                | —              | SDK disabled if empty; env: `SENTRY_DSN`                                                         |
+| `environment`              | `string`                | `"production"` | e.g., `"staging"`; env: `SENTRY_ENVIRONMENT`                                                     |
+| `release`                  | `string`                | —              | e.g., `"myapp@1.0.0"`; env: `SENTRY_RELEASE`                                                     |
+| `sendDefaultPii`           | `boolean`               | `false`        | Include IP addresses and request headers                                                         |
+| `tracesSampleRate`         | `number`                | —              | Transaction sample rate; `undefined` disables tracing                                            |
+| `tracesSampler`            | `function`              | —              | Custom per-transaction sampling (overrides rate)                                                 |
+| `tracePropagationTargets`  | `Array<string\|RegExp>` | —              | URLs to propagate `sentry-trace`/`baggage` headers to                                            |
+| `profileSessionSampleRate` | `number`                | —              | Continuous profiling session rate (SDK ≥ 10.27.0)                                                |
+| `profileLifecycle`         | `"trace"\|"manual"`     | `"trace"`      | `"trace"` = auto-start profiler with spans; `"manual"` = call `startProfiler()`/`stopProfiler()` |
+| `enableLogs`               | `boolean`               | `false`        | Send structured logs to Sentry (SDK ≥ 9.41.0)                                                    |
+| `ignoreErrors`             | `Array<string\|RegExp>` | `[]`           | Error message patterns to suppress                                                               |
+| `ignoreTransactions`       | `Array<string\|RegExp>` | `[]`           | Transaction name patterns to suppress                                                            |
+| `beforeSend`               | `function`              | —              | Hook to mutate or drop error events                                                              |
+| `beforeSendTransaction`    | `function`              | —              | Hook to mutate or drop transaction events                                                        |
+| `beforeSendLog`            | `function`              | —              | Hook to mutate or drop log events                                                                |
+| `debug`                    | `boolean`               | `false`        | Verbose SDK debug output                                                                         |
+| `maxBreadcrumbs`           | `number`                | `100`          | Max breadcrumbs per event                                                                        |
 
 ### Environment Variables
 
-| Variable | Maps to | Notes |
-|----------|---------|-------|
-| `SENTRY_DSN` | `dsn` | Used if `dsn` not passed to `init()` |
-| `SENTRY_RELEASE` | `release` | Also auto-detected from git SHA, Heroku, CircleCI |
-| `SENTRY_ENVIRONMENT` | `environment` | Falls back to `"production"` |
-| `SENTRY_AUTH_TOKEN` | CLI/source maps | For `npx @sentry/wizard@latest -i sourcemaps` |
-| `SENTRY_ORG` | CLI/source maps | Organization slug |
-| `SENTRY_PROJECT` | CLI/source maps | Project slug |
+| Variable             | Maps to         | Notes                                             |
+| -------------------- | --------------- | ------------------------------------------------- |
+| `SENTRY_DSN`         | `dsn`           | Used if `dsn` not passed to `init()`              |
+| `SENTRY_RELEASE`     | `release`       | Also auto-detected from git SHA, Heroku, CircleCI |
+| `SENTRY_ENVIRONMENT` | `environment`   | Falls back to `"production"`                      |
+| `SENTRY_AUTH_TOKEN`  | CLI/source maps | For `npx @sentry/wizard@latest -i sourcemaps`     |
+| `SENTRY_ORG`         | CLI/source maps | Organization slug                                 |
+| `SENTRY_PROJECT`     | CLI/source maps | Project slug                                      |
 
 ### Auto-Enabled Integrations
 
 These integrations activate automatically when their packages are detected — no `integrations: [...]` needed:
 
-| Auto-enabled | Notes |
-|---|---|
-| `httpIntegration` | Outgoing HTTP calls via `http`/`https`/`fetch` |
-| `expressIntegration` | Express adapter (default NestJS) |
-| `nestIntegration` | NestJS lifecycle (middleware, guards, pipes, interceptors, handlers) |
-| `onUncaughtExceptionIntegration` | Uncaught exceptions |
-| `onUnhandledRejectionIntegration` | Unhandled promise rejections |
-| `openAIIntegration` | OpenAI SDK (when installed) |
-| `anthropicAIIntegration` | Anthropic SDK (when installed) |
-| `langchainIntegration` | LangChain (when installed) |
-| `graphqlIntegration` | GraphQL (when `graphql` package present) |
-| `postgresIntegration` | `pg` driver |
-| `mysqlIntegration` | `mysql` / `mysql2` |
-| `mongoIntegration` | MongoDB / Mongoose |
-| `redisIntegration` | `ioredis` / `redis` |
+| Auto-enabled                      | Notes                                                                |
+| --------------------------------- | -------------------------------------------------------------------- |
+| `httpIntegration`                 | Outgoing HTTP calls via `http`/`https`/`fetch`                       |
+| `expressIntegration`              | Express adapter (default NestJS)                                     |
+| `nestIntegration`                 | NestJS lifecycle (middleware, guards, pipes, interceptors, handlers) |
+| `onUncaughtExceptionIntegration`  | Uncaught exceptions                                                  |
+| `onUnhandledRejectionIntegration` | Unhandled promise rejections                                         |
+| `openAIIntegration`               | OpenAI SDK (when installed)                                          |
+| `anthropicAIIntegration`          | Anthropic SDK (when installed)                                       |
+| `langchainIntegration`            | LangChain (when installed)                                           |
+| `graphqlIntegration`              | GraphQL (when `graphql` package present)                             |
+| `postgresIntegration`             | `pg` driver                                                          |
+| `mysqlIntegration`                | `mysql` / `mysql2`                                                   |
+| `mongoIntegration`                | MongoDB / Mongoose                                                   |
+| `redisIntegration`                | `ioredis` / `redis`                                                  |
 
 ### Integrations Requiring Manual Setup
 
-| Integration | When to add | Code |
-|---|---|---|
-| `nodeProfilingIntegration` | Profiling desired | `import { nodeProfilingIntegration } from "@sentry/profiling-node"` |
-| `prismaIntegration` | Prisma ORM used | `integrations: [Sentry.prismaIntegration()]` |
-| `consoleLoggingIntegration` | Capture console output | `integrations: [Sentry.consoleLoggingIntegration()]` |
-| `localVariablesIntegration` | Capture local var values in errors | `integrations: [Sentry.localVariablesIntegration()]` |
+| Integration                 | When to add                        | Code                                                                |
+| --------------------------- | ---------------------------------- | ------------------------------------------------------------------- |
+| `nodeProfilingIntegration`  | Profiling desired                  | `import { nodeProfilingIntegration } from "@sentry/profiling-node"` |
+| `prismaIntegration`         | Prisma ORM used                    | `integrations: [Sentry.prismaIntegration()]`                        |
+| `consoleLoggingIntegration` | Capture console output             | `integrations: [Sentry.consoleLoggingIntegration()]`                |
+| `localVariablesIntegration` | Capture local var values in errors | `integrations: [Sentry.localVariablesIntegration()]`                |
 
 ---
 
@@ -482,12 +561,14 @@ getError() {
 ```
 
 Or send a test message without crashing:
+
 ```typescript
 import * as Sentry from "@sentry/nestjs";
 Sentry.captureMessage("NestJS Sentry SDK test");
 ```
 
 If nothing appears:
+
 1. Set `debug: true` in `Sentry.init()` — prints SDK internals to stdout
 2. Verify `SENTRY_DSN` env var is set in the running process
 3. Check that `import "./instrument"` is the **first line** in `main.ts`
@@ -508,49 +589,53 @@ cat ../frontend/package.json ../web/package.json 2>/dev/null \
 
 If a frontend exists without Sentry, suggest the matching skill:
 
-| Frontend detected | Suggest skill |
-|-------------------|--------------|
-| Next.js | `sentry-nextjs-sdk` |
-| React | `sentry-react-sdk` |
-| Svelte / SvelteKit | `sentry-svelte-sdk` |
-| Vue / Nuxt | Use `@sentry/vue` — see [docs.sentry.io/platforms/javascript/guides/vue/](https://docs.sentry.io/platforms/javascript/guides/vue/) |
-| React Native / Expo | `sentry-react-native-sdk` |
+| Frontend detected   | Suggest skill                                                                                                                      |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Next.js             | `sentry-nextjs-sdk`                                                                                                                |
+| React               | `sentry-react-sdk`                                                                                                                 |
+| Svelte / SvelteKit  | `sentry-svelte-sdk`                                                                                                                |
+| Vue / Nuxt          | Use `@sentry/vue` — see [docs.sentry.io/platforms/javascript/guides/vue/](https://docs.sentry.io/platforms/javascript/guides/vue/) |
+| React Native / Expo | `sentry-react-native-sdk`                                                                                                          |
 
 ---
 
 ## Troubleshooting
 
-| Issue | Solution |
-|-------|----------|
-| Events not appearing | Set `debug: true`, verify `SENTRY_DSN`, check `instrument.ts` is imported first |
-| Malformed DSN error | Format: `https://<key>@o<org>.ingest.sentry.io/<project>` |
-| Exceptions not captured | Ensure `SentryGlobalFilter` is registered via `APP_FILTER` in `AppModule` |
-| Auto-instrumentation not working | `instrument.ts` must be the **first import** in `main.ts` — before all NestJS imports |
-| Profiling not starting | Requires `tracesSampleRate > 0` + `profileSessionSampleRate > 0` + `@sentry/profiling-node` installed |
-| `enableLogs` not working | Requires SDK ≥ 9.41.0 |
-| No traces appearing | Verify `tracesSampleRate` is set (not `undefined`) |
-| Too many transactions | Lower `tracesSampleRate` or use `tracesSampler` to drop health checks |
-| Fastify + GraphQL issues | Known edge cases — see [GitHub #13388](https://github.com/getsentry/sentry-javascript/issues/13388); prefer Express for GraphQL |
-| Background job events mixed | Wrap job body in `Sentry.withIsolationScope(() => { ... })` |
-| Prisma spans missing | Add `integrations: [Sentry.prismaIntegration()]` to `Sentry.init()` |
-| ESM syntax errors | Set `registerEsmLoaderHooks: false` (disables ESM hooks; also disables auto-instrumentation for ESM modules) |
-| `SentryModule` breaks instrumentation | Must import from `@sentry/nestjs/setup`, never from `@sentry/nestjs` |
-| RPC exceptions not captured | Add dedicated `SentryRpcExceptionFilter` (see Option D in exception filter section) |
-| WebSocket exceptions not captured | Use `@SentryExceptionCaptured()` on gateway `handleConnection`/`handleDisconnect` |
-| `@SentryCron` not triggering | Decorator order matters — `@SentryCron` MUST come after `@Cron` |
-| TypeScript path alias issues | Ensure `tsconfig.json` `paths` are configured so `instrument` resolves from `main.ts` location |
+| Issue                                              | Solution                                                                                                                                                      |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Events not appearing                               | Set `debug: true`, verify `SENTRY_DSN`, check `instrument.ts` is imported first                                                                               |
+| Malformed DSN error                                | Format: `https://<key>@o<org>.ingest.sentry.io/<project>`                                                                                                     |
+| Exceptions not captured                            | Ensure `SentryGlobalFilter` is registered via `APP_FILTER` in `AppModule`                                                                                     |
+| Auto-instrumentation not working                   | `instrument.ts` must be the **first import** in `main.ts` — before all NestJS imports                                                                         |
+| Profiling not starting                             | Requires `tracesSampleRate > 0` + `profileSessionSampleRate > 0` + `@sentry/profiling-node` installed                                                         |
+| `enableLogs` not working                           | Requires SDK ≥ 9.41.0                                                                                                                                         |
+| No traces appearing                                | Verify `tracesSampleRate` is set (not `undefined`)                                                                                                            |
+| Too many transactions                              | Lower `tracesSampleRate` or use `tracesSampler` to drop health checks                                                                                         |
+| Fastify + GraphQL issues                           | Known edge cases — see [GitHub #13388](https://github.com/getsentry/sentry-javascript/issues/13388); prefer Express for GraphQL                               |
+| Background job events mixed                        | Wrap job body in `Sentry.withIsolationScope(() => { ... })`                                                                                                   |
+| Prisma spans missing                               | Add `integrations: [Sentry.prismaIntegration()]` to `Sentry.init()`                                                                                           |
+| ESM syntax errors                                  | Set `registerEsmLoaderHooks: false` (disables ESM hooks; also disables auto-instrumentation for ESM modules)                                                  |
+| `SentryModule` breaks instrumentation              | Must import from `@sentry/nestjs/setup`, never from `@sentry/nestjs`                                                                                          |
+| RPC exceptions not captured                        | Add dedicated `SentryRpcExceptionFilter` (see Option D in exception filter section)                                                                           |
+| WebSocket exceptions not captured                  | Use `@SentryExceptionCaptured()` on gateway `handleConnection`/`handleDisconnect`                                                                             |
+| `@SentryCron` not triggering                       | Decorator order matters — `@SentryCron` MUST come after `@Cron`                                                                                               |
+| TypeScript path alias issues                       | Ensure `tsconfig.json` `paths` are configured so `instrument` resolves from `main.ts` location                                                                |
+| `import * as Sentry` ESLint error                  | Many projects ban namespace imports. Use named imports (`import { startSpan, captureException } from "@sentry/nestjs"`) or use the project's DI proxy instead |
+| `profilesSampleRate` vs `profileSessionSampleRate` | `profilesSampleRate` is deprecated in SDK 10.x. Use `profileSessionSampleRate` + `profileLifecycle: "trace"` instead                                          |
+| Duplicate spans on every request                   | `SentryModule.forRoot()` registered in multiple modules. Ensure it's only called once — check shared/library modules                                          |
+| Config property not recognized in `instrument.ts`  | When using a typed config class, new SDK options must be added to the config type definition and the project rebuilt before TypeScript recognizes them        |
 
 ### Version Requirements
 
-| Feature | Minimum SDK Version |
-|---|---|
-| `@sentry/nestjs` package | 8.0.0 |
-| `@SentryTraced` decorator | 8.15.0 |
-| `@SentryCron` decorator | 8.16.0 |
-| Event Emitter auto-instrumentation | 8.39.0 |
-| `SentryGlobalFilter` (unified) | 8.40.0 |
-| `Sentry.logger` API (`enableLogs`) | 9.41.0 |
-| `profileSessionSampleRate` | 10.27.0 |
-| Node.js requirement | ≥ 18 |
-| Node.js for ESM `--import` | ≥ 18.19.0 |
-| NestJS compatibility | 8.x – 11.x |
+| Feature                            | Minimum SDK Version |
+| ---------------------------------- | ------------------- |
+| `@sentry/nestjs` package           | 8.0.0               |
+| `@SentryTraced` decorator          | 8.15.0              |
+| `@SentryCron` decorator            | 8.16.0              |
+| Event Emitter auto-instrumentation | 8.39.0              |
+| `SentryGlobalFilter` (unified)     | 8.40.0              |
+| `Sentry.logger` API (`enableLogs`) | 9.41.0              |
+| `profileSessionSampleRate`         | 10.27.0             |
+| Node.js requirement                | ≥ 18                |
+| Node.js for ESM `--import`         | ≥ 18.19.0           |
+| NestJS compatibility               | 8.x – 11.x          |

--- a/skills/sentry-nestjs-sdk/references/tracing.md
+++ b/skills/sentry-nestjs-sdk/references/tracing.md
@@ -4,16 +4,16 @@
 
 ## Configuration
 
-| Option | Type | Default | Purpose |
-|--------|------|---------|---------|
-| `tracesSampleRate` | `number` | `undefined` | Fraction of transactions to trace (0.0–1.0); omit to disable tracing |
-| `tracesSampler` | `function` | `undefined` | Per-transaction sampling function; overrides `tracesSampleRate` |
-| `tracePropagationTargets` | `(string \| RegExp)[]` | all origins | URLs/patterns to inject `sentry-trace` / `baggage` headers into |
-| `profileSessionSampleRate` | `number` | `undefined` | Fraction of **process sessions** to profile (0.0–1.0); decided once at init |
-| `profileLifecycle` | `'trace' \| 'manual'` | `'trace'` | `'trace'` = auto start/stop with spans; `'manual'` = call `startProfiler()`/`stopProfiler()` |
-| `beforeSendSpan` | `function` | `undefined` | Callback to mutate or drop individual spans before sending |
-| `skipOpenTelemetrySetup` | `boolean` | `false` | Skip automatic OTel provider setup (for custom OTel configurations) |
-| `strictTraceContinuation` | `boolean` | `false` | Only continue traces from same Sentry org (v10+) |
+| Option                     | Type                   | Default     | Purpose                                                                                      |
+| -------------------------- | ---------------------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `tracesSampleRate`         | `number`               | `undefined` | Fraction of transactions to trace (0.0–1.0); omit to disable tracing                         |
+| `tracesSampler`            | `function`             | `undefined` | Per-transaction sampling function; overrides `tracesSampleRate`                              |
+| `tracePropagationTargets`  | `(string \| RegExp)[]` | all origins | URLs/patterns to inject `sentry-trace` / `baggage` headers into                              |
+| `profileSessionSampleRate` | `number`               | `undefined` | Fraction of **process sessions** to profile (0.0–1.0); decided once at init                  |
+| `profileLifecycle`         | `'trace' \| 'manual'`  | `'trace'`   | `'trace'` = auto start/stop with spans; `'manual'` = call `startProfiler()`/`stopProfiler()` |
+| `beforeSendSpan`           | `function`             | `undefined` | Callback to mutate or drop individual spans before sending                                   |
+| `skipOpenTelemetrySetup`   | `boolean`              | `false`     | Skip automatic OTel provider setup (for custom OTel configurations)                          |
+| `strictTraceContinuation`  | `boolean`              | `false`     | Only continue traces from same Sentry org (v10+)                                             |
 
 ## Architecture
 
@@ -43,13 +43,13 @@ import * as Sentry from "@sentry/nestjs";
 
 Sentry.init({
   dsn: "https://<key>@<org>.ingest.sentry.io/<project>",
-  tracesSampleRate: 1.0,   // 1.0 = 100% of transactions; reduce in production
+  tracesSampleRate: 1.0, // 1.0 = 100% of transactions; reduce in production
 });
 ```
 
 ```typescript
 // main.ts
-import "./instrument";  // MUST be first — before @nestjs/core or any module
+import "./instrument"; // MUST be first — before @nestjs/core or any module
 import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 
@@ -63,16 +63,16 @@ bootstrap();
 ```typescript
 // app.module.ts — two distinct entry points
 import { Module } from "@nestjs/common";
-import { SentryModule } from "@sentry/nestjs/setup";      // /setup entry point
+import { SentryModule } from "@sentry/nestjs/setup"; // /setup entry point
 import { APP_FILTER } from "@nestjs/core";
 import { SentryGlobalFilter } from "@sentry/nestjs/setup"; // /setup entry point
 
 @Module({
-  imports: [SentryModule.forRoot()],          // registers SentryTracingInterceptor globally
+  imports: [SentryModule.forRoot()], // registers SentryTracingInterceptor globally
   providers: [
     {
       provide: APP_FILTER,
-      useClass: SentryGlobalFilter,           // captures unhandled HTTP/GraphQL/RPC exceptions
+      useClass: SentryGlobalFilter, // captures unhandled HTTP/GraphQL/RPC exceptions
     },
   ],
 })
@@ -80,6 +80,7 @@ export class AppModule {}
 ```
 
 > **`@sentry/nestjs` vs `@sentry/nestjs/setup` — two separate entry points:**
+>
 > - `@sentry/nestjs` — `Sentry.init()`, decorators, span APIs, all `@sentry/node` re-exports
 > - `@sentry/nestjs/setup` — `SentryModule`, `SentryTracingInterceptor`, `SentryGlobalFilter`
 
@@ -119,12 +120,12 @@ import { Injectable } from "@nestjs/common";
 
 @Injectable()
 export class OrderService {
-  @SentryTraced("db.query")    // op="db.query", name="findOrder" (method name)
+  @SentryTraced("db.query") // op="db.query", name="findOrder" (method name)
   async findOrder(id: string) {
     return this.orderRepo.findOne({ where: { id } });
   }
 
-  @SentryTraced()              // op="function" (default)
+  @SentryTraced() // op="function" (default)
   async processOrder(data: CreateOrderDto) {
     return this.process(data);
   }
@@ -153,7 +154,7 @@ export class PaymentService {
         const result = await this.stripeService.charge(userId, amount);
         span.setAttribute("payment.transactionId", result.id);
         return result;
-      }
+      },
     );
   }
 }
@@ -162,13 +163,16 @@ export class PaymentService {
 ### `startSpanManual` (callback-style, must call `span.end()`)
 
 ```typescript
-return Sentry.startSpanManual({ name: "legacy-callback", op: "function" }, (span) => {
-  legacyLib.doWork((err, result) => {
-    span.setStatus({ code: err ? 2 : 1 }); // 1=OK, 2=ERROR
-    span.end();
-    callback(err, result);
-  });
-});
+return Sentry.startSpanManual(
+  { name: "legacy-callback", op: "function" },
+  (span) => {
+    legacyLib.doWork((err, result) => {
+      span.setStatus({ code: err ? 2 : 1 }); // 1=OK, 2=ERROR
+      span.end();
+      callback(err, result);
+    });
+  },
+);
 ```
 
 ### `startInactiveSpan` (detached, no auto-parent)
@@ -181,15 +185,15 @@ span.end();
 
 ### Span options reference
 
-| Option | Type | Description |
-|--------|------|-------------|
-| `name` | `string` | **Required.** Span name |
-| `op` | `string` | Operation type (`db`, `http.client`, `function`, `queue.process`, etc.) |
-| `attributes` | `Record<string, string \| number \| boolean>` | Key-value metadata |
-| `startTime` | `number` | Custom start timestamp (Unix seconds) |
-| `parentSpan` | `Span` | Explicit parent (overrides auto-parent from context) |
-| `onlyIfParent` | `boolean` | Skip creating span if no active parent exists |
-| `forceTransaction` | `boolean` | Display as root transaction in Sentry UI |
+| Option             | Type                                          | Description                                                             |
+| ------------------ | --------------------------------------------- | ----------------------------------------------------------------------- |
+| `name`             | `string`                                      | **Required.** Span name                                                 |
+| `op`               | `string`                                      | Operation type (`db`, `http.client`, `function`, `queue.process`, etc.) |
+| `attributes`       | `Record<string, string \| number \| boolean>` | Key-value metadata                                                      |
+| `startTime`        | `number`                                      | Custom start timestamp (Unix seconds)                                   |
+| `parentSpan`       | `Span`                                        | Explicit parent (overrides auto-parent from context)                    |
+| `onlyIfParent`     | `boolean`                                     | Skip creating span if no active parent exists                           |
+| `forceTransaction` | `boolean`                                     | Display as root transaction in Sentry UI                                |
 
 ### Accessing and modifying the active span
 
@@ -213,19 +217,23 @@ span?.setStatus({ code: 2 });
 ### Nested spans
 
 ```typescript
-return Sentry.startSpan({ name: "process-checkout", op: "business.logic" }, async () => {
-  const cart = await Sentry.startSpan({ name: "fetch-cart", op: "db.query" }, () =>
-    this.cartRepo.findById(cartId)
-  );
+return Sentry.startSpan(
+  { name: "process-checkout", op: "business.logic" },
+  async () => {
+    const cart = await Sentry.startSpan(
+      { name: "fetch-cart", op: "db.query" },
+      () => this.cartRepo.findById(cartId),
+    );
 
-  await Sentry.startSpan({ name: "apply-discount", op: "function" }, () =>
-    this.discountService.apply(cart)
-  );
+    await Sentry.startSpan({ name: "apply-discount", op: "function" }, () =>
+      this.discountService.apply(cart),
+    );
 
-  return Sentry.startSpan({ name: "create-order", op: "db.query" }, () =>
-    this.orderRepo.create(cart)
-  );
-});
+    return Sentry.startSpan({ name: "create-order", op: "db.query" }, () =>
+      this.orderRepo.create(cart),
+    );
+  },
+);
 ```
 
 ### Modify all spans globally (`beforeSendSpan`)
@@ -288,7 +296,7 @@ export class NotificationListener {
     // Span: name="event user.created|user.updated"
   }
 
-  @OnEvent("order.*")  // wildcards supported
+  @OnEvent("order.*") // wildcards supported
   async handleOrder(payload: OrderEvent) {
     await this.orderService.process(payload);
   }
@@ -314,21 +322,25 @@ GraphQL is auto-traced via `graphqlIntegration` (enabled by default). No configu
 
 ### Microservices — transport support matrix
 
-| Transport | Auto-traced? | Mechanism |
-|-----------|-------------|-----------|
-| AMQP / RabbitMQ | ✅ | `amqplibIntegration` — `amqp.publish` + `amqp.process` spans, headers auto-injected |
-| Kafka (KafkaJS) | ✅ | `kafkaIntegration` — `kafka.send` + `kafka.process` spans, trace context in record headers |
-| Redis pub/sub | ⚠️ Partial | `redisIntegration` traces Redis commands only |
-| TCP | ❌ | No OTel instrumentation |
-| NATS | ❌ | Community OTel NATS package needed |
-| gRPC | ❌ | Community OTel gRPC package needed |
+| Transport       | Auto-traced? | Mechanism                                                                                  |
+| --------------- | ------------ | ------------------------------------------------------------------------------------------ |
+| AMQP / RabbitMQ | ✅           | `amqplibIntegration` — `amqp.publish` + `amqp.process` spans, headers auto-injected        |
+| Kafka (KafkaJS) | ✅           | `kafkaIntegration` — `kafka.send` + `kafka.process` spans, trace context in record headers |
+| Redis pub/sub   | ⚠️ Partial   | `redisIntegration` traces Redis commands only                                              |
+| TCP             | ❌           | No OTel instrumentation                                                                    |
+| NATS            | ❌           | Community OTel NATS package needed                                                         |
+| gRPC            | ❌           | Community OTel gRPC package needed                                                         |
 
 ### WebSocket gateway tracing (manual)
 
 No dedicated WebSocket auto-tracing exists. `SentryTracingInterceptor` only handles HTTP contexts:
 
 ```typescript
-import { SubscribeMessage, WebSocketGateway, MessageBody } from "@nestjs/websockets";
+import {
+  SubscribeMessage,
+  WebSocketGateway,
+  MessageBody,
+} from "@nestjs/websockets";
 import * as Sentry from "@sentry/nestjs";
 
 @WebSocketGateway(3001)
@@ -337,12 +349,15 @@ export class ChatGateway {
   async handleMessage(@MessageBody() payload: { data: any; _sentry?: any }) {
     const { sentryTrace, baggage } = payload._sentry ?? {};
 
-    return Sentry.continueTrace(
-      { sentryTrace, baggage },
-      () => Sentry.startSpan(
-        { name: "ws.chat.message", op: "websocket.server", forceTransaction: true },
-        async () => this.chatService.process(payload.data)
-      )
+    return Sentry.continueTrace({ sentryTrace, baggage }, () =>
+      Sentry.startSpan(
+        {
+          name: "ws.chat.message",
+          op: "websocket.server",
+          forceTransaction: true,
+        },
+        async () => this.chatService.process(payload.data),
+      ),
     );
   }
 }
@@ -351,13 +366,53 @@ export class ChatGateway {
 const traceData = Sentry.getTraceData();
 socket.emit("message", {
   data: payload,
-  _sentry: { sentryTrace: traceData["sentry-trace"], baggage: traceData["baggage"] },
+  _sentry: {
+    sentryTrace: traceData["sentry-trace"],
+    baggage: traceData["baggage"],
+  },
 });
 ```
 
 ### Bull/BullMQ job tracing (manual)
 
-No dedicated Bull integration — use manual spans in `@Process()` handlers:
+No dedicated Bull integration — use manual spans in `@Process()` handlers. Always wrap with `withIsolationScope` to prevent scope leakage between concurrent jobs.
+
+#### BullMQ with `WorkerHost` (recommended for `@nestjs/bullmq`)
+
+```typescript
+import { Processor, WorkerHost } from "@nestjs/bullmq";
+import { Job } from "bullmq";
+import * as Sentry from "@sentry/nestjs";
+
+@Processor("email")
+export class EmailProcessor extends WorkerHost {
+  async process(job: Job) {
+    return Sentry.withIsolationScope(() =>
+      Sentry.startSpan(
+        {
+          name: `email ${job.name}`,
+          op: "queue.process",
+          forceTransaction: true,
+          attributes: {
+            "messaging.system": "bullmq",
+            "messaging.destination": "email",
+            "messaging.message.id": job.id ?? "unknown",
+            "job.name": job.name,
+            "job.attemptsMade": job.attemptsMade,
+          },
+        },
+        async () => {
+          await this.emailService.sendWelcomeEmail(job.data.userId);
+        },
+      ),
+    );
+  }
+}
+```
+
+> **Why `withIsolationScope`?** BullMQ processes jobs concurrently in the same process. Without isolation, `setTag`, `setUser`, and breadcrumbs leak between concurrent jobs.
+
+#### Bull with `@Process()` decorator
 
 ```typescript
 import { Process, Processor } from "@nestjs/bull";
@@ -370,22 +425,34 @@ export class EmailProcessor {
   async handle(job: Job<{ userId: string; _sentry?: Record<string, string> }>) {
     const { _sentry, ...data } = job.data;
 
-    // Continue distributed trace from the publisher
-    return Sentry.continueTrace(
-      { sentryTrace: _sentry?.["sentry-trace"], baggage: _sentry?.["baggage"] },
-      () => Sentry.startSpan(
-        { name: "email.send-welcome", op: "queue.process", forceTransaction: true },
-        async (span) => {
-          span.setAttribute("job.id", job.id.toString());
-          span.setAttribute("job.attemptsMade", job.attemptsMade);
-          await this.emailService.sendWelcomeEmail(data.userId);
-        }
-      )
+    return Sentry.withIsolationScope(() =>
+      Sentry.continueTrace(
+        {
+          sentryTrace: _sentry?.["sentry-trace"],
+          baggage: _sentry?.["baggage"],
+        },
+        () =>
+          Sentry.startSpan(
+            {
+              name: "email.send-welcome",
+              op: "queue.process",
+              forceTransaction: true,
+            },
+            async (span) => {
+              span.setAttribute("job.id", job.id.toString());
+              span.setAttribute("job.attemptsMade", job.attemptsMade);
+              await this.emailService.sendWelcomeEmail(data.userId);
+            },
+          ),
+      ),
     );
   }
 }
+```
 
-// Publisher: attach trace context to job data
+#### Publisher — attach trace context to job data
+
+```typescript
 async queueWelcomeEmail(userId: string) {
   return Sentry.startSpan({ name: "email.queue", op: "queue.publish" }, () => {
     const traceData = Sentry.getTraceData();
@@ -393,6 +460,38 @@ async queueWelcomeEmail(userId: string) {
   });
 }
 ```
+
+### Kafka / NATS microservice handler tracing
+
+Kafka messages are auto-instrumented by `kafkaIntegration` (KafkaJS), but NATS and other transports require manual spans. For consistency, wrapping `@EventPattern()` and `@MessagePattern()` handlers with explicit spans is recommended for all transports:
+
+```typescript
+import { Controller } from "@nestjs/common";
+import { EventPattern, MessagePattern, Payload } from "@nestjs/microservices";
+import * as Sentry from "@sentry/nestjs";
+
+@Controller()
+export class OrderController {
+  @EventPattern("order.created")
+  async handleOrderCreated(@Payload() data: OrderEvent) {
+    return Sentry.startSpan(
+      { name: "handleOrderCreated", op: "kafka", forceTransaction: true },
+      async () => {
+        await this.orderService.processCreated(data);
+      },
+    );
+  }
+
+  @MessagePattern("order.get")
+  async getOrder(@Payload() data: { id: string }) {
+    return Sentry.startSpan({ name: "getOrder", op: "rpc" }, async () => {
+      return this.orderService.findById(data.id);
+    });
+  }
+}
+```
+
+> Use `forceTransaction: true` for event handlers that should appear as root transactions in Sentry UI.
 
 ### Distributed tracing between services
 
@@ -444,18 +543,18 @@ Sentry.init({
 
 ### Database auto-instrumentation
 
-| Driver / ORM | Auto-enabled | Notes |
-|--------------|-------------|-------|
-| PostgreSQL (`pg`) | ✅ | `postgresIntegration` |
-| MySQL | ✅ | `mysqlIntegration` |
-| MySQL2 | ✅ | `mysql2Integration` |
-| MongoDB | ✅ | `mongoIntegration` |
-| Mongoose | ✅ | `mongooseIntegration` |
-| Prisma | ⚠️ Manual | `prismaIntegration` — add explicitly: `integrations: [Sentry.prismaIntegration()]` |
-| SQL Server (Tedious) | ✅ | `tediousIntegration` |
-| Knex | ❌ | Must add manually |
-| TypeORM | ❌ | Use `opentelemetry-instrumentation-typeorm` community package |
-| Sequelize | ❌ | No known integration |
+| Driver / ORM         | Auto-enabled | Notes                                                                              |
+| -------------------- | ------------ | ---------------------------------------------------------------------------------- |
+| PostgreSQL (`pg`)    | ✅           | `postgresIntegration`                                                              |
+| MySQL                | ✅           | `mysqlIntegration`                                                                 |
+| MySQL2               | ✅           | `mysql2Integration`                                                                |
+| MongoDB              | ✅           | `mongoIntegration`                                                                 |
+| Mongoose             | ✅           | `mongooseIntegration`                                                              |
+| Prisma               | ⚠️ Manual    | `prismaIntegration` — add explicitly: `integrations: [Sentry.prismaIntegration()]` |
+| SQL Server (Tedious) | ✅           | `tediousIntegration`                                                               |
+| Knex                 | ❌           | Must add manually                                                                  |
+| TypeORM              | ❌           | Use `opentelemetry-instrumentation-typeorm` community package                      |
+| Sequelize            | ❌           | No known integration                                                               |
 
 ```typescript
 // Knex — must add explicitly:
@@ -541,15 +640,15 @@ Sentry.init({
   dsn: "YOUR_DSN",
   integrations: [nodeProfilingIntegration()],
   tracesSampleRate: 1.0,
-  profileSessionSampleRate: 1.0,   // profile 100% of process sessions
-  profileLifecycle: "trace",        // auto start/stop with spans (recommended)
+  profileSessionSampleRate: 1.0, // profile 100% of process sessions
+  profileLifecycle: "trace", // auto start/stop with spans (recommended)
 });
 ```
 
-| `profileLifecycle` | Start | Stop | Use case |
-|--------------------|-------|------|----------|
-| `"trace"` (default) | First active span | Last span ends | General profiling — zero config |
-| `"manual"` | `Sentry.profiler.startProfiler()` | `Sentry.profiler.stopProfiler()` | Targeted hot paths |
+| `profileLifecycle`  | Start                             | Stop                             | Use case                        |
+| ------------------- | --------------------------------- | -------------------------------- | ------------------------------- |
+| `"trace"` (default) | First active span                 | Last span ends                   | General profiling — zero config |
+| `"manual"`          | `Sentry.profiler.startProfiler()` | `Sentry.profiler.stopProfiler()` | Targeted hot paths              |
 
 > **`profileSessionSampleRate` is process-level** — decided once at startup, not per-request.
 > Use `0.1` to profile 10% of pods in a fleet without overhead on the rest.
@@ -558,12 +657,12 @@ Sentry.init({
 
 ### Framework & HTTP (all auto-enabled)
 
-| Integration | What is traced |
-|-------------|----------------|
-| `nestIntegration` | Middleware, guards, pipes, interceptors, filters, `@OnEvent` handlers |
-| `httpIntegration` | Incoming HTTP requests + outgoing `http`/`https` calls |
-| `nativeNodeFetchIntegration` | Outgoing `fetch()` calls |
-| `requestDataIntegration` | HTTP request data attached to error events |
+| Integration                  | What is traced                                                        |
+| ---------------------------- | --------------------------------------------------------------------- |
+| `nestIntegration`            | Middleware, guards, pipes, interceptors, filters, `@OnEvent` handlers |
+| `httpIntegration`            | Incoming HTTP requests + outgoing `http`/`https` calls                |
+| `nativeNodeFetchIntegration` | Outgoing `fetch()` calls                                              |
+| `requestDataIntegration`     | HTTP request data attached to error events                            |
 
 ### Databases (all auto-enabled)
 
@@ -585,31 +684,31 @@ Sentry.init({
 
 ### Auto-traced (no code changes needed)
 
-| Feature | Mechanism |
-|---------|-----------|
-| HTTP requests + transaction naming | `nestIntegration` + `SentryTracingInterceptor` |
+| Feature                                            | Mechanism                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------ |
+| HTTP requests + transaction naming                 | `nestIntegration` + `SentryTracingInterceptor`               |
 | Middleware, guard, pipe, interceptor, filter spans | `SentryNestInstrumentation` (patches `@Injectable`/`@Catch`) |
-| `@OnEvent` handler spans | `SentryNestEventInstrumentation` (patches `@OnEvent`) |
-| GraphQL queries/mutations/resolvers | `graphqlIntegration` |
-| AMQP/RabbitMQ + Kafka messages | `amqplibIntegration` + `kafkaIntegration` |
-| Redis, MongoDB, Mongoose, MySQL, PG | Auto-integrations |
-| Outgoing HTTP (axios, fetch, http) | `httpIntegration` + `nativeNodeFetchIntegration` |
-| Any OTel instrumentation | Auto-forwarded via OTel bridge |
+| `@OnEvent` handler spans                           | `SentryNestEventInstrumentation` (patches `@OnEvent`)        |
+| GraphQL queries/mutations/resolvers                | `graphqlIntegration`                                         |
+| AMQP/RabbitMQ + Kafka messages                     | `amqplibIntegration` + `kafkaIntegration`                    |
+| Redis, MongoDB, Mongoose, MySQL, PG                | Auto-integrations                                            |
+| Outgoing HTTP (axios, fetch, http)                 | `httpIntegration` + `nativeNodeFetchIntegration`             |
+| Any OTel instrumentation                           | Auto-forwarded via OTel bridge                               |
 
 ### Requires manual instrumentation
 
-| Feature | API |
-|---------|-----|
-| Custom business logic spans | `Sentry.startSpan()`, `startSpanManual()`, `startInactiveSpan()` |
-| Method-level tracing | `@SentryTraced()` decorator |
-| Cron job monitoring | `@SentryCron()` decorator |
-| Exception filter error capture | `@SentryExceptionCaptured()` decorator |
-| WebSocket gateway tracing | `continueTrace()` + `startSpan()` in message handler |
-| TCP/NATS/gRPC microservices | Manual `startSpan()` + `continueTrace()` |
-| Bull/BullMQ job tracing | Manual `startSpan()` in `@Process()` |
-| Non-HTTP distributed tracing | `getTraceData()` + `continueTrace()` |
-| TypeORM / Sequelize tracing | Community OTel packages or manual spans |
-| Node.js profiling | `@sentry/profiling-node` + `nodeProfilingIntegration()` |
+| Feature                        | API                                                                  |
+| ------------------------------ | -------------------------------------------------------------------- |
+| Custom business logic spans    | `Sentry.startSpan()`, `startSpanManual()`, `startInactiveSpan()`     |
+| Method-level tracing           | `@SentryTraced()` decorator                                          |
+| Cron job monitoring            | `@SentryCron()` decorator                                            |
+| Exception filter error capture | `@SentryExceptionCaptured()` decorator                               |
+| WebSocket gateway tracing      | `continueTrace()` + `startSpan()` in message handler                 |
+| TCP/NATS/gRPC microservices    | Manual `startSpan()` + `continueTrace()`                             |
+| Bull/BullMQ job tracing        | `withIsolationScope()` + `startSpan()` in `process()` / `@Process()` |
+| Non-HTTP distributed tracing   | `getTraceData()` + `continueTrace()`                                 |
+| TypeORM / Sequelize tracing    | Community OTel packages or manual spans                              |
+| Node.js profiling              | `@sentry/profiling-node` + `nodeProfilingIntegration()`              |
 
 ## Best Practices
 
@@ -620,18 +719,25 @@ Sentry.init({
 - Add `sentry-trace` and `baggage` to your CORS allowlist when tracing browser-to-backend flows
 - Pin `@sentry/profiling-node` to the **exact same version** as `@sentry/nestjs`
 - Use `profileSessionSampleRate` to profile a fraction of pods rather than every pod — the decision is per-process, not per-request
+- Always wrap background job handlers (`@Process()`, `WorkerHost.process()`, `@Cron()`, `@OnEvent()`) with `withIsolationScope()` before `startSpan()` — without isolation, concurrent jobs share scope state
+- If the project uses a DI wrapper for Sentry (e.g. `SENTRY_PROXY_TOKEN`), use the injected service for `startSpan`, `captureException`, etc. — only `instrument.ts` should import `@sentry/nestjs` directly
+- When using a config class for `Sentry.init()`, add new SDK options to the config type rather than hardcoding them — this keeps options configurable per environment
 
 ## Troubleshooting
 
-| Issue | Solution |
-|-------|----------|
-| No transactions appearing | Verify `tracesSampleRate > 0` or `tracesSampler` returns non-zero |
-| Transaction names show raw URL (e.g., `/users/123`) instead of pattern | `SentryModule.forRoot()` not imported; or `instrument.ts` loaded after `@nestjs/core` |
-| Middleware/guard/pipe spans missing | `nestIntegration` not registered; ensure `instrument.ts` is first import |
-| `@OnEvent` spans not appearing | `@nestjs/event-emitter` < 2.0.0; or `instrument.ts` loaded after event emitter |
-| Distributed traces broken across services | Check `sentry-trace` and `baggage` headers pass through proxies/API gateways |
-| DB spans missing | Driver loaded before `instrument.ts`; reorder imports |
-| Profiler crashes at startup | `@sentry/profiling-node` version doesn't match `@sentry/nestjs` |
-| Event spans appear as isolated transactions | Expected — `@OnEvent` uses `forceTransaction: true` by design |
-| RPC exceptions not captured or app crashes | Use a dedicated `@Catch(RpcException)` filter; `SentryGlobalFilter` logs a warning for RPC |
-| OTel instrumentation spans not appearing | Ensure the OTel package is loaded after `instrument.ts` |
+| Issue                                                                  | Solution                                                                                            |
+| ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| No transactions appearing                                              | Verify `tracesSampleRate > 0` or `tracesSampler` returns non-zero                                   |
+| Transaction names show raw URL (e.g., `/users/123`) instead of pattern | `SentryModule.forRoot()` not imported; or `instrument.ts` loaded after `@nestjs/core`               |
+| Middleware/guard/pipe spans missing                                    | `nestIntegration` not registered; ensure `instrument.ts` is first import                            |
+| `@OnEvent` spans not appearing                                         | `@nestjs/event-emitter` < 2.0.0; or `instrument.ts` loaded after event emitter                      |
+| Distributed traces broken across services                              | Check `sentry-trace` and `baggage` headers pass through proxies/API gateways                        |
+| DB spans missing                                                       | Driver loaded before `instrument.ts`; reorder imports                                               |
+| Profiler crashes at startup                                            | `@sentry/profiling-node` version doesn't match `@sentry/nestjs`                                     |
+| Event spans appear as isolated transactions                            | Expected — `@OnEvent` uses `forceTransaction: true` by design                                       |
+| RPC exceptions not captured or app crashes                             | Use a dedicated `@Catch(RpcException)` filter; `SentryGlobalFilter` logs a warning for RPC          |
+| OTel instrumentation spans not appearing                               | Ensure the OTel package is loaded after `instrument.ts`                                             |
+| BullMQ jobs share tags/user/breadcrumbs                                | Wrap `process()` body with `Sentry.withIsolationScope(() => ...)`                                   |
+| `profilesSampleRate` not working                                       | Deprecated in SDK 10.x — use `profileSessionSampleRate` + `profileLifecycle: "trace"`               |
+| `SentryModule.forRoot()` registered twice                              | Only register once — if a shared library module already imports it, skip in `AppModule`             |
+| `import * as Sentry` blocked by ESLint                                 | Use named imports or the project's DI proxy; namespace imports trigger `no-restricted-syntax` rules |


### PR DESCRIPTION
Update the sentry-nestjs-sdk skill based on learnings from instrumenting
a real NestJS monorepo with Sentry tracing.

Motivation: Many NestJS projects use DI wrappers (SENTRY_PROXY_TOKEN),
config classes for Sentry.init(), and BullMQ WorkerHost. The skill
previously did not detect or guide these patterns, leading to duplicate
SentryModule registration, hardcoded config, and incorrect BullMQ tracing.

Key changes:
- Phase 1: Detect Sentry DI wrappers, config classes, duplicate SentryModule
- Phase 3: Config-driven Sentry.init() example, DI proxy guidance, duplicate warning
- Add "Working with Sentry DI Wrappers" section
- BullMQ WorkerHost pattern with withIsolationScope in tracing reference
- Kafka/NATS handler tracing guidance
- Troubleshooting: namespace imports, profileSessionSampleRate migration, config type resolution
