### PR TITLE
docs(routers): make router skills agent-friendly standalone entry points

### DIFF
--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -7,30 +7,46 @@ role: router
 
 > [All Skills](../../SKILL_TREE.md)
 
-# Sentry Feature Setup — Router
+# Sentry Feature Setup
 
-Match the user's request to the appropriate feature skill below.
+Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring, OpenTelemetry pipelines, and alerts. This page helps you find the right feature skill for your task.
 
-| Skill | Feature |
-|---|---|
-| `sentry-setup-ai-monitoring` | Instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI calls |
-| `sentry-otel-exporter-setup` | Configure OpenTelemetry Collector with Sentry Exporter for multi-project routing |
-| `sentry-create-alert` | Create alerts via Sentry workflow engine API — email, Slack, PagerDuty, Discord |
+## How to Fetch Skills
 
-## Routing Instructions
+Each skill below is a detailed, step-by-step configuration guide. To load one, **append its path to the base URL**:
 
-1. If the user mentions AI monitoring, LLM tracing, or instrumenting an AI SDK → load `sentry-setup-ai-monitoring`.
-2. If the user mentions OpenTelemetry, OTel Collector, or multi-service telemetry routing → load `sentry-otel-exporter-setup`.
-3. If the user mentions alerts, notifications, on-call, Slack/PagerDuty integration, or workflow rules → load `sentry-create-alert`.
+    https://skills.sentry.gg/<skill-name>/SKILL.md
 
-## Dynamic Skill Fetching
+Use the **exact paths from the `Path` column** in the table below. Do not guess or shorten URLs.
 
-If the matched skill is **not installed locally**, fetch it from the skill library:
+Example — to fetch the AI monitoring skill:
 
-```
-https://skills.sentry.gg/skills/<skill-name>/SKILL.md
-```
+    https://skills.sentry.gg/sentry-setup-ai-monitoring/SKILL.md
 
-For example: `curl -sL https://skills.sentry.gg/skills/sentry-setup-ai-monitoring/SKILL.md`
+Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
 
-The [Skill Tree](../../SKILL_TREE.md) lists every available skill — use it as the source of truth for valid skill names.
+## Start Here — Read This Before Doing Anything
+
+**Do not skip this section.** Do not assume which feature the user needs. Ask first.
+
+1. If the user mentions **AI monitoring, LLM tracing, or instrumenting an AI SDK** (OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI) → `sentry-setup-ai-monitoring`
+2. If the user mentions **OpenTelemetry, OTel Collector, or multi-service telemetry routing** → `sentry-otel-exporter-setup`
+3. If the user mentions **alerts, notifications, on-call, Slack/PagerDuty/Discord integration, or workflow rules** → `sentry-create-alert`
+
+When unclear, **ask the user** which feature they want to configure. Do not guess.
+
+---
+
+## Feature Skills
+
+| Feature | Skill | Path |
+|---|---|---|
+| AI/LLM monitoring — instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI | [`sentry-setup-ai-monitoring`](../sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+| OpenTelemetry Collector with Sentry Exporter — multi-project routing, automatic project creation | [`sentry-otel-exporter-setup`](../sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
+| Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
+
+Each skill contains its own detection logic, prerequisites, and step-by-step instructions. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
+
+---
+
+Looking for SDK setup or debugging workflows instead? See the [full Skill Tree](../../SKILL_TREE.md).

--- a/skills/sentry-sdk-setup/SKILL.md
+++ b/skills/sentry-sdk-setup/SKILL.md
@@ -7,48 +7,89 @@ role: router
 
 > [All Skills](../../SKILL_TREE.md)
 
-# Sentry SDK Setup — Router
+# Sentry SDK Setup
 
-Detect the user's platform from project files (e.g. `package.json`, `go.mod`, `Gemfile`, `*.csproj`, `*.xcodeproj`), then load the matching SDK skill below.
+Set up Sentry error monitoring, tracing, and session replay in any language or framework. This page helps you find the right SDK skill for your project.
 
-| Skill | Platform | Key Frameworks |
+## How to Fetch Skills
+
+Each skill below is a detailed, step-by-step setup guide. To load one, **append its path to the base URL**:
+
+    https://skills.sentry.gg/<skill-name>/SKILL.md
+
+Use the **exact paths from the `Path` column** in the table below. Do not guess or shorten URLs.
+
+Example — to fetch the Next.js setup skill:
+
+    https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
+
+Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+
+## Start Here — Read This Before Doing Anything
+
+**Do not skip this section.** Do not assume which SDK the user needs based on their project files. Do not start installing packages or creating config files until you have confirmed the user's intent.
+
+1. **Detect the platform** from project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `build.gradle`, etc.).
+2. **Tell the user what you found** and which SDK you recommend.
+3. **Wait for confirmation** before fetching the skill and proceeding.
+
+Each SDK skill contains its own detection logic, prerequisites, and step-by-step configuration. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
+
+---
+
+## SDK Skills
+
+| Platform | Skill | Path |
 |---|---|---|
-| `sentry-android-sdk` | Android | Jetpack Compose, Views, OkHttp, Room, Fragment, Timber |
-| `sentry-cocoa-sdk` | iOS, macOS, tvOS, watchOS, visionOS | Swift, SwiftUI, UIKit |
-| `sentry-dotnet-sdk` | .NET, C# | ASP.NET Core, MAUI, WPF, Blazor, Azure Functions |
-| `sentry-go-sdk` | Go | net/http, Gin, Echo, Fiber |
-| `sentry-nestjs-sdk` | NestJS | Express, Fastify, GraphQL, Microservices |
-| `sentry-nextjs-sdk` | Next.js | App Router, Pages Router |
-| `sentry-node-sdk` | Node.js, Bun, Deno | Express, Fastify, Koa, Hapi, Connect, Bun.serve(), Deno.serve() |
-| `sentry-php-sdk` | PHP | Laravel, Symfony |
-| `sentry-python-sdk` | Python | Django, Flask, FastAPI, Celery |
-| `sentry-browser-sdk` | Browser JavaScript | Vanilla JS, jQuery, WordPress, static sites, CDN |
-| `sentry-react-native-sdk` | React Native | Expo managed, Expo bare |
-| `sentry-react-sdk` | React | React Router, TanStack, Redux |
-| `sentry-ruby-sdk` | Ruby | Rails, Sinatra, Sidekiq |
-| `sentry-svelte-sdk` | Svelte | SvelteKit |
+| Android | [`sentry-android-sdk`](../sentry-android-sdk/SKILL.md) | `sentry-android-sdk/SKILL.md` |
+| browser JavaScript | [`sentry-browser-sdk`](../sentry-browser-sdk/SKILL.md) | `sentry-browser-sdk/SKILL.md` |
+| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | [`sentry-cocoa-sdk`](../sentry-cocoa-sdk/SKILL.md) | `sentry-cocoa-sdk/SKILL.md` |
+| .NET | [`sentry-dotnet-sdk`](../sentry-dotnet-sdk/SKILL.md) | `sentry-dotnet-sdk/SKILL.md` |
+| Go | [`sentry-go-sdk`](../sentry-go-sdk/SKILL.md) | `sentry-go-sdk/SKILL.md` |
+| NestJS | [`sentry-nestjs-sdk`](../sentry-nestjs-sdk/SKILL.md) | `sentry-nestjs-sdk/SKILL.md` |
+| Next.js | [`sentry-nextjs-sdk`](../sentry-nextjs-sdk/SKILL.md) | `sentry-nextjs-sdk/SKILL.md` |
+| Node.js, Bun, and Deno | [`sentry-node-sdk`](../sentry-node-sdk/SKILL.md) | `sentry-node-sdk/SKILL.md` |
+| PHP | [`sentry-php-sdk`](../sentry-php-sdk/SKILL.md) | `sentry-php-sdk/SKILL.md` |
+| Python | [`sentry-python-sdk`](../sentry-python-sdk/SKILL.md) | `sentry-python-sdk/SKILL.md` |
+| React Native and Expo | [`sentry-react-native-sdk`](../sentry-react-native-sdk/SKILL.md) | `sentry-react-native-sdk/SKILL.md` |
+| React | [`sentry-react-sdk`](../sentry-react-sdk/SKILL.md) | `sentry-react-sdk/SKILL.md` |
+| Ruby | [`sentry-ruby-sdk`](../sentry-ruby-sdk/SKILL.md) | `sentry-ruby-sdk/SKILL.md` |
+| Svelte and SvelteKit | [`sentry-svelte-sdk`](../sentry-svelte-sdk/SKILL.md) | `sentry-svelte-sdk/SKILL.md` |
 
-## Routing Instructions
+### Platform Detection Priority
 
-1. Inspect project files to identify the platform and framework.
-2. Match to the table above and load the corresponding skill.
-3. If Android (`build.gradle` with android plugin) is detected, use `sentry-android-sdk`.
-4. If NestJS is detected (`@nestjs/core`), prefer `sentry-nestjs-sdk` over `sentry-node-sdk`.
-5. If Next.js is detected, prefer `sentry-nextjs-sdk` over `sentry-react-sdk` and `sentry-node-sdk`.
-6. If React Native is detected, prefer `sentry-react-native-sdk` over `sentry-react-sdk`.
-7. If `composer.json` with `laravel/framework` or `symfony/framework-bundle` is detected, use `sentry-php-sdk`.
-8. If Node.js, Bun, or Deno is detected without a specific framework skill above, use `sentry-node-sdk`.
-9. If vanilla JavaScript, jQuery, WordPress, a static HTML site, or a browser project without a framework is detected, use `sentry-browser-sdk`.
-10. If no match is found, direct the user to https://docs.sentry.io/platforms/ to find their platform.
+When multiple SDKs could match, prefer the more specific one:
 
-## Dynamic Skill Fetching
+- **Android** (`build.gradle` with android plugin) → `sentry-android-sdk`
+- **NestJS** (`@nestjs/core`) → `sentry-nestjs-sdk` over `sentry-node-sdk`
+- **Next.js** → `sentry-nextjs-sdk` over `sentry-react-sdk` or `sentry-node-sdk`
+- **React Native** → `sentry-react-native-sdk` over `sentry-react-sdk`
+- **PHP** with Laravel or Symfony → `sentry-php-sdk`
+- **Node.js / Bun / Deno** without a specific framework → `sentry-node-sdk`
+- **Browser JS** (vanilla, jQuery, static sites) → `sentry-browser-sdk`
+- **No match** → direct user to [Sentry Docs](https://docs.sentry.io/platforms/)
 
-If the matched SDK skill is **not installed locally**, fetch it from the skill library:
+## Quick Lookup
 
-```
-https://skills.sentry.gg/skills/<skill-name>/SKILL.md
-```
+Match your project to a skill by keywords. Append the path to `https://skills.sentry.gg/` to fetch.
 
-For example: `curl -sL https://skills.sentry.gg/skills/sentry-nextjs-sdk/SKILL.md`
+| Keywords | Path |
+|---|---|
+| android, kotlin, java, jetpack compose | `sentry-android-sdk/SKILL.md` |
+| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | `sentry-browser-sdk/SKILL.md` |
+| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | `sentry-cocoa-sdk/SKILL.md` |
+| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | `sentry-dotnet-sdk/SKILL.md` |
+| go, golang, gin, echo, fiber | `sentry-go-sdk/SKILL.md` |
+| nestjs, nest | `sentry-nestjs-sdk/SKILL.md` |
+| nextjs, next.js, next | `sentry-nextjs-sdk/SKILL.md` |
+| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | `sentry-node-sdk/SKILL.md` |
+| php, laravel, symfony | `sentry-php-sdk/SKILL.md` |
+| python, django, flask, fastapi, celery, starlette | `sentry-python-sdk/SKILL.md` |
+| react native, expo | `sentry-react-native-sdk/SKILL.md` |
+| react, react router, tanstack, redux, vite | `sentry-react-sdk/SKILL.md` |
+| ruby, rails, sinatra, sidekiq, rack | `sentry-ruby-sdk/SKILL.md` |
+| svelte, sveltekit | `sentry-svelte-sdk/SKILL.md` |
 
-The [Skill Tree](../../SKILL_TREE.md) lists every available skill — use it as the source of truth for valid skill names.
+---
+
+Looking for workflows or feature configuration instead? See the [full Skill Tree](../../SKILL_TREE.md).

--- a/skills/sentry-workflow/SKILL.md
+++ b/skills/sentry-workflow/SKILL.md
@@ -7,33 +7,48 @@ role: router
 
 > [All Skills](../../SKILL_TREE.md)
 
-# Sentry Workflow — Router
+# Sentry Workflows
 
-Match the user's intent to the appropriate workflow skill below.
+Debug production issues and maintain code quality with Sentry context. This page helps you find the right workflow skill for your task.
 
-| Skill | Use When |
-|---|---|
-| `sentry-fix-issues` | Finding and fixing production issues using Sentry MCP — stack traces, breadcrumbs, event data |
-| `sentry-code-review` | Resolving comments from `sentry[bot]` on GitHub PRs |
-| `sentry-pr-code-review` | Fixing issues detected by Seer Bug Prediction in PR reviews |
-| `sentry-sdk-upgrade` | Upgrading the Sentry JavaScript SDK across major versions — migration guides, breaking changes, deprecated APIs |
+## How to Fetch Skills
 
-## Routing Instructions
+Each skill below is a detailed, step-by-step workflow guide. To load one, **append its path to the base URL**:
 
-1. If the user mentions fixing errors, debugging exceptions, or investigating production issues → load `sentry-fix-issues`.
-2. If the user mentions Sentry bot comments, PR review comments from Sentry, or `sentry[bot]` → load `sentry-code-review`.
-3. If the user mentions Seer, bug prediction, or reviewing PRs for predicted issues → load `sentry-pr-code-review`.
-4. If the user mentions upgrading Sentry, migrating SDK versions, fixing deprecated Sentry APIs, or resolving breaking changes after a Sentry version bump → load `sentry-sdk-upgrade`.
-5. When unclear, ask whether the task involves live production issues (MCP), PR review comments, or SDK upgrades.
+    https://skills.sentry.gg/<skill-name>/SKILL.md
 
-## Dynamic Skill Fetching
+Use the **exact paths from the `Path` column** in the table below. Do not guess or shorten URLs.
 
-If the matched skill is **not installed locally**, fetch it from the skill library:
+Example — to fetch the issue-fixing skill:
 
-```
-https://skills.sentry.gg/skills/<skill-name>/SKILL.md
-```
+    https://skills.sentry.gg/sentry-fix-issues/SKILL.md
 
-For example: `curl -sL https://skills.sentry.gg/skills/sentry-fix-issues/SKILL.md`
+Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
 
-The [Skill Tree](../../SKILL_TREE.md) lists every available skill — use it as the source of truth for valid skill names.
+## Start Here — Read This Before Doing Anything
+
+**Do not skip this section.** Do not assume which workflow the user needs. Ask first.
+
+1. If the user mentions **fixing errors, debugging exceptions, or investigating production issues** → `sentry-fix-issues`
+2. If the user mentions **Sentry bot comments or `sentry[bot]` on a PR** → `sentry-code-review`
+3. If the user mentions **Seer, bug prediction, or reviewing PRs for predicted issues** → `sentry-pr-code-review`
+4. If the user mentions **upgrading Sentry, migrating SDK versions, or fixing deprecated APIs** → `sentry-sdk-upgrade`
+
+When unclear, **ask the user** whether the task involves live production issues, PR review comments, or SDK upgrades. Do not guess.
+
+---
+
+## Workflow Skills
+
+| Use when | Skill | Path |
+|---|---|---|
+| Finding and fixing production issues — stack traces, breadcrumbs, event data | [`sentry-fix-issues`](../sentry-fix-issues/SKILL.md) | `sentry-fix-issues/SKILL.md` |
+| Resolving comments from `sentry[bot]` on GitHub PRs | [`sentry-code-review`](../sentry-code-review/SKILL.md) | `sentry-code-review/SKILL.md` |
+| Fixing issues detected by Seer Bug Prediction in PR reviews | [`sentry-pr-code-review`](../sentry-pr-code-review/SKILL.md) | `sentry-pr-code-review/SKILL.md` |
+| Upgrading the Sentry JavaScript SDK — migration guides, breaking changes, deprecated APIs | [`sentry-sdk-upgrade`](../sentry-sdk-upgrade/SKILL.md) | `sentry-sdk-upgrade/SKILL.md` |
+
+Each skill contains its own detection logic, prerequisites, and step-by-step instructions. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
+
+---
+
+Looking for SDK setup or feature configuration instead? See the [full Skill Tree](../../SKILL_TREE.md).


### PR DESCRIPTION
## Problem

The three router skills (`sentry-sdk-setup`, `sentry-workflow`, `sentry-feature-setup`) are terse internal routing tables. They lack the agent-friendly patterns we added to SKILL_TREE.md in #29 and #30:

- No "ask first" nudge — agents can rush straight to installing things
- No `Path` column — agents have to parse markdown links or guess URLs
- Wrong fetch URL prefix (`/skills/<name>/SKILL.md` instead of `/<name>/SKILL.md`)
- No curl hint for tools that summarize content

This matters because these routers are about to become **direct entry points** via `skills.sentry.gg/sdks`, `/workflows`, and `/features` — agents will land on them without seeing the SKILL_TREE first.

## Changes

All three router skills rewritten to be self-contained entry points:

| Section | What it does |
|---|---|
| **How to Fetch Skills** | URL pattern, concrete example, curl hint |
| **Start Here** | "Ask first" nudge — confirm intent before acting |
| **Table with Path column** | Platform/use-case first, then skill name, then exact fetchable path |
| **Quick Lookup** (SDK router) | Keyword → path mapping for fast platform matching |
| **Cross-links** | Footer linking back to full Skill Tree for other categories |
| **Fixed URLs** | Removed incorrect `/skills/` prefix from fetch examples |

## Companion PR

The proxy changes for `/sdks`, `/workflows`, `/features` routes are in a separate PR on [skills.sentry.gg](https://github.com/getsentry/skills.sentry.gg).

## Follows

- #29 — agent-friendly SKILL_TREE.md (URL paths, ask-first nudge)
- #30 — curl hint for summarizing fetch tools