### PR TITLE
docs(skill-tree): hint agents to use curl when fetch tools summarize content

### DIFF
--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -14,6 +14,8 @@ Example — to fetch the Next.js setup skill:
 
     https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
 
+Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume what the user needs based on their project files. Do not start installing packages, creating files, or running commands until you have confirmed the user's intent.

--- a/scripts/build-skill-tree.sh
+++ b/scripts/build-skill-tree.sh
@@ -253,6 +253,8 @@ Example — to fetch the Next.js setup skill:
 
     https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
 
+Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume what the user needs based on their project files. Do not start installing packages, creating files, or running commands until you have confirmed the user's intent.


### PR DESCRIPTION
## Problem

Agent fetch tools (like Claude Code's `WebFetch`) often **summarize long markdown files** instead of returning full content. Sentry skill files are 10–20 KB of detailed instructions — summaries lose critical config snippets, exact code blocks, and step-by-step details.

Observed in a test session: Claude used `WebFetch` on `sentry-nextjs-sdk/SKILL.md` and got a 2,500-char summary of an 18,000-char file — twice — before figuring out to fall back to `curl -sL`.

## Fix

One-line hint in the "How to Fetch Skills" section:

> Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.

Saves agents from discovering this the hard way.

## Context

Follow-up to #29. That PR fixed URL guessing (✅ worked — agent fetched the right URL on the first try) and the "ask first" nudge (✅ worked — agent asked the user before proceeding). This addresses the remaining friction: fetch tool summarization.