### PR TITLE
fix(otel-skill): use consistent config_file placeholder in docker commands

### DIFF
--- a/skills/sentry-otel-exporter-setup/SKILL.md
+++ b/skills/sentry-otel-exporter-setup/SKILL.md
@@ -224,7 +224,7 @@ set -a && source "<env_file>" && set +a && "<collector_path>" validate --config 
 
 ```bash
 docker run --rm \
-  -v "<absolute_config_path>":/etc/otelcol-contrib/config.yaml \
+  -v "<config_file>":/etc/otelcol-contrib/config.yaml \
   --env-file "<env_file>" \
   otel/opentelemetry-collector-contrib:<numeric_version> \
   validate --config /etc/otelcol-contrib/config.yaml
@@ -280,7 +280,7 @@ docker run -d \
   -p 4317:4317 \
   -p 4318:4318 \
   -p 13133:13133 \
-  -v "<absolute_config_path>":/etc/otelcol-contrib/config.yaml \
+  -v "<config_file>":/etc/otelcol-contrib/config.yaml \
   --env-file "<env_file>" \
   otel/opentelemetry-collector-contrib:<numeric_version>
 ```


### PR DESCRIPTION
## Summary
- Fixed placeholder mismatch in the OTel exporter setup skill's docker commands
- The explanatory note references `<config_file>` but the docker `run` commands used `<absolute_config_path>`, creating a disconnect that could cause an AI agent to fail on path substitution
- Replaced both occurrences (validation and production docker commands) with `<config_file>` to match the note, which already explains how to make relative paths absolute

## Test plan
- [x] Read through the docker validation section (lines 221-231) and confirm placeholders are consistent
- [x] Read through the docker run section (lines 270-286) and confirm placeholders are consistent
- [x] Verify the note on making paths absolute still makes sense with the updated placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)