### PR TITLE
feat: add skill-creator agent for building new SDK skills

### DIFF
--- a/.github/agents/skill-creator.agent.md
+++ b/.github/agents/skill-creator.agent.md
@@ -192,7 +192,17 @@ Only create reference files for features the SDK actually supports.
 If profiling was removed or never existed, either skip it or create a short
 file that honestly says it's not available.
 
-## Step 6: Final Verification
+## Step 6: Register in Skill Tree
+
+Do this BEFORE running the skill tree validator — the validator checks that every
+skill with a `parent` field is listed in its parent router, so registration must
+come first.
+
+1. Add the skill to the router table in `skills/sentry-sdk-setup/SKILL.md`
+2. Run `./scripts/build-skill-tree.sh` to regenerate `SKILL_TREE.md` and validate
+3. Update `AGENTS.md` SDK skills table if needed
+
+## Step 7: Final Verification
 
 Run the full quality checklist from `quality-checklist.md`. Specifically:
 
@@ -213,8 +223,8 @@ grep -oP 'sentry-[\w-]+-sdk' skills/sentry-<platform>-sdk/SKILL.md | sort -u
 # 5. API names verified against cloned source (re-check 5 critical ones)
 # Search for each in /tmp/sentry-sdk-verify/
 
-# 6. Skill tree validates
-./scripts/build-skill-tree.sh
+# 6. Skill tree validates (must pass after Step 6 registration)
+./scripts/build-skill-tree.sh --check
 ```
 
 ### Cross-Consistency Check
@@ -225,12 +235,6 @@ Re-read every file you wrote and verify:
 - Same minimum version claims across files
 - No deprecated APIs used anywhere
 - Code examples use real import paths from the SDK
-
-## Step 7: Register in Skill Tree
-
-1. Add the skill to the router table in `skills/sentry-sdk-setup/SKILL.md`
-2. Run `./scripts/build-skill-tree.sh` to regenerate `SKILL_TREE.md` and validate
-3. Update `AGENTS.md` SDK skills table if needed
 
 ## Step 8: Commit and Open PR
 


### PR DESCRIPTION
## Summary

Adds a **GitHub Copilot custom agent** (`.github/agents/skill-creator.agent.md`) that creates complete Sentry SDK skill bundles from scratch for any platform or framework.

### What makes this agent different

The key differentiator is **source code verification**. The agent:

1. **Studies existing skills** — reads 2 real skills (one backend, one frontend) to internalize the exact patterns, table formats, and frontmatter conventions before writing anything
2. **Researches official docs** — fetches every relevant `docs.sentry.io` page for the platform, extracting real API signatures, config options, and code examples
3. **Clones the SDK repo** — `git clone --depth 1` into `/tmp/sentry-sdk-verify` to verify every API name, config option casing, init parameter, and import path against the actual source code
4. **Follows the full creator workflow** — all 6 phases from `skills/sentry-sdk-skill-creator/SKILL.md`, no shortcuts
5. **Runs the quality checklist** — every item from `quality-checklist.md` must pass before the PR opens

### Design: reference, don't duplicate

Like `skill-updater`, this agent reads the source-of-truth files at runtime:
- `skills/sentry-sdk-skill-creator/SKILL.md`
- `skills/sentry-sdk-skill-creator/references/philosophy.md`
- `skills/sentry-sdk-skill-creator/references/quality-checklist.md`
- `skills/sentry-sdk-skill-creator/references/research-playbook.md`

When those files are updated, the agent automatically picks up the changes.

### What the agent inlines (and why)

- **The source verification workflow** — because this is the critical step that prevents hallucinated APIs, and it's not covered in the existing skill-creator files (they were written for Claude Code, not for a Copilot agent that can clone repos)
- **The docs URL mapping table** — so the agent knows which pages to fetch per feature area
- **The step-by-step commit and PR strategy** — structured commits for clean PRs

### Usage

Assign an issue like "Create a Sentry SDK skill for Elixir" to Copilot. The `skill-creator` agent will:
1. Study `sentry-go-sdk` and `sentry-nextjs-sdk` for patterns
2. Research `docs.sentry.io/platforms/elixir/`
3. Clone `getsentry/sentry-elixir` and verify APIs
4. Write `skills/sentry-elixir-sdk/SKILL.md` + reference files
5. Register in skill tree
6. Open a PR with structured commits

### Agent inventory

| Agent | Purpose |
|-------|---------|
| `skill-updater` | Updates existing skills when SDKs change (handles drift issues) |
| **`skill-creator`** | **Creates new skills from scratch with full research + source verification** |

## Test plan

- [ ] Verify agent appears in Copilot's agent list
- [ ] Create a test issue "Create a Sentry SDK skill for Elixir" and assign to Copilot
- [ ] Verify agent clones SDK repo and verifies APIs against source
- [ ] Verify produced skill matches existing skill patterns
- [ ] Verify `build-skill-tree.sh --check` passes on the result