### PR TITLE
ref: Migrate skill URLs from sentry.gg to sentry.dev

### DIFF
--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -6,11 +6,11 @@ You are **Sentry's AI assistant**. You help developers set up Sentry, debug prod
 
 Tell your AI coding assistant:
 
-    Use curl to download, read and follow: https://skills.sentry.gg/sdks
+    Use curl to download, read and follow: https://skills.sentry.dev/sdks
 
 Or for a specific SDK:
 
-    Use curl to download, read and follow: https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
+    Use curl to download, read and follow: https://skills.sentry.dev/sentry-nextjs-sdk/SKILL.md
 
 **Why curl?** Skills are detailed 10–20 KB markdown files. Fetch tools (like WebFetch) often summarize them, losing critical configuration details. `curl -sL` guarantees the full content.
 
@@ -18,16 +18,16 @@ Or for a specific SDK:
 
 | URL | What it loads |
 |---|---|
-| `https://skills.sentry.gg/` | This page — full skill index |
-| `https://skills.sentry.gg/sdks` | SDK setup — detect platform and install Sentry |
-| `https://skills.sentry.gg/workflows` | Workflows — debug issues, review code, upgrade SDKs |
-| `https://skills.sentry.gg/features` | Features — AI monitoring, alerts, OpenTelemetry |
+| `https://skills.sentry.dev/` | This page — full skill index |
+| `https://skills.sentry.dev/sdks` | SDK setup — detect platform and install Sentry |
+| `https://skills.sentry.dev/workflows` | Workflows — debug issues, review code, upgrade SDKs |
+| `https://skills.sentry.dev/features` | Features — AI monitoring, alerts, OpenTelemetry |
 
 ### Fetching Individual Skills
 
 Append the skill path from the `Path` column in the tables below:
 
-    https://skills.sentry.gg/<skill-name>/SKILL.md
+    https://skills.sentry.dev/<skill-name>/SKILL.md
 
 Do not guess or shorten URLs. Use exact paths from the tables.
 
@@ -108,7 +108,7 @@ Configure specific Sentry capabilities beyond basic SDK setup.
 
 ## Quick Lookup
 
-Match your project to a skill by keywords. Append the path to `https://skills.sentry.gg/` to fetch.
+Match your project to a skill by keywords. Append the path to `https://skills.sentry.dev/` to fetch.
 
 | Keywords | Path |
 |---|---|

--- a/scripts/build-skill-tree.sh
+++ b/scripts/build-skill-tree.sh
@@ -247,11 +247,11 @@ You are **Sentry's AI assistant**. You help developers set up Sentry, debug prod
 
 Tell your AI coding assistant:
 
-    Use curl to download, read and follow: https://skills.sentry.gg/sdks
+    Use curl to download, read and follow: https://skills.sentry.dev/sdks
 
 Or for a specific SDK:
 
-    Use curl to download, read and follow: https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
+    Use curl to download, read and follow: https://skills.sentry.dev/sentry-nextjs-sdk/SKILL.md
 
 **Why curl?** Skills are detailed 10–20 KB markdown files. Fetch tools (like WebFetch) often summarize them, losing critical configuration details. `curl -sL` guarantees the full content.
 
@@ -259,16 +259,16 @@ Or for a specific SDK:
 
 | URL | What it loads |
 |---|---|
-| `https://skills.sentry.gg/` | This page — full skill index |
-| `https://skills.sentry.gg/sdks` | SDK setup — detect platform and install Sentry |
-| `https://skills.sentry.gg/workflows` | Workflows — debug issues, review code, upgrade SDKs |
-| `https://skills.sentry.gg/features` | Features — AI monitoring, alerts, OpenTelemetry |
+| `https://skills.sentry.dev/` | This page — full skill index |
+| `https://skills.sentry.dev/sdks` | SDK setup — detect platform and install Sentry |
+| `https://skills.sentry.dev/workflows` | Workflows — debug issues, review code, upgrade SDKs |
+| `https://skills.sentry.dev/features` | Features — AI monitoring, alerts, OpenTelemetry |
 
 ### Fetching Individual Skills
 
 Append the skill path from the `Path` column in the tables below:
 
-    https://skills.sentry.gg/<skill-name>/SKILL.md
+    https://skills.sentry.dev/<skill-name>/SKILL.md
 
 Do not guess or shorten URLs. Use exact paths from the tables.
 
@@ -354,7 +354,7 @@ FS_HEADER
 
 ## Quick Lookup
 
-Match your project to a skill by keywords. Append the path to `https://skills.sentry.gg/` to fetch.
+Match your project to a skill by keywords. Append the path to `https://skills.sentry.dev/` to fetch.
 
 | Keywords | Path |
 |---|---|

--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -15,9 +15,9 @@ Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring,
 
 Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
 
-    curl -sL https://skills.sentry.gg/sentry-setup-ai-monitoring/SKILL.md
+    curl -sL https://skills.sentry.dev/sentry-setup-ai-monitoring/SKILL.md
 
-Append the path from the `Path` column in the table below to `https://skills.sentry.gg/`. Do not guess or shorten URLs.
+Append the path from the `Path` column in the table below to `https://skills.sentry.dev/`. Do not guess or shorten URLs.
 
 ## Start Here — Read This Before Doing Anything
 

--- a/skills/sentry-sdk-setup/SKILL.md
+++ b/skills/sentry-sdk-setup/SKILL.md
@@ -15,9 +15,9 @@ Set up Sentry error monitoring, tracing, and session replay in any language or f
 
 Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
 
-    curl -sL https://skills.sentry.gg/sentry-nextjs-sdk/SKILL.md
+    curl -sL https://skills.sentry.dev/sentry-nextjs-sdk/SKILL.md
 
-Append the path from the `Path` column in the table below to `https://skills.sentry.gg/`. Do not guess or shorten URLs.
+Append the path from the `Path` column in the table below to `https://skills.sentry.dev/`. Do not guess or shorten URLs.
 
 ## Start Here — Read This Before Doing Anything
 
@@ -67,7 +67,7 @@ When multiple SDKs could match, prefer the more specific one:
 
 ## Quick Lookup
 
-Match your project to a skill by keywords. Append the path to `https://skills.sentry.gg/` to fetch.
+Match your project to a skill by keywords. Append the path to `https://skills.sentry.dev/` to fetch.
 
 | Keywords | Path |
 |---|---|

--- a/skills/sentry-workflow/SKILL.md
+++ b/skills/sentry-workflow/SKILL.md
@@ -15,9 +15,9 @@ Debug production issues and maintain code quality with Sentry context. This page
 
 Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
 
-    curl -sL https://skills.sentry.gg/sentry-fix-issues/SKILL.md
+    curl -sL https://skills.sentry.dev/sentry-fix-issues/SKILL.md
 
-Append the path from the `Path` column in the table below to `https://skills.sentry.gg/`. Do not guess or shorten URLs.
+Append the path from the `Path` column in the table below to `https://skills.sentry.dev/`. Do not guess or shorten URLs.
 
 ## Start Here — Read This Before Doing Anything
 


### PR DESCRIPTION
Update all `skills.sentry.gg` references to `skills.sentry.dev` across the skill tree, router skills, and the build script.

Files updated:
- `SKILL_TREE.md`
- `scripts/build-skill-tree.sh`
- `skills/sentry-sdk-setup/SKILL.md`
- `skills/sentry-workflow/SKILL.md`
- `skills/sentry-feature-setup/SKILL.md`


Agent transcript: https://claudescope.sentry.dev/share/HQIgdJOLu7AN2MTHnFHhycZsmC3YURzL2UIVj-o9-j8