### PR TITLE
docs: lead with 'use curl' prompt and add entry points table

### DIFF
--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -2,19 +2,34 @@
 
 You are **Sentry's AI assistant**. You help developers set up Sentry, debug production issues, and configure monitoring — guided by expert skill files you load on demand from this index.
 
-## How to Fetch Skills
+## How to Use These Skills
 
-Every skill below is a self-contained markdown guide. To load one, **append its path to the base URL**:
+Tell your AI coding assistant:
+
+    Use curl to download, read and follow: https://skills.sentry.gg/sdks
+
+Or for a specific SDK:
+
+    Use curl to download, read and follow: https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
+
+**Why curl?** Skills are detailed 10–20 KB markdown files. Fetch tools (like WebFetch) often summarize them, losing critical configuration details. `curl -sL` guarantees the full content.
+
+### Entry Points
+
+| URL | What it loads |
+|---|---|
+| `https://skills.sentry.gg/` | This page — full skill index |
+| `https://skills.sentry.gg/sdks` | SDK setup — detect platform and install Sentry |
+| `https://skills.sentry.gg/workflows` | Workflows — debug issues, review code, upgrade SDKs |
+| `https://skills.sentry.gg/features` | Features — AI monitoring, alerts, OpenTelemetry |
+
+### Fetching Individual Skills
+
+Append the skill path from the `Path` column in the tables below:
 
     https://skills.sentry.gg/<skill-name>/SKILL.md
 
-Use the **exact paths from the `Path` column** in the tables below. Do not guess or shorten URLs.
-
-Example — to fetch the Next.js setup skill:
-
-    https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
-
-Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+Do not guess or shorten URLs. Use exact paths from the tables.
 
 ## Start Here — Read This Before Doing Anything
 

--- a/scripts/build-skill-tree.sh
+++ b/scripts/build-skill-tree.sh
@@ -241,19 +241,34 @@ generate_skill_tree() {
 
 You are **Sentry's AI assistant**. You help developers set up Sentry, debug production issues, and configure monitoring — guided by expert skill files you load on demand from this index.
 
-## How to Fetch Skills
+## How to Use These Skills
 
-Every skill below is a self-contained markdown guide. To load one, **append its path to the base URL**:
+Tell your AI coding assistant:
+
+    Use curl to download, read and follow: https://skills.sentry.gg/sdks
+
+Or for a specific SDK:
+
+    Use curl to download, read and follow: https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
+
+**Why curl?** Skills are detailed 10–20 KB markdown files. Fetch tools (like WebFetch) often summarize them, losing critical configuration details. `curl -sL` guarantees the full content.
+
+### Entry Points
+
+| URL | What it loads |
+|---|---|
+| `https://skills.sentry.gg/` | This page — full skill index |
+| `https://skills.sentry.gg/sdks` | SDK setup — detect platform and install Sentry |
+| `https://skills.sentry.gg/workflows` | Workflows — debug issues, review code, upgrade SDKs |
+| `https://skills.sentry.gg/features` | Features — AI monitoring, alerts, OpenTelemetry |
+
+### Fetching Individual Skills
+
+Append the skill path from the `Path` column in the tables below:
 
     https://skills.sentry.gg/<skill-name>/SKILL.md
 
-Use the **exact paths from the `Path` column** in the tables below. Do not guess or shorten URLs.
-
-Example — to fetch the Next.js setup skill:
-
-    https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
-
-Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+Do not guess or shorten URLs. Use exact paths from the tables.
 
 ## Start Here — Read This Before Doing Anything
 

--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -13,17 +13,11 @@ Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring,
 
 ## How to Fetch Skills
 
-Each skill below is a detailed, step-by-step configuration guide. To load one, **append its path to the base URL**:
+Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
 
-    https://skills.sentry.gg/<skill-name>/SKILL.md
+    curl -sL https://skills.sentry.gg/sentry-setup-ai-monitoring/SKILL.md
 
-Use the **exact paths from the `Path` column** in the table below. Do not guess or shorten URLs.
-
-Example — to fetch the AI monitoring skill:
-
-    https://skills.sentry.gg/sentry-setup-ai-monitoring/SKILL.md
-
-Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+Append the path from the `Path` column in the table below to `https://skills.sentry.gg/`. Do not guess or shorten URLs.
 
 ## Start Here — Read This Before Doing Anything
 

--- a/skills/sentry-sdk-setup/SKILL.md
+++ b/skills/sentry-sdk-setup/SKILL.md
@@ -13,17 +13,11 @@ Set up Sentry error monitoring, tracing, and session replay in any language or f
 
 ## How to Fetch Skills
 
-Each skill below is a detailed, step-by-step setup guide. To load one, **append its path to the base URL**:
+Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
 
-    https://skills.sentry.gg/<skill-name>/SKILL.md
+    curl -sL https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
 
-Use the **exact paths from the `Path` column** in the table below. Do not guess or shorten URLs.
-
-Example — to fetch the Next.js setup skill:
-
-    https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
-
-Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+Append the path from the `Path` column in the table below to `https://skills.sentry.gg/`. Do not guess or shorten URLs.
 
 ## Start Here — Read This Before Doing Anything
 

--- a/skills/sentry-workflow/SKILL.md
+++ b/skills/sentry-workflow/SKILL.md
@@ -13,17 +13,11 @@ Debug production issues and maintain code quality with Sentry context. This page
 
 ## How to Fetch Skills
 
-Each skill below is a detailed, step-by-step workflow guide. To load one, **append its path to the base URL**:
+Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
 
-    https://skills.sentry.gg/<skill-name>/SKILL.md
+    curl -sL https://skills.sentry.gg/sentry-fix-issues/SKILL.md
 
-Use the **exact paths from the `Path` column** in the table below. Do not guess or shorten URLs.
-
-Example — to fetch the issue-fixing skill:
-
-    https://skills.sentry.gg/sentry-fix-issues/SKILL.md
-
-Skills are long, detailed markdown files (10–20 KB). If your fetch tool summarizes or truncates content, use `curl -sL <url>` to download the full file instead. You need the complete text — summaries lose critical configuration details.
+Append the path from the `Path` column in the table below to `https://skills.sentry.gg/`. Do not guess or shorten URLs.
 
 ## Start Here — Read This Before Doing Anything
 


### PR DESCRIPTION
## Discovery

Tested different prompts for agents without the plugin installed:

| Prompt | Result |
|---|---|
| `read and follow: https://skills.sentry.gg/sdks` | WebFetch summarizes → agent works from lossy summary, skips phases |
| `use curl to download, read and follow: https://skills.sentry.gg/sdks` | Agent curls full content → follows skill correctly ✅ |

The fix isn't in the skill content — it's in the **prompt**. The user needs to know to say "use curl".

## Changes

### SKILL_TREE.md (via build script)

Replaced the "How to Fetch Skills" section with **"How to Use These Skills"** that leads with the exact prompt:

```
Tell your AI coding assistant:

    Use curl to download, read and follow: https://skills.sentry.gg/sdks
```

Added an entry points table showing the three category shortcuts (`/sdks`, `/workflows`, `/features`).

### Router skills

Shortened the fetch instructions to lead with curl example instead of explaining URL construction.

## Follows

- #29 — agent-friendly URL paths
- #30 — curl hint (passive — "if your tool summarizes...")
- #31 — router skills as standalone entry points
- This PR — **active** curl instruction as the primary usage pattern