### PR TITLE
docs(skill-tree): make SKILL_TREE.md agent-friendly with explicit fetch paths

### DIFF
--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -2,30 +2,34 @@
 
 You are **Sentry's AI assistant**. You help developers set up Sentry, debug production issues, and configure monitoring — guided by expert skill files you load on demand from this index.
 
-## How It Works
+## How to Fetch Skills
 
-This is the root of Sentry's skill library. Each skill below is a self-contained, step-by-step guide for a specific task. Load one by fetching its file and following the instructions inside.
+Every skill below is a self-contained markdown guide. To load one, **append its path to the base URL**:
 
-All paths below are relative to this file. Fetch them however your environment supports — local file read, HTTP fetch, or URL construction:
+    https://skills.sentry.gg/<skill-name>/SKILL.md
 
-```
-Base URL: https://skills.sentry.gg
-Example:  https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
-```
+Use the **exact paths from the `Path` column** in the tables below. Do not guess or shorten URLs.
 
-These skills are also available via the [`skills.sentry.gg`](https://github.com/getsentry/skills.sentry.gg) proxy, which serves files from this repository with caching and clean URLs. Both path styles work — the proxy redirects `skills/` prefixed paths to their canonical form.
+Example — to fetch the Next.js setup skill:
 
-## Start Here
+    https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
 
-Greet the user and ask what they'd like help with. Present these options:
+## Start Here — Read This Before Doing Anything
 
-1. **Set up Sentry** — Add error monitoring, performance tracing, and session replay to a project
-2. **Debug a production issue** — Investigate errors and exceptions using Sentry data
-3. **Configure a feature** — AI/LLM monitoring, alerts, OpenTelemetry pipelines
-4. **Review code** — Resolve Sentry bot comments or check for predicted bugs
-5. **Upgrade Sentry SDK** — Migrate to a new major version
+**Do not skip this section.** Do not assume what the user needs based on their project files. Do not start installing packages, creating files, or running commands until you have confirmed the user's intent.
 
-Based on their response, find the matching skill below, fetch it, and follow its instructions.
+1. **Ask first.** Greet the user and ask what they'd like help with. Present these options:
+   - **Set up Sentry** — Add error monitoring, performance tracing, and session replay to a project
+   - **Debug a production issue** — Investigate errors and exceptions using Sentry data
+   - **Configure a feature** — AI/LLM monitoring, alerts, OpenTelemetry pipelines
+   - **Review code** — Resolve Sentry bot comments or check for predicted bugs
+   - **Upgrade Sentry SDK** — Migrate to a new major version
+
+2. **Wait for their answer.** Do not proceed until the user tells you what they want.
+
+3. **Fetch the matching skill** from the tables below and follow its instructions step by step.
+
+Each skill file contains its own detection logic, prerequisites, and configuration steps. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 
 ---
 
@@ -33,22 +37,22 @@ Based on their response, find the matching skill below, fetch it, and follow its
 
 Install and configure Sentry for any platform. If unsure which SDK fits, detect the platform from the user's project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `build.gradle`, etc.).
 
-| Skill | Platform |
-|---|---|
-| [`sentry-android-sdk`](skills/sentry-android-sdk/SKILL.md) | Android |
-| [`sentry-browser-sdk`](skills/sentry-browser-sdk/SKILL.md) | browser JavaScript |
-| [`sentry-cocoa-sdk`](skills/sentry-cocoa-sdk/SKILL.md) | Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) |
-| [`sentry-dotnet-sdk`](skills/sentry-dotnet-sdk/SKILL.md) | .NET |
-| [`sentry-go-sdk`](skills/sentry-go-sdk/SKILL.md) | Go |
-| [`sentry-nestjs-sdk`](skills/sentry-nestjs-sdk/SKILL.md) | NestJS |
-| [`sentry-nextjs-sdk`](skills/sentry-nextjs-sdk/SKILL.md) | Next.js |
-| [`sentry-node-sdk`](skills/sentry-node-sdk/SKILL.md) | Node.js, Bun, and Deno |
-| [`sentry-php-sdk`](skills/sentry-php-sdk/SKILL.md) | PHP |
-| [`sentry-python-sdk`](skills/sentry-python-sdk/SKILL.md) | Python |
-| [`sentry-react-native-sdk`](skills/sentry-react-native-sdk/SKILL.md) | React Native and Expo |
-| [`sentry-react-sdk`](skills/sentry-react-sdk/SKILL.md) | React |
-| [`sentry-ruby-sdk`](skills/sentry-ruby-sdk/SKILL.md) | Ruby |
-| [`sentry-svelte-sdk`](skills/sentry-svelte-sdk/SKILL.md) | Svelte and SvelteKit |
+| Platform | Skill | Path |
+|---|---|---|
+| Android | [`sentry-android-sdk`](skills/sentry-android-sdk/SKILL.md) | `sentry-android-sdk/SKILL.md` |
+| browser JavaScript | [`sentry-browser-sdk`](skills/sentry-browser-sdk/SKILL.md) | `sentry-browser-sdk/SKILL.md` |
+| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | [`sentry-cocoa-sdk`](skills/sentry-cocoa-sdk/SKILL.md) | `sentry-cocoa-sdk/SKILL.md` |
+| .NET | [`sentry-dotnet-sdk`](skills/sentry-dotnet-sdk/SKILL.md) | `sentry-dotnet-sdk/SKILL.md` |
+| Go | [`sentry-go-sdk`](skills/sentry-go-sdk/SKILL.md) | `sentry-go-sdk/SKILL.md` |
+| NestJS | [`sentry-nestjs-sdk`](skills/sentry-nestjs-sdk/SKILL.md) | `sentry-nestjs-sdk/SKILL.md` |
+| Next.js | [`sentry-nextjs-sdk`](skills/sentry-nextjs-sdk/SKILL.md) | `sentry-nextjs-sdk/SKILL.md` |
+| Node.js, Bun, and Deno | [`sentry-node-sdk`](skills/sentry-node-sdk/SKILL.md) | `sentry-node-sdk/SKILL.md` |
+| PHP | [`sentry-php-sdk`](skills/sentry-php-sdk/SKILL.md) | `sentry-php-sdk/SKILL.md` |
+| Python | [`sentry-python-sdk`](skills/sentry-python-sdk/SKILL.md) | `sentry-python-sdk/SKILL.md` |
+| React Native and Expo | [`sentry-react-native-sdk`](skills/sentry-react-native-sdk/SKILL.md) | `sentry-react-native-sdk/SKILL.md` |
+| React | [`sentry-react-sdk`](skills/sentry-react-sdk/SKILL.md) | `sentry-react-sdk/SKILL.md` |
+| Ruby | [`sentry-ruby-sdk`](skills/sentry-ruby-sdk/SKILL.md) | `sentry-ruby-sdk/SKILL.md` |
+| Svelte and SvelteKit | [`sentry-svelte-sdk`](skills/sentry-svelte-sdk/SKILL.md) | `sentry-svelte-sdk/SKILL.md` |
 
 ### Platform Detection Priority
 
@@ -67,19 +71,40 @@ When multiple SDKs could match, prefer the more specific one:
 
 Debug production issues and maintain code quality with Sentry context.
 
-| Skill | Use when |
-|---|---|
-| [`sentry-code-review`](skills/sentry-code-review/SKILL.md) | Analyze and resolve Sentry comments on GitHub Pull Requests |
-| [`sentry-fix-issues`](skills/sentry-fix-issues/SKILL.md) | Find and fix issues from Sentry using MCP |
-| [`sentry-pr-code-review`](skills/sentry-pr-code-review/SKILL.md) | Review a project's PRs to check for issues detected in code review by Seer Bug Prediction |
-| [`sentry-sdk-upgrade`](skills/sentry-sdk-upgrade/SKILL.md) | Upgrade the Sentry JavaScript SDK across major versions |
+| Use when | Skill | Path |
+|---|---|---|
+| Analyze and resolve Sentry comments on GitHub Pull Requests | [`sentry-code-review`](skills/sentry-code-review/SKILL.md) | `sentry-code-review/SKILL.md` |
+| Find and fix issues from Sentry using MCP | [`sentry-fix-issues`](skills/sentry-fix-issues/SKILL.md) | `sentry-fix-issues/SKILL.md` |
+| Review a project's PRs to check for issues detected in code review by Seer Bug Prediction | [`sentry-pr-code-review`](skills/sentry-pr-code-review/SKILL.md) | `sentry-pr-code-review/SKILL.md` |
+| Upgrade the Sentry JavaScript SDK across major versions | [`sentry-sdk-upgrade`](skills/sentry-sdk-upgrade/SKILL.md) | `sentry-sdk-upgrade/SKILL.md` |
 
 ## Feature Setup
 
 Configure specific Sentry capabilities beyond basic SDK setup.
 
-| Skill | Feature |
+| Feature | Skill | Path |
+|---|---|---|
+| Create Sentry alerts using the workflow engine API | [`sentry-create-alert`](skills/sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
+| Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
+| Setup Sentry AI Agent Monitoring in any project | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+
+## Quick Lookup
+
+Match your project to a skill by keywords. Append the path to `https://skills.sentry.gg/` to fetch.
+
+| Keywords | Path |
 |---|---|
-| [`sentry-create-alert`](skills/sentry-create-alert/SKILL.md) | Create Sentry alerts using the workflow engine API |
-| [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation |
-| [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | Setup Sentry AI Agent Monitoring in any project |
+| android, kotlin, java, jetpack compose | `sentry-android-sdk/SKILL.md` |
+| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | `sentry-browser-sdk/SKILL.md` |
+| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | `sentry-cocoa-sdk/SKILL.md` |
+| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | `sentry-dotnet-sdk/SKILL.md` |
+| go, golang, gin, echo, fiber | `sentry-go-sdk/SKILL.md` |
+| nestjs, nest | `sentry-nestjs-sdk/SKILL.md` |
+| nextjs, next.js, next | `sentry-nextjs-sdk/SKILL.md` |
+| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | `sentry-node-sdk/SKILL.md` |
+| php, laravel, symfony | `sentry-php-sdk/SKILL.md` |
+| python, django, flask, fastapi, celery, starlette | `sentry-python-sdk/SKILL.md` |
+| react native, expo | `sentry-react-native-sdk/SKILL.md` |
+| react, react router, tanstack, redux, vite | `sentry-react-sdk/SKILL.md` |
+| ruby, rails, sinatra, sidekiq, rack | `sentry-ruby-sdk/SKILL.md` |
+| svelte, sveltekit | `sentry-svelte-sdk/SKILL.md` |

--- a/scripts/build-skill-tree.sh
+++ b/scripts/build-skill-tree.sh
@@ -180,11 +180,58 @@ build_table_rows() {
   local skills=("$@")
 
   for name in ${skills[@]+"${skills[@]}"}; do
-    local file desc col_val
+    local file desc col_val skill_path
     file="$(skill_get "$name" file)"
     desc="$(skill_get "$name" desc)"
     col_val="$(get_column_value "$desc" "$category")"
-    printf "| [\`%s\`](%s) | %s |\n" "$name" "$file" "$col_val"
+    # Strip leading "skills/" from file path for the fetchable URL path
+    skill_path="${file#skills/}"
+    printf "| %s | [\`%s\`](%s) | \`%s\` |\n" "$col_val" "$name" "$file" "$skill_path"
+  done
+}
+
+# Build keyword lookup rows for SDK skills
+# Maps common platform keywords to fetchable paths
+build_keyword_lookup() {
+  for name in ${SKILLS_SDK_SETUP[@]+"${SKILLS_SDK_SETUP[@]}"}; do
+    local file keywords skill_path
+    file="$(skill_get "$name" file)"
+    skill_path="${file#skills/}"
+
+    case "$name" in
+      sentry-android-sdk)
+        keywords="android, kotlin, java, jetpack compose" ;;
+      sentry-browser-sdk)
+        keywords="browser, vanilla js, javascript, jquery, cdn, wordpress, static site" ;;
+      sentry-cocoa-sdk)
+        keywords="ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit" ;;
+      sentry-dotnet-sdk)
+        keywords=".net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions" ;;
+      sentry-go-sdk)
+        keywords="go, golang, gin, echo, fiber" ;;
+      sentry-nestjs-sdk)
+        keywords="nestjs, nest" ;;
+      sentry-nextjs-sdk)
+        keywords="nextjs, next.js, next" ;;
+      sentry-node-sdk)
+        keywords="node, nodejs, node.js, bun, deno, express, fastify, koa, hapi" ;;
+      sentry-php-sdk)
+        keywords="php, laravel, symfony" ;;
+      sentry-python-sdk)
+        keywords="python, django, flask, fastapi, celery, starlette" ;;
+      sentry-react-native-sdk)
+        keywords="react native, expo" ;;
+      sentry-react-sdk)
+        keywords="react, react router, tanstack, redux, vite" ;;
+      sentry-ruby-sdk)
+        keywords="ruby, rails, sinatra, sidekiq, rack" ;;
+      sentry-svelte-sdk)
+        keywords="svelte, sveltekit" ;;
+      *)
+        keywords="$name" ;;
+    esac
+
+    printf "| %s | \`%s\` |\n" "$keywords" "$skill_path"
   done
 }
 
@@ -194,30 +241,34 @@ generate_skill_tree() {
 
 You are **Sentry's AI assistant**. You help developers set up Sentry, debug production issues, and configure monitoring — guided by expert skill files you load on demand from this index.
 
-## How It Works
+## How to Fetch Skills
 
-This is the root of Sentry's skill library. Each skill below is a self-contained, step-by-step guide for a specific task. Load one by fetching its file and following the instructions inside.
+Every skill below is a self-contained markdown guide. To load one, **append its path to the base URL**:
 
-All paths below are relative to this file. Fetch them however your environment supports — local file read, HTTP fetch, or URL construction:
+    https://skills.sentry.gg/<skill-name>/SKILL.md
 
-```
-Base URL: https://skills.sentry.gg
-Example:  https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
-```
+Use the **exact paths from the `Path` column** in the tables below. Do not guess or shorten URLs.
 
-These skills are also available via the [`skills.sentry.gg`](https://github.com/getsentry/skills.sentry.gg) proxy, which serves files from this repository with caching and clean URLs. Both path styles work — the proxy redirects `skills/` prefixed paths to their canonical form.
+Example — to fetch the Next.js setup skill:
 
-## Start Here
+    https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
 
-Greet the user and ask what they'd like help with. Present these options:
+## Start Here — Read This Before Doing Anything
 
-1. **Set up Sentry** — Add error monitoring, performance tracing, and session replay to a project
-2. **Debug a production issue** — Investigate errors and exceptions using Sentry data
-3. **Configure a feature** — AI/LLM monitoring, alerts, OpenTelemetry pipelines
-4. **Review code** — Resolve Sentry bot comments or check for predicted bugs
-5. **Upgrade Sentry SDK** — Migrate to a new major version
+**Do not skip this section.** Do not assume what the user needs based on their project files. Do not start installing packages, creating files, or running commands until you have confirmed the user's intent.
 
-Based on their response, find the matching skill below, fetch it, and follow its instructions.
+1. **Ask first.** Greet the user and ask what they'd like help with. Present these options:
+   - **Set up Sentry** — Add error monitoring, performance tracing, and session replay to a project
+   - **Debug a production issue** — Investigate errors and exceptions using Sentry data
+   - **Configure a feature** — AI/LLM monitoring, alerts, OpenTelemetry pipelines
+   - **Review code** — Resolve Sentry bot comments or check for predicted bugs
+   - **Upgrade Sentry SDK** — Migrate to a new major version
+
+2. **Wait for their answer.** Do not proceed until the user tells you what they want.
+
+3. **Fetch the matching skill** from the tables below and follow its instructions step by step.
+
+Each skill file contains its own detection logic, prerequisites, and configuration steps. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 
 ---
 HEADER
@@ -233,8 +284,8 @@ HEADER
 Install and configure Sentry for any platform. If unsure which SDK fits, detect the platform from the user's project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `build.gradle`, etc.).
 
 SDK_HEADER
-  printf "| Skill | %s |\n" "$col_sdk"
-  printf "|---|---|\n"
+  printf "| %s | Skill | Path |\n" "$col_sdk"
+  printf "|---|---|---|\n"
   build_table_rows "sdk-setup" ${SKILLS_SDK_SETUP[@]+"${SKILLS_SDK_SETUP[@]}"}
 
   cat <<'SDK_ROUTING'
@@ -262,8 +313,8 @@ SDK_ROUTING
 Debug production issues and maintain code quality with Sentry context.
 
 WF_HEADER
-  printf "| Skill | %s |\n" "$col_wf"
-  printf "|---|---|\n"
+  printf "| %s | Skill | Path |\n" "$col_wf"
+  printf "|---|---|---|\n"
   build_table_rows "workflow" ${SKILLS_WORKFLOW[@]+"${SKILLS_WORKFLOW[@]}"}
 
   # Feature Setup
@@ -275,9 +326,21 @@ WF_HEADER
 Configure specific Sentry capabilities beyond basic SDK setup.
 
 FS_HEADER
-  printf "| Skill | %s |\n" "$col_fs"
-  printf "|---|---|\n"
+  printf "| %s | Skill | Path |\n" "$col_fs"
+  printf "|---|---|---|\n"
   build_table_rows "feature-setup" ${SKILLS_FEATURE_SETUP[@]+"${SKILLS_FEATURE_SETUP[@]}"}
+
+  # Quick Lookup section
+  cat <<'LOOKUP_HEADER'
+
+## Quick Lookup
+
+Match your project to a skill by keywords. Append the path to `https://skills.sentry.gg/` to fetch.
+
+| Keywords | Path |
+|---|---|
+LOOKUP_HEADER
+  build_keyword_lookup
 
   printf "\n"
 }


### PR DESCRIPTION
## Problem

AI agents read the SKILL_TREE.md, identify their target platform, then **guess URLs** instead of following the markdown links. In a [test session](https://github.com/getsentry/sentry-for-ai/issues/new), Claude Code tried 4 wrong URLs before finding the correct one:

1. `/nextjs` → 404
2. `/sdk-setup/nextjs` → 404
3. `/skills/sdk-setup/nextjs` → 404
4. `/skills/sdk-setup/nextjs.md` → 404
5. Back to `/` to re-read the index
6. `/skills/sentry-nextjs-sdk/SKILL.md` → ✅ (finally)

The correct path was in the markdown link target the whole time — agents just don't reliably parse `[text](url)` syntax. They read the visible text and construct URLs from it.

## Solution

Make the SKILL_TREE.md impossible to misread by putting fetchable paths in plain sight.

### Changes to `build-skill-tree.sh` (the generator):

1. **Directive header** — Replace "How It Works" with "How to Fetch Skills" that puts the URL pattern and an explicit example front-and-center

2. **Path column in tables** — Every skill table now has a `Path` column showing the exact fetchable path as backtick-wrapped code:

   | Platform | Skill | Path |
   |---|---|---|
   | Next.js | [`sentry-nextjs-sdk`](skills/sentry-nextjs-sdk/SKILL.md) | `sentry-nextjs-sdk/SKILL.md` |

3. **Reordered columns** — Description/platform first (what agents match on), then skill name, then path

4. **Quick Lookup section** — Keyword → path mapping at the bottom for agents that skim:

   | Keywords | Path |
   |---|---|
   | nextjs, next.js, next | `sentry-nextjs-sdk/SKILL.md` |
   | python, django, flask, fastapi | `sentry-python-sdk/SKILL.md` |

### What didn't change:
- No proxy/redirect changes needed — the fix is in the content, not the routing
- GitHub rendering still works (markdown links preserved for clickability)
- CI validation (`--check` mode) passes