### PR TITLE
feat(sdk-setup): add TanStack Start and React Router framework skills

### DIFF
--- a/.github/workflows/skill-drift-assign-reviewers.yml
+++ b/.github/workflows/skill-drift-assign-reviewers.yml
@@ -37,6 +37,7 @@ jobs:
               'sentry-python-sdk':        'getsentry/owners-python-sdk',
               'sentry-react-native-sdk':  'getsentry/team-mobile-cross-platform',
               'sentry-react-sdk':         'getsentry/team-javascript-sdks',
+              'sentry-react-router-framework-sdk': 'getsentry/team-javascript-sdks',
               'sentry-ruby-sdk':          'getsentry/team-web-sdk-backend',
               'sentry-svelte-sdk':        'getsentry/team-javascript-sdks',
             };

--- a/.github/workflows/skill-drift-assign-reviewers.yml
+++ b/.github/workflows/skill-drift-assign-reviewers.yml
@@ -38,6 +38,7 @@ jobs:
               'sentry-react-native-sdk':  'getsentry/team-mobile-cross-platform',
               'sentry-react-sdk':         'getsentry/team-javascript-sdks',
               'sentry-react-router-framework-sdk': 'getsentry/team-javascript-sdks',
+              'sentry-tanstack-start-sdk': 'getsentry/team-javascript-sdks',
               'sentry-ruby-sdk':          'getsentry/team-web-sdk-backend',
               'sentry-svelte-sdk':        'getsentry/team-javascript-sdks',
             };

--- a/.github/workflows/skill-drift-check.md
+++ b/.github/workflows/skill-drift-check.md
@@ -80,6 +80,7 @@ Some repos are monorepos — use the path filters to determine which skills are 
 | `sentry-react-native-sdk` | `getsentry/sentry-react-native` | — | `@getsentry/team-mobile-cross-platform` |
 | `sentry-react-sdk` | `getsentry/sentry-javascript` | `packages/react/`, `packages/browser/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
 | `sentry-react-router-framework-sdk` | `getsentry/sentry-javascript` | `packages/react-router/`, `packages/profiling-node/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
+| `sentry-tanstack-start-sdk` | `getsentry/sentry-javascript` | `packages/tanstackstart-react/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
 | `sentry-ruby-sdk` | `getsentry/sentry-ruby` | — | `@getsentry/team-web-sdk-backend` |
 | `sentry-svelte-sdk` | `getsentry/sentry-javascript` | `packages/svelte/`, `packages/sveltekit/`, `packages/browser/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
 

--- a/.github/workflows/skill-drift-check.md
+++ b/.github/workflows/skill-drift-check.md
@@ -79,6 +79,7 @@ Some repos are monorepos — use the path filters to determine which skills are 
 | `sentry-python-sdk` | `getsentry/sentry-python` | — | `@getsentry/owners-python-sdk` |
 | `sentry-react-native-sdk` | `getsentry/sentry-react-native` | — | `@getsentry/team-mobile-cross-platform` |
 | `sentry-react-sdk` | `getsentry/sentry-javascript` | `packages/react/`, `packages/browser/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
+| `sentry-react-router-framework-sdk` | `getsentry/sentry-javascript` | `packages/react-router/`, `packages/profiling-node/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
 | `sentry-ruby-sdk` | `getsentry/sentry-ruby` | — | `@getsentry/team-web-sdk-backend` |
 | `sentry-svelte-sdk` | `getsentry/sentry-javascript` | `packages/svelte/`, `packages/sveltekit/`, `packages/browser/`, `packages/core/` | `@getsentry/team-javascript-sdks` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,9 @@ Skills use YAML frontmatter with `allowed-tools` — this is required by Cursor 
 | `sentry-python-sdk` | Full setup wizard for Python (Django, Flask, FastAPI, Celery) |
 | `sentry-react-native-sdk` | Full setup wizard for React Native and Expo |
 | `sentry-browser-sdk` | Full setup wizard for Browser JavaScript (vanilla JS, jQuery, WordPress, static sites, Loader Script, CDN) |
-| `sentry-react-sdk` | Full setup wizard for React (Router v5-v7, TanStack, Redux) |
+| `sentry-react-sdk` | Full setup wizard for React (Router v5-v7 non-framework mode, TanStack, Redux) |
+| `sentry-react-router-framework-sdk` | Full setup wizard for React Router Framework mode (`@sentry/react-router`) |
+| `sentry-tanstack-start-sdk` | Full setup wizard for TanStack Start React (router tracing, server entry instrumentation, Vite plugin, middleware) |
 | `sentry-ruby-sdk` | Full setup wizard for Ruby (Rails, Sinatra, Sidekiq) |
 | `sentry-svelte-sdk` | Full setup wizard for Svelte/SvelteKit |
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ Full platform bundles that scan your project, recommend features, and guide you 
 | `sentry-php-sdk` | PHP (Laravel, Symfony) |
 | `sentry-python-sdk` | Python (Django, Flask, FastAPI, Celery, Starlette, AIOHTTP) |
 | `sentry-react-native-sdk` | React Native, Expo managed/bare |
-| `sentry-react-sdk` | React 16+, React Router v5-v7, TanStack Router, Redux |
+| `sentry-react-sdk` | React 16+, React Router v5-v7 non-framework mode, TanStack Router, Redux |
+| `sentry-react-router-framework-sdk` | React Router Framework mode (`@sentry/react-router`) |
+| `sentry-tanstack-start-sdk` | TanStack Start React |
 | `sentry-ruby-sdk` | Ruby, Rails, Sinatra, Rack, Sidekiq |
 | `sentry-svelte-sdk` | Svelte, SvelteKit |
 

--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -70,9 +70,11 @@ Install and configure Sentry for any platform. If unsure which SDK fits, detect 
 | PHP | [`sentry-php-sdk`](skills/sentry-php-sdk/SKILL.md) | `sentry-php-sdk/SKILL.md` |
 | Python | [`sentry-python-sdk`](skills/sentry-python-sdk/SKILL.md) | `sentry-python-sdk/SKILL.md` |
 | React Native and Expo | [`sentry-react-native-sdk`](skills/sentry-react-native-sdk/SKILL.md) | `sentry-react-native-sdk/SKILL.md` |
+| React Router Framework mode | [`sentry-react-router-framework-sdk`](skills/sentry-react-router-framework-sdk/SKILL.md) | `sentry-react-router-framework-sdk/SKILL.md` |
 | React | [`sentry-react-sdk`](skills/sentry-react-sdk/SKILL.md) | `sentry-react-sdk/SKILL.md` |
 | Ruby | [`sentry-ruby-sdk`](skills/sentry-ruby-sdk/SKILL.md) | `sentry-ruby-sdk/SKILL.md` |
 | Svelte and SvelteKit | [`sentry-svelte-sdk`](skills/sentry-svelte-sdk/SKILL.md) | `sentry-svelte-sdk/SKILL.md` |
+| TanStack Start React | [`sentry-tanstack-start-sdk`](skills/sentry-tanstack-start-sdk/SKILL.md) | `sentry-tanstack-start-sdk/SKILL.md` |
 
 ### Platform Detection Priority
 
@@ -81,6 +83,8 @@ When multiple SDKs could match, prefer the more specific one:
 - **Android** (`build.gradle` with android plugin) → `sentry-android-sdk`
 - **NestJS** (`@nestjs/core`) → `sentry-nestjs-sdk` over `sentry-node-sdk`
 - **Next.js** → `sentry-nextjs-sdk` over `sentry-react-sdk` or `sentry-node-sdk`
+- **React Router Framework** (`@sentry/react-router` or `@react-router/*`) → `sentry-react-router-framework-sdk` over `sentry-react-sdk`
+- **TanStack Start React** (`@tanstack/react-start`) → `sentry-tanstack-start-sdk` over `sentry-react-sdk`
 - **React Native** → `sentry-react-native-sdk` over `sentry-react-sdk`
 - **PHP** with Laravel or Symfony → `sentry-php-sdk`
 - **Node.js / Bun / Deno** without a specific framework → `sentry-node-sdk`
@@ -128,6 +132,8 @@ Match your project to a skill by keywords. Append the path to `https://skills.se
 | php, laravel, symfony | `sentry-php-sdk/SKILL.md` |
 | python, django, flask, fastapi, celery, starlette | `sentry-python-sdk/SKILL.md` |
 | react native, expo | `sentry-react-native-sdk/SKILL.md` |
+| react-router framework, @sentry/react-router, @react-router/dev, react-router reveal | `sentry-react-router-framework-sdk/SKILL.md` |
 | react, react router, tanstack, redux, vite | `sentry-react-sdk/SKILL.md` |
 | ruby, rails, sinatra, sidekiq, rack | `sentry-ruby-sdk/SKILL.md` |
 | svelte, sveltekit | `sentry-svelte-sdk/SKILL.md` |
+| tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react | `sentry-tanstack-start-sdk/SKILL.md` |

--- a/scripts/build-skill-tree.sh
+++ b/scripts/build-skill-tree.sh
@@ -229,6 +229,10 @@ build_keyword_lookup() {
         keywords="react native, expo" ;;
       sentry-react-sdk)
         keywords="react, react router, tanstack, redux, vite" ;;
+      sentry-react-router-framework-sdk)
+        keywords="react-router framework, @sentry/react-router, @react-router/dev, react-router reveal" ;;
+      sentry-tanstack-start-sdk)
+        keywords="tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react" ;;
       sentry-ruby-sdk)
         keywords="ruby, rails, sinatra, sidekiq, rack" ;;
       sentry-svelte-sdk)
@@ -320,6 +324,8 @@ When multiple SDKs could match, prefer the more specific one:
 - **Android** (`build.gradle` with android plugin) → `sentry-android-sdk`
 - **NestJS** (`@nestjs/core`) → `sentry-nestjs-sdk` over `sentry-node-sdk`
 - **Next.js** → `sentry-nextjs-sdk` over `sentry-react-sdk` or `sentry-node-sdk`
+- **React Router Framework** (`@sentry/react-router` or `@react-router/*`) → `sentry-react-router-framework-sdk` over `sentry-react-sdk`
+- **TanStack Start React** (`@tanstack/react-start`) → `sentry-tanstack-start-sdk` over `sentry-react-sdk`
 - **React Native** → `sentry-react-native-sdk` over `sentry-react-sdk`
 - **PHP** with Laravel or Symfony → `sentry-php-sdk`
 - **Node.js / Bun / Deno** without a specific framework → `sentry-node-sdk`

--- a/skills/sentry-react-router-framework-sdk/SKILL.md
+++ b/skills/sentry-react-router-framework-sdk/SKILL.md
@@ -1,0 +1,405 @@
+---
+name: sentry-react-router-framework-sdk
+description: Full Sentry SDK setup for React Router Framework mode. Use when asked to "add Sentry to React Router Framework", "install @sentry/react-router", or configure error monitoring, tracing, profiling, session replay, logs, or user feedback for a React Router v7 framework app.
+license: Apache-2.0
+category: sdk-setup
+parent: sentry-sdk-setup
+disable-model-invocation: true
+---
+
+> [All Skills](../../SKILL_TREE.md) > [SDK Setup](../sentry-sdk-setup/SKILL.md) > React Router Framework SDK
+
+# Sentry React Router Framework SDK
+
+Opinionated wizard that scans your React Router Framework project and guides you through complete Sentry setup across client and server entry points.
+
+## Invoke This Skill When
+
+- User asks to "add Sentry to React Router Framework" or "set up Sentry in React Router v7 framework mode"
+- User wants to install or configure `@sentry/react-router`
+- User uses React Router framework entry files (`entry.client.tsx`, `entry.server.tsx`) and wants tracing/error capture
+- User asks about `reactRouterTracingIntegration`, `sentryOnError`, `createSentryHandleRequest`, or React Router wizard setup
+
+> **Important:** This SDK is currently beta.
+> For React Router non-framework/data/declarative mode (v5/v6/v7), use `sentry-react-sdk` with `@sentry/react` integrations instead.
+
+---
+
+## Phase 1: Detect
+
+Run these commands to understand the project before making any recommendations:
+
+```bash
+# Detect React Router Framework indicators and versions
+cat package.json | grep -E '"react-router"|"@react-router/"|"react-router-dev"|"react-router-serve"'
+
+# Detect Sentry package choice
+cat package.json | grep -E '"@sentry/react-router"|"@sentry/react"|"@sentry/profiling-node"'
+
+# Check entry point visibility and server instrumentation files
+ls entry.client.tsx entry.server.tsx instrument.server.mjs react-router.config.ts vite.config.ts 2>/dev/null
+
+# Check if React Router files are still hidden (framework mode helper command available)
+cat package.json | grep -E '"reveal"|react-router'
+
+# Detect runtime startup scripts and import strategy
+cat package.json | grep -E '"dev"|"start"|NODE_OPTIONS|--import'
+
+# Detect optional logging/profile-related dependencies
+cat package.json | grep -E '"pino"|"winston"|"@sentry/profiling-node"'
+
+# Detect companion backend directories
+ls ../backend ../server ../api 2>/dev/null
+cat ../go.mod ../requirements.txt ../Gemfile ../pom.xml 2>/dev/null | head -3
+```
+
+**What to determine:**
+
+| Question | Impact |
+|----------|--------|
+| `@sentry/react-router` already installed? | Skip install and move to feature setup |
+| Framework entry files exposed? | Need `npx react-router reveal` before manual config |
+| Using `@sentry/react` instead? | This is likely non-framework routing; redirect to `sentry-react-sdk` |
+| `react-router.config.ts` + Vite config present? | Source map upload and build-end hook setup path |
+| `NODE_OPTIONS --import` available? | Preferred server instrumentation startup path |
+| `@sentry/profiling-node` desired/available? | Enable server profiling integration |
+| Backend directory found? | Trigger Phase 4 cross-link suggestion |
+
+---
+
+## Phase 2: Recommend
+
+Present a concrete recommendation based on what you found. Do not ask open-ended questions — lead with a proposal:
+
+**Recommended (core coverage):**
+- ✅ **Error Monitoring** — always; captures client and server errors with framework hooks
+- ✅ **Tracing** — recommended baseline in framework apps with client/server request flow
+- ✅ **Session Replay** — recommended for user-facing applications
+
+**Optional (enhanced observability):**
+- ⚡ **Profiling** — server-side profiling with `@sentry/profiling-node`
+- ⚡ **Logs** — structured `Sentry.logger.*` ingestion and correlation
+- ⚡ **User Feedback** — in-app feedback widget/reporting flows
+
+**Recommendation logic:**
+
+| Feature | Recommend when... |
+|---------|------------------|
+| Error Monitoring | **Always** — non-negotiable baseline |
+| Tracing | **Usually yes** in framework apps; route and request timing is high-value |
+| Session Replay | User-facing product or difficult UX debugging |
+| Profiling | Server performance investigations needed; Node runtime compatibility verified |
+| Logs | Team wants log-search and trace correlation in Sentry |
+| User Feedback | Product/support teams need direct in-app issue reports |
+
+Propose: *"I recommend Error Monitoring + Tracing + Session Replay first. Want me to also enable Profiling, Logs, and User Feedback?"*
+
+---
+
+## Phase 3: Guide
+
+### Option 1: Wizard (Recommended)
+
+> **You need to run this yourself** — the wizard is interactive and may require browser login:
+>
+> ```bash
+> npx @sentry/wizard@latest -i reactRouter
+> ```
+>
+> It installs `@sentry/react-router`, exposes React Router entry files, creates instrumentation files, updates root error handling, configures source map upload, and adds verification examples.
+>
+> **Once it finishes, continue at [Verification](#verification).**
+
+If the user skips wizard setup, continue with manual setup below.
+
+---
+
+### Option 2: Manual Setup
+
+#### Install packages
+
+```bash
+npm install @sentry/react-router --save
+```
+
+If profiling is needed:
+
+```bash
+npm install @sentry/profiling-node --save
+```
+
+#### Expose framework entry files
+
+```bash
+npx react-router reveal
+```
+
+#### Configure client in `entry.client.tsx`
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+import { startTransition, StrictMode } from "react";
+import { hydrateRoot } from "react-dom/client";
+import { HydratedRouter } from "react-router/dom";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  sendDefaultPii: true,
+  integrations: [
+    Sentry.reactRouterTracingIntegration(),
+    Sentry.replayIntegration(),
+    Sentry.feedbackIntegration({ colorScheme: "system" }),
+  ],
+  enableLogs: true,
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: [/^\//, /^https:\/\/yourserver\.io\/api/],
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
+
+startTransition(() => {
+  hydrateRoot(
+    document,
+    <StrictMode>
+      <HydratedRouter onError={Sentry.sentryOnError} />
+    </StrictMode>,
+  );
+});
+```
+
+#### Configure server in `instrument.server.mjs`
+
+```javascript
+import * as Sentry from "@sentry/react-router";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  sendDefaultPii: true,
+  enableLogs: true,
+  integrations: [nodeProfilingIntegration()],
+  tracesSampleRate: 1.0,
+  profileSessionSampleRate: 1.0,
+});
+```
+
+#### Wrap server handlers in `entry.server.tsx`
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+import { createReadableStreamFromReadable } from "@react-router/node";
+import { renderToPipeableStream } from "react-dom/server";
+import { ServerRouter } from "react-router";
+
+const handleRequest = Sentry.createSentryHandleRequest({
+  ServerRouter,
+  renderToPipeableStream,
+  createReadableStreamFromReadable,
+});
+
+export default handleRequest;
+
+export const handleError = Sentry.createSentryHandleError({
+  logErrors: false,
+});
+```
+
+For custom server logic, use `wrapSentryHandleRequest`, `getMetaTagTransformer`, and manual `Sentry.captureException` in your custom `handleError`.
+
+#### Load server instrumentation on startup
+
+Prefer `NODE_OPTIONS --import`:
+
+```json
+{
+  "scripts": {
+    "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router dev",
+    "start": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js"
+  }
+}
+```
+
+Fallback for platforms where runtime flags are restricted:
+
+```tsx
+import "./instrument.server";
+```
+
+This direct-import method can result in incomplete auto-instrumentation compared to `--import`.
+
+#### Configure source maps
+
+`vite.config.ts`:
+
+```typescript
+import { reactRouter } from "@react-router/dev/vite";
+import {
+  sentryReactRouter,
+  type SentryReactRouterBuildOptions,
+} from "@sentry/react-router";
+import { defineConfig } from "vite";
+
+const sentryConfig: SentryReactRouterBuildOptions = {
+  org: "___ORG_SLUG___",
+  project: "___PROJECT_SLUG___",
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+};
+
+export default defineConfig((config) => {
+  return {
+    plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
+  };
+});
+```
+
+`react-router.config.ts`:
+
+```typescript
+import type { Config } from "@react-router/dev/config";
+import { sentryOnBuildEnd } from "@sentry/react-router";
+
+export default {
+  ssr: true,
+  buildEnd: async ({ viteConfig, reactRouterConfig, buildManifest }) => {
+    await sentryOnBuildEnd({ viteConfig, reactRouterConfig, buildManifest });
+  },
+} satisfies Config;
+```
+
+---
+
+### For Each Agreed Feature
+
+Walk through features one at a time. Load the reference file, follow steps exactly, and verify before moving on:
+
+| Feature | Reference | Load when... |
+|---------|-----------|-------------|
+| Error Monitoring | `${SKILL_ROOT}/references/error-monitoring.md` | Always |
+| Tracing | `${SKILL_ROOT}/references/tracing.md` | Route/request performance visibility needed |
+| Profiling | `${SKILL_ROOT}/references/profiling.md` | Server performance analysis needed |
+| Session Replay | `${SKILL_ROOT}/references/session-replay.md` | User-facing app |
+| Logs | `${SKILL_ROOT}/references/logging.md` | Structured logs/correlation needed |
+| User Feedback | `${SKILL_ROOT}/references/user-feedback.md` | In-app feedback flows needed |
+| Framework Features | `${SKILL_ROOT}/references/react-router-framework-features.md` | Entry files, wrappers, source maps, startup import strategy |
+
+For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
+
+---
+
+## Configuration Reference
+
+### Key `Sentry.init()` options
+
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `dsn` | `string` | — | Required; SDK disabled when empty |
+| `sendDefaultPii` | `boolean` | `false` | Includes headers/IP-derived user context |
+| `integrations` | `Integration[]` | SDK defaults | Add tracing/replay/feedback/profiling integrations |
+| `enableLogs` | `boolean` | `false` | Enables `Sentry.logger.*` ingestion |
+| `tracesSampleRate` | `number` | — | Usually `1.0` in testing, lower in production |
+| `tracePropagationTargets` | `(string|RegExp)[]` | SDK defaults | URLs that receive tracing headers |
+| `replaysSessionSampleRate` | `number` | — | Fraction of all sessions recorded |
+| `replaysOnErrorSampleRate` | `number` | — | Fraction of error sessions recorded |
+| `profileSessionSampleRate` | `number` | — | Fraction of transactions profiled (server profiling) |
+| `tunnel` | `string` | — | Optional ad-blocker bypass endpoint |
+| `debug` | `boolean` | `false` | Verbose SDK diagnostics |
+
+### Framework-specific APIs
+
+| API | Purpose |
+|-----|---------|
+| `reactRouterTracingIntegration()` | Client-side tracing integration for framework mode |
+| `sentryOnError` | Hooks into React Router `HydratedRouter` error reporting |
+| `createSentryHandleRequest(...)` | Server request wrapper for framework entry server |
+| `createSentryHandleError(...)` | Server error handler wrapper |
+| `wrapServerLoader(...)` / `wrapServerAction(...)` | Manual wrapping for server loaders/actions |
+| `sentryReactRouter(...)` | Vite plugin for source maps/build integration |
+| `sentryOnBuildEnd(...)` | React Router build-end hook for source map processing |
+
+---
+
+## Verification
+
+### Wizard-generated path
+
+If wizard examples were generated, open `/sentry-example-page` and trigger test actions.
+
+### Manual error test
+
+```tsx
+export async function loader() {
+  throw new Error("My first Sentry error!");
+}
+```
+
+### Manual tracing test
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+
+export async function loader() {
+  return Sentry.startSpan(
+    { op: "test", name: "My First Test Transaction" },
+    () => {
+      throw new Error("My first Sentry error!");
+    },
+  );
+}
+```
+
+### Logs test
+
+```javascript
+Sentry.logger.info("User example action completed");
+Sentry.logger.warn("Slow operation detected", { operation: "data_fetch", duration: 3500 });
+Sentry.logger.error("Validation failed", { field: "email", reason: "Invalid email" });
+```
+
+Confirm in Sentry:
+- **Issues**: errors appear
+- **Traces**: transaction/span data appears
+- **Profiles**: profiles appear when profiling enabled
+- **Replays**: replay entries appear when enabled
+- **Logs**: log events appear when `enableLogs: true`
+- **User Feedback**: submissions appear when feedback enabled
+
+---
+
+## Phase 4: Cross-Link
+
+After completing React Router Framework setup:
+
+1. Check whether the app is actually non-framework routing (v5/v6/v7 data/declarative with `@sentry/react`).
+2. If yes, redirect to `sentry-react-sdk` for non-framework routing integrations.
+
+Then check companion backend coverage:
+
+```bash
+ls ../backend ../server ../api ../go ../python 2>/dev/null
+cat ../go.mod ../requirements.txt ../pyproject.toml ../Gemfile ../pom.xml 2>/dev/null | head -5
+```
+
+| Backend detected | Suggest skill |
+|------------------|--------------|
+| Go | `sentry-go-sdk` |
+| Python | `sentry-python-sdk` |
+| Ruby | `sentry-ruby-sdk` |
+| Node backend services | `sentry-node-sdk` |
+| Java services | Use `@sentry/java` docs |
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `entry.client.tsx` / `entry.server.tsx` missing | Run `npx react-router reveal` first |
+| Client errors missing | Ensure `HydratedRouter` includes `onError={Sentry.sentryOnError}` |
+| Server errors missing | Use `createSentryHandleRequest` and `createSentryHandleError` wrappers |
+| Custom server handlers bypass Sentry | Use `wrapSentryHandleRequest` and manual `captureException` in custom `handleError` |
+| Source maps not uploaded | Verify `sentryReactRouter` plugin config and `sentryOnBuildEnd` hook |
+| `SENTRY_AUTH_TOKEN` undefined in Vite config | Load env vars in config or use `.env.sentry-build-plugin` |
+| Incomplete server auto-instrumentation | Prefer `NODE_OPTIONS='--import ./instrument.server.mjs'` startup |
+| Profiling data missing | Confirm `@sentry/profiling-node` installed and `nodeProfilingIntegration` enabled |
+| Running unsupported Node auto-instrumentation version | Use instrumentation API/manual wrappers as documented |
+| Non-framework app configured with `@sentry/react-router` | Switch to `sentry-react-sdk` + `@sentry/react` for v5/v6/v7 non-framework routes |

--- a/skills/sentry-react-router-framework-sdk/SKILL.md
+++ b/skills/sentry-react-router-framework-sdk/SKILL.md
@@ -222,7 +222,7 @@ Prefer `NODE_OPTIONS --import`:
 Fallback for platforms where runtime flags are restricted:
 
 ```tsx
-import "./instrument.server";
+import "./instrument.server.mjs";
 ```
 
 This direct-import method can result in incomplete auto-instrumentation compared to `--import`.

--- a/skills/sentry-react-router-framework-sdk/references/error-monitoring.md
+++ b/skills/sentry-react-router-framework-sdk/references/error-monitoring.md
@@ -1,0 +1,127 @@
+# Error Monitoring — Sentry React Router Framework SDK
+
+> Minimum SDK: `@sentry/react-router` (beta)
+
+---
+
+## Automatic and Manual Capture
+
+| Area | Auto Captured? | Mechanism |
+|------|----------------|-----------|
+| Client-side framework errors | ✅ Yes | `HydratedRouter onError={Sentry.sentryOnError}` |
+| Unhandled client exceptions | ✅ Yes | Browser global handlers from SDK init |
+| Server request/render errors | ✅ Yes | `createSentryHandleRequest` + `createSentryHandleError` |
+| Custom handled server errors | ❌ Not always | Call `Sentry.captureException` manually |
+| Custom loader/action failures | ⚠️ Depends | Use `wrapServerLoader` / `wrapServerAction` or manual capture |
+
+---
+
+## Client setup requirement
+
+`entry.client.tsx` must include:
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+import { HydratedRouter } from "react-router/dom";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+});
+
+hydrateRoot(document, <HydratedRouter onError={Sentry.sentryOnError} />);
+```
+
+Without `sentryOnError`, framework-level client errors may be missed.
+
+---
+
+## Server setup requirement
+
+`entry.server.tsx`:
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+import { createReadableStreamFromReadable } from "@react-router/node";
+import { renderToPipeableStream } from "react-dom/server";
+import { ServerRouter } from "react-router";
+
+const handleRequest = Sentry.createSentryHandleRequest({
+  ServerRouter,
+  renderToPipeableStream,
+  createReadableStreamFromReadable,
+});
+
+export default handleRequest;
+
+export const handleError = Sentry.createSentryHandleError({
+  logErrors: false,
+});
+```
+
+---
+
+## Manual capture in custom handlers
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+
+export function handleError(error: unknown, args: unknown) {
+  Sentry.captureException(error);
+  console.error(error);
+}
+```
+
+For custom streaming request implementations, wrap your handler:
+
+```tsx
+import { wrapSentryHandleRequest } from "@sentry/react-router";
+
+export default wrapSentryHandleRequest(customHandleRequest);
+```
+
+---
+
+## Loader/action wrappers
+
+```ts
+import * as Sentry from "@sentry/react-router";
+
+export const loader = Sentry.wrapServerLoader(
+  { name: "Load Data", description: "Loads route data" },
+  async () => {
+    // loader logic
+  },
+);
+
+export const action = Sentry.wrapServerAction(
+  { name: "Submit Data", description: "Handles form submission" },
+  async () => {
+    // action logic
+  },
+);
+```
+
+---
+
+## Verification
+
+Use a route loader that throws:
+
+```tsx
+export async function loader() {
+  throw new Error("My first Sentry error!");
+}
+```
+
+Open the route and verify the event appears in **Issues**.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Client framework errors missing | Ensure `HydratedRouter` uses `onError={Sentry.sentryOnError}` |
+| Server render/request errors missing | Verify both `createSentryHandleRequest` and `createSentryHandleError` are exported |
+| Custom handlers not captured | Add explicit `captureException` calls |
+| Error appears locally but not in Sentry | Check DSN, network restrictions, and `debug: true` output |

--- a/skills/sentry-react-router-framework-sdk/references/logging.md
+++ b/skills/sentry-react-router-framework-sdk/references/logging.md
@@ -1,0 +1,65 @@
+# Logs — Sentry React Router Framework SDK
+
+> Minimum SDK: `@sentry/react-router` with Logs support
+
+---
+
+## Enable logs
+
+Set `enableLogs: true` in both client and server initialization where you want log ingestion.
+
+```tsx
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  enableLogs: true,
+});
+```
+
+---
+
+## Logging APIs
+
+```javascript
+Sentry.logger.info("User example action completed");
+
+Sentry.logger.warn("Slow operation detected", {
+  operation: "data_fetch",
+  duration: 3500,
+});
+
+Sentry.logger.error("Validation failed", {
+  field: "email",
+  reason: "Invalid email",
+});
+```
+
+---
+
+## Correlation guidance
+
+For better debugging:
+
+1. Enable tracing with meaningful transaction names.
+2. Add structured fields to logs (`operation`, `route`, `tenant`, `requestId`).
+3. Keep consistent keys across client and server logs.
+
+This improves issue/trace/log correlation in Sentry.
+
+---
+
+## Verification
+
+1. Emit info/warn/error logs from app code.
+2. Open **Logs** in Sentry.
+3. Filter by message/metadata and confirm ingestion.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Logs not visible | Verify `enableLogs: true` in active init path |
+| Missing metadata | Pass structured objects as second logger argument |
+| Noisy logs | Reduce volume or gate lower-severity logs by environment |
+| Logs not linked to traces | Ensure tracing is active and shared context fields are present |

--- a/skills/sentry-react-router-framework-sdk/references/profiling.md
+++ b/skills/sentry-react-router-framework-sdk/references/profiling.md
@@ -1,0 +1,57 @@
+# Profiling — Sentry React Router Framework SDK
+
+> Minimum SDK: `@sentry/react-router` with `@sentry/profiling-node` for server profiling
+
+---
+
+## Profiling setup (server)
+
+Install profiling package:
+
+```bash
+npm install @sentry/profiling-node --save
+```
+
+Configure in `instrument.server.mjs`:
+
+```js
+import * as Sentry from "@sentry/react-router";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [nodeProfilingIntegration()],
+  tracesSampleRate: 1.0,
+  profileSessionSampleRate: 1.0,
+});
+```
+
+---
+
+## Sampling strategy
+
+| Setting | Purpose |
+|---------|---------|
+| `tracesSampleRate` | How many transactions are captured |
+| `profileSessionSampleRate` | What fraction of traced transactions get profiles |
+
+Start high in development, then lower for production cost control.
+
+---
+
+## Verification
+
+1. Trigger a server transaction with profiling enabled.
+2. Open **Profiles** in Sentry.
+3. Confirm profile entries appear and are linked to transactions.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No profiles visible | Ensure `@sentry/profiling-node` is installed and integration is active |
+| Traces visible but no profiles | Increase `profileSessionSampleRate` |
+| Profile volume too high | Lower `profileSessionSampleRate` and/or `tracesSampleRate` |
+| Runtime incompatibility symptoms | Verify Node runtime support and fallback to tracing-only where needed |

--- a/skills/sentry-react-router-framework-sdk/references/react-router-framework-features.md
+++ b/skills/sentry-react-router-framework-sdk/references/react-router-framework-features.md
@@ -84,7 +84,7 @@ Use `SENTRY_AUTH_TOKEN` via environment variables (or `.env.sentry-build-plugin`
 If runtime flags are unavailable, import server instrumentation at the top of `entry.server.tsx`:
 
 ```tsx
-import "./instrument.server";
+import "./instrument.server.mjs";
 ```
 
 This fallback may have incomplete automatic instrumentation compared to `--import`.

--- a/skills/sentry-react-router-framework-sdk/references/react-router-framework-features.md
+++ b/skills/sentry-react-router-framework-sdk/references/react-router-framework-features.md
@@ -1,0 +1,107 @@
+# React Router Framework Features — Sentry React Router Framework SDK
+
+> Framework mode package: `@sentry/react-router`
+
+---
+
+## Wizard path
+
+Use the installer for fastest setup:
+
+```bash
+npx @sentry/wizard@latest -i reactRouter
+```
+
+The wizard can:
+- install SDK packages
+- expose `entry.client.tsx` and `entry.server.tsx`
+- create `instrument.server.mjs`
+- configure source maps in Vite/React Router config
+- add example verification files/routes
+
+---
+
+## Manual framework file checklist
+
+1. `entry.client.tsx` with:
+   - `Sentry.init(...)`
+   - `HydratedRouter onError={Sentry.sentryOnError}`
+2. `instrument.server.mjs` with server `Sentry.init(...)`
+3. `entry.server.tsx` with:
+   - `createSentryHandleRequest`
+   - `createSentryHandleError`
+4. Runtime startup with `NODE_OPTIONS='--import ./instrument.server.mjs'`
+
+---
+
+## Source maps for framework builds
+
+### Vite plugin
+
+```ts
+import { reactRouter } from "@react-router/dev/vite";
+import { sentryReactRouter } from "@sentry/react-router";
+
+export default defineConfig((config) => ({
+  plugins: [reactRouter(), sentryReactRouter(sentryConfig, config)],
+}));
+```
+
+### React Router build end hook
+
+```ts
+import { sentryOnBuildEnd } from "@sentry/react-router";
+
+export default {
+  ssr: true,
+  buildEnd: async ({ viteConfig, reactRouterConfig, buildManifest }) => {
+    await sentryOnBuildEnd({ viteConfig, reactRouterConfig, buildManifest });
+  },
+};
+```
+
+### Auth token
+
+Use `SENTRY_AUTH_TOKEN` via environment variables (or `.env.sentry-build-plugin`).
+
+---
+
+## Runtime startup strategies
+
+### Preferred (`NODE_OPTIONS --import`)
+
+```json
+{
+  "scripts": {
+    "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router dev",
+    "start": "NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js"
+  }
+}
+```
+
+### Fallback (direct import)
+
+If runtime flags are unavailable, import server instrumentation at the top of `entry.server.tsx`:
+
+```tsx
+import "./instrument.server";
+```
+
+This fallback may have incomplete automatic instrumentation compared to `--import`.
+
+---
+
+## Non-framework handoff
+
+If project uses React Router in data/declarative mode without framework entry wrappers, route setup to `sentry-react-sdk` (`@sentry/react`) for v5/v6/v7 integrations.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Entry files not present | Run `npx react-router reveal` |
+| Source maps still minified | Confirm both `sentryReactRouter` plugin and `sentryOnBuildEnd` hook are configured |
+| Server startup misses instrumentation | Ensure `NODE_OPTIONS --import` is actually applied in deployed runtime |
+| Framework setup used in non-framework app | Switch to `sentry-react-sdk` guidance |

--- a/skills/sentry-react-router-framework-sdk/references/session-replay.md
+++ b/skills/sentry-react-router-framework-sdk/references/session-replay.md
@@ -1,0 +1,67 @@
+# Session Replay — Sentry React Router Framework SDK
+
+> Minimum SDK: `@sentry/react-router` with Replay support
+
+---
+
+## Replay setup (client)
+
+Configure replay in `entry.client.tsx`:
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.replayIntegration()],
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
+```
+
+---
+
+## Sampling guidance
+
+| Goal | Suggested setup |
+|------|-----------------|
+| Validate integration | `replaysSessionSampleRate: 0.1`, `replaysOnErrorSampleRate: 1.0` |
+| Control storage costs | Lower session sample rate; keep error replay rate high |
+| Incident debugging | Temporarily increase session sample rate |
+
+---
+
+## Privacy controls
+
+```tsx
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
+```
+
+---
+
+## Verification
+
+1. Use the app in a browser and trigger an error.
+2. Open **Replays** in Sentry.
+3. Confirm replay exists and is linked to errors/traces.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Replay missing | Ensure `replayIntegration()` is configured in client init |
+| Only error replays show | Increase `replaysSessionSampleRate` |
+| Sensitive data visible | Enable masking/blocking and verify element privacy settings |
+| Replay volume too high | Lower replay sampling rates |

--- a/skills/sentry-react-router-framework-sdk/references/tracing.md
+++ b/skills/sentry-react-router-framework-sdk/references/tracing.md
@@ -1,0 +1,92 @@
+# Tracing — Sentry React Router Framework SDK
+
+> Minimum SDK: `@sentry/react-router` (beta)
+
+---
+
+## Enable tracing
+
+Configure tracing in `entry.client.tsx`:
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.reactRouterTracingIntegration()],
+  tracesSampleRate: 1.0,
+  tracePropagationTargets: ["localhost", /^https:\/\/yourserver\.io\/api/],
+});
+```
+
+---
+
+## Sampling guidance
+
+| Environment | Suggested value |
+|-------------|-----------------|
+| Development/testing | `tracesSampleRate: 1.0` |
+| Initial production rollout | `0.1` to `0.3` |
+| High throughput | Use lower fixed rate or `tracesSampler` |
+
+If both `tracesSampleRate` and `tracesSampler` are provided, `tracesSampler` takes precedence.
+
+---
+
+## Distributed tracing
+
+Use `tracePropagationTargets` so Sentry sends trace headers to your backend routes:
+
+```tsx
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.reactRouterTracingIntegration()],
+  tracesSampleRate: 0.2,
+  tracePropagationTargets: [/^\//, /^https:\/\/api\.example\.com/],
+});
+```
+
+---
+
+## Custom spans
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+
+export async function loader() {
+  return Sentry.startSpan(
+    {
+      op: "test",
+      name: "My First Test Transaction",
+    },
+    () => {
+      throw new Error("My first Sentry error!");
+    },
+  );
+}
+```
+
+---
+
+## Node runtime note
+
+Automatic server-side instrumentation compatibility has version limits for some Node versions in current docs. If your runtime is outside supported auto-instrumentation ranges, use framework instrumentation APIs or manual wrappers to keep tracing coverage.
+
+---
+
+## Verification
+
+1. Trigger one loader/action request from the app.
+2. Open **Traces** in Sentry.
+3. Confirm transaction names, spans, and linked errors appear.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No trace data | Confirm `reactRouterTracingIntegration()` and `tracesSampleRate` are configured |
+| Client and server traces not connected | Adjust `tracePropagationTargets` to include backend URLs |
+| Too many traces | Lower sample rate or use `tracesSampler` |
+| Tracing disappears in certain environments | Check runtime version constraints and fallback instrumentation path |

--- a/skills/sentry-react-router-framework-sdk/references/user-feedback.md
+++ b/skills/sentry-react-router-framework-sdk/references/user-feedback.md
@@ -1,0 +1,71 @@
+# User Feedback — Sentry React Router Framework SDK
+
+> Minimum SDK: `@sentry/react-router` with Feedback support
+
+---
+
+## Feedback widget setup
+
+Configure in `entry.client.tsx`:
+
+```tsx
+import * as Sentry from "@sentry/react-router";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.feedbackIntegration({
+      colorScheme: "system",
+    }),
+  ],
+});
+```
+
+---
+
+## Common options
+
+```tsx
+Sentry.feedbackIntegration({
+  autoInject: true,
+  colorScheme: "system",
+  showName: true,
+  showEmail: true,
+  triggerLabel: "Report a bug",
+  formTitle: "Report a bug",
+  submitButtonLabel: "Send report",
+  successMessageText: "Thanks for the report.",
+});
+```
+
+---
+
+## Error-linked feedback dialog
+
+```tsx
+const eventId = Sentry.captureException(new Error("Checkout failed"));
+Sentry.showReportDialog({
+  eventId,
+  title: "Something went wrong",
+  subtitle: "Tell us what happened",
+});
+```
+
+---
+
+## Verification
+
+1. Trigger feedback widget submission from the app.
+2. Open **User Feedback** in Sentry.
+3. Confirm submissions appear and error-linked reports attach to events.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Feedback widget not visible | Ensure `feedbackIntegration()` is in client integrations |
+| Missing user context | Set Sentry user context before submitting feedback |
+| Feedback not linked to errors | Use `showReportDialog` with a real `eventId` |
+| UI overlap/z-index issues | Adjust app styles and trigger placement |

--- a/skills/sentry-react-sdk/SKILL.md
+++ b/skills/sentry-react-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-react-sdk
-description: Full Sentry SDK setup for React. Use when asked to "add Sentry to React", "install @sentry/react", or configure error monitoring, tracing, session replay, profiling, or logging for React applications. Supports React 16+, React Router v5-v7, TanStack Router, Redux, Vite, and webpack.
+description: Full Sentry SDK setup for React. Use when asked to "add Sentry to React", "install @sentry/react", or configure error monitoring, tracing, session replay, profiling, or logging for React applications. Supports React 16+, React Router v5-v7 non-framework mode, TanStack Router, Redux, Vite, and webpack.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -18,7 +18,9 @@ Opinionated wizard that scans your React project and guides you through complete
 - User asks to "add Sentry to React" or "set up Sentry" in a React app
 - User wants error monitoring, tracing, session replay, profiling, or logging in React
 - User mentions `@sentry/react`, React Sentry SDK, or Sentry error boundaries
-- User wants to monitor React Router navigation, Redux state, or component performance
+- User wants to monitor React Router v5/v6/v7 non-framework navigation, Redux state, or component performance
+
+If project is React Router **Framework mode** using `@sentry/react-router`, use `sentry-react-router-framework-sdk` instead of this skill.
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/react` ≥8.0.0).
 > Always verify against [docs.sentry.io/platforms/javascript/guides/react/](https://docs.sentry.io/platforms/javascript/guides/react/) before implementing.
@@ -36,8 +38,8 @@ cat package.json | grep -E '"react"|"react-dom"'
 # Check for existing Sentry
 cat package.json | grep '"@sentry/'
 
-# Detect router
-cat package.json | grep -E '"react-router-dom"|"@tanstack/react-router"'
+# Detect router and framework mode hints
+cat package.json | grep -E '"react-router-dom"|"react-router"|"@react-router/"|"@tanstack/react-router"|"@sentry/react-router"'
 
 # Detect state management
 cat package.json | grep -E '"redux"|"@reduxjs/toolkit"'
@@ -61,6 +63,7 @@ cat ../go.mod ../requirements.txt ../Gemfile ../pom.xml 2>/dev/null | head -3
 | React 19+? | Use `reactErrorHandler()` hook pattern |
 | React <19? | Use `Sentry.ErrorBoundary` |
 | `@sentry/react` already present? | Skip install, go straight to feature config |
+| React Router Framework mode indicators (`@sentry/react-router`, `@react-router/*`)? | Use `sentry-react-router-framework-sdk` |
 | `react-router-dom` v5 / v6 / v7? | Determines which router integration to use |
 | `@tanstack/react-router`? | Use `tanstackRouterBrowserTracingIntegration()` |
 | Redux in use? | Recommend `createReduxEnhancer()` |
@@ -95,7 +98,8 @@ Present a concrete recommendation based on what you found. Don't ask open-ended 
 
 **React-specific extras:**
 - React 19 detected → set up `reactErrorHandler()` on `createRoot`
-- React Router detected → configure matching router integration (see Phase 3)
+- React Router v5/v6/v7 non-framework detected → configure matching router integration (see Phase 3)
+- React Router Framework mode detected → switch to `sentry-react-router-framework-sdk`
 - Redux detected → add `createReduxEnhancer()` to Redux store
 - Vite detected → configure `sentryVitePlugin` for source maps (essential for readable stack traces)
 
@@ -202,7 +206,7 @@ Use `<Sentry.ErrorBoundary>` for any sub-tree that should catch errors independe
 
 ### Router Integration
 
-Configure the matching integration for your router:
+Configure the matching integration for your router (non-framework mode):
 
 | Router | Integration | Notes |
 |--------|------------|-------|

--- a/skills/sentry-react-sdk/references/tracing.md
+++ b/skills/sentry-react-sdk/references/tracing.md
@@ -241,6 +241,9 @@ browserTracingIntegration({ enableInp: true })
 
 All React Router integrations live in `@sentry/react`. The core mechanism: **replace** `browserTracingIntegration()` with the router-specific variant. Both cannot be used simultaneously.
 
+> This section is for React Router non-framework/data/declarative usage.
+> If the project uses React Router Framework mode with `@sentry/react-router`, use `sentry-react-router-framework-sdk`.
+
 ---
 
 ### React Router v7 (Library Mode)
@@ -711,6 +714,8 @@ This grouping is essential for meaningful performance data — without it, every
 
 ```
 Are you using React Router?
+├─ Framework mode (`@sentry/react-router`) ─► use sentry-react-router-framework-sdk
+│
 ├─ v7 (react-router package) ──────► reactRouterV7BrowserTracingIntegration
 │    ├─ createBrowserRouter? ──────► wrapCreateBrowserRouterV7(createBrowserRouter)
 │    ├─ createMemoryRouter? ───────► wrapCreateMemoryRouterV7(createMemoryRouter)

--- a/skills/sentry-sdk-setup/SKILL.md
+++ b/skills/sentry-sdk-setup/SKILL.md
@@ -50,6 +50,8 @@ Each SDK skill contains its own detection logic, prerequisites, and step-by-step
 | Flutter and Dart | [`sentry-flutter-sdk`](../sentry-flutter-sdk/SKILL.md) | `sentry-flutter-sdk/SKILL.md` |
 | React Native and Expo | [`sentry-react-native-sdk`](../sentry-react-native-sdk/SKILL.md) | `sentry-react-native-sdk/SKILL.md` |
 | React | [`sentry-react-sdk`](../sentry-react-sdk/SKILL.md) | `sentry-react-sdk/SKILL.md` |
+| React Router Framework | [`sentry-react-router-framework-sdk`](../sentry-react-router-framework-sdk/SKILL.md) | `sentry-react-router-framework-sdk/SKILL.md` |
+| TanStack Start React | [`sentry-tanstack-start-sdk`](../sentry-tanstack-start-sdk/SKILL.md) | `sentry-tanstack-start-sdk/SKILL.md` |
 | Ruby | [`sentry-ruby-sdk`](../sentry-ruby-sdk/SKILL.md) | `sentry-ruby-sdk/SKILL.md` |
 | Svelte and SvelteKit | [`sentry-svelte-sdk`](../sentry-svelte-sdk/SKILL.md) | `sentry-svelte-sdk/SKILL.md` |
 
@@ -61,6 +63,8 @@ When multiple SDKs could match, prefer the more specific one:
 - **Cloudflare** (`wrangler.toml` or `wrangler.jsonc`) → `sentry-cloudflare-sdk` over `sentry-node-sdk`
 - **NestJS** (`@nestjs/core`) → `sentry-nestjs-sdk` over `sentry-node-sdk`
 - **Next.js** → `sentry-nextjs-sdk` over `sentry-react-sdk` or `sentry-node-sdk`
+- **React Router Framework** (`@sentry/react-router` or `@react-router/*`) → `sentry-react-router-framework-sdk` over `sentry-react-sdk`
+- **TanStack Start React** (`@tanstack/react-start`) → `sentry-tanstack-start-sdk` over `sentry-react-sdk`
 - **Flutter** (`pubspec.yaml` with `flutter:` dependency or `sentry_flutter`) → `sentry-flutter-sdk`
 - **React Native** → `sentry-react-native-sdk` over `sentry-react-sdk`
 - **PHP** with Laravel or Symfony → `sentry-php-sdk`
@@ -90,6 +94,8 @@ Match your project to a skill by keywords. Append the path to `https://skills.se
 | flutter, dart, pubspec | `sentry-flutter-sdk/SKILL.md` |
 | react native, expo | `sentry-react-native-sdk/SKILL.md` |
 | react, react router, tanstack, redux, vite | `sentry-react-sdk/SKILL.md` |
+| react-router framework, @sentry/react-router, @react-router/dev, react-router reveal | `sentry-react-router-framework-sdk/SKILL.md` |
+| tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react | `sentry-tanstack-start-sdk/SKILL.md` |
 | ruby, rails, sinatra, sidekiq, rack | `sentry-ruby-sdk/SKILL.md` |
 | svelte, sveltekit | `sentry-svelte-sdk/SKILL.md` |
 

--- a/skills/sentry-tanstack-start-sdk/SKILL.md
+++ b/skills/sentry-tanstack-start-sdk/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: sentry-tanstack-start-sdk
+description: Full Sentry SDK setup for TanStack Start React. Use when asked to "add Sentry to TanStack Start", "install @sentry/tanstackstart-react", or configure error monitoring, tracing, session replay, logs, or user feedback in a TanStack Start React app.
+license: Apache-2.0
+category: sdk-setup
+parent: sentry-sdk-setup
+disable-model-invocation: true
+---
+
+> [All Skills](../../SKILL_TREE.md) > [SDK Setup](../sentry-sdk-setup/SKILL.md) > TanStack Start React SDK
+
+# Sentry TanStack Start React SDK
+
+Opinionated wizard that scans your TanStack Start React project and guides you through complete Sentry setup for browser and server runtimes.
+
+## Invoke This Skill When
+
+- User asks to "add Sentry to TanStack Start" or "set up Sentry" in a TanStack Start React app
+- User wants to install or configure `@sentry/tanstackstart-react`
+- User wants error monitoring, tracing, session replay, logs, or user feedback for TanStack Start React
+- User asks about `sentryTanstackStart`, `wrapFetchWithSentry`, `instrument.server.mjs`, or TanStack Start middleware instrumentation
+
+> **Note:** This SDK is currently alpha and documented as compatible with TanStack Start `1.0 RC`.
+> Always verify against [docs.sentry.io/platforms/javascript/guides/tanstackstart-react/](https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/) before implementing.
+
+---
+
+## Phase 1: Detect
+
+Run these commands to understand the project before making any recommendations:
+
+```bash
+# Detect TanStack Start / Router and existing Sentry
+cat package.json | grep -E '"@tanstack/react-start"|"@tanstack/react-router"|"@sentry/tanstackstart-react"'
+
+# Check if Sentry is already present
+cat package.json | grep '"@sentry/'
+
+# Detect key files used by the TanStack Start setup
+ls src/router.tsx src/start.ts src/server.ts instrument.server.mjs vite.config.ts vite.config.js 2>/dev/null
+
+# Check whether source map upload credentials are configured
+cat .env .env.local .env.sentry-build-plugin 2>/dev/null | grep "SENTRY_AUTH_TOKEN"
+
+# Detect deployment hints in scripts
+cat package.json | grep -E '"dev"|"build"|"start"|NODE_OPTIONS|--import'
+
+# Detect logging libraries
+cat package.json | grep -E '"pino"|"winston"|"loglevel"'
+
+# Detect companion backend directories
+ls ../backend ../server ../api 2>/dev/null
+cat ../go.mod ../requirements.txt ../Gemfile ../pom.xml 2>/dev/null | head -3
+```
+
+**What to determine:**
+
+| Question | Impact |
+|----------|--------|
+| `@tanstack/react-start` present? | Confirms this skill is the right setup path |
+| `@sentry/tanstackstart-react` already installed? | Skip install and go to feature tuning |
+| `src/router.tsx` exists? | Client-side `Sentry.init` placement |
+| `src/start.ts` exists? | Global middleware setup for server-side errors |
+| `src/server.ts` exists? | Server entry instrumentation placement |
+| `instrument.server.mjs` exists? | Runtime startup instrumentation path |
+| `vite.config.ts` exists? | Add `sentryTanstackStart` plugin and source maps |
+| `SENTRY_AUTH_TOKEN` configured? | Source map upload readiness |
+| Backend directory found? | Trigger Phase 4 cross-link suggestion |
+
+---
+
+## Phase 2: Recommend
+
+Present a concrete recommendation based on what you found. Do not ask open-ended questions — lead with a proposal:
+
+**Recommended (core coverage):**
+- ✅ **Error Monitoring** — always; captures unhandled client and server errors
+- ✅ **Tracing** — high-value for request and route timing across browser and server
+- ✅ **Session Replay** — recommended for user-facing apps
+
+**Optional (enhanced observability):**
+- ⚡ **Logs** — recommend when structured log search and log-to-trace correlation are needed
+- ⚡ **User Feedback** — recommend when product teams want in-app issue reports
+
+**Recommendation logic:**
+
+| Feature | Recommend when... |
+|---------|------------------|
+| Error Monitoring | **Always** — non-negotiable baseline |
+| Tracing | **Usually yes** for TanStack Start; route + fetch instrumentation gives immediate value |
+| Session Replay | User-facing app, login flows, checkout flows, or hard-to-reproduce UX bugs |
+| Logs | Existing logging strategy, support workflow, or trace/log correlation needs |
+| User Feedback | Team wants direct user reports without leaving the app |
+
+Propose: *"I recommend Error Monitoring + Tracing + Session Replay. Want me to also enable Logs and User Feedback?"*
+
+---
+
+## Phase 3: Guide
+
+### Install
+
+```bash
+npm install @sentry/tanstackstart-react --save
+```
+
+### Configure Client-Side Sentry in `src/router.tsx`
+
+Initialize Sentry inside the router factory and gate it to the browser:
+
+```tsx
+import * as Sentry from "@sentry/tanstackstart-react";
+import { createRouter } from "@tanstack/react-router";
+
+export const getRouter = () => {
+  const router = createRouter();
+
+  if (!router.isServer) {
+    Sentry.init({
+      dsn: "___PUBLIC_DSN___",
+      sendDefaultPii: true,
+
+      integrations: [
+        Sentry.tanstackRouterBrowserTracingIntegration(router),
+        Sentry.replayIntegration(),
+        Sentry.feedbackIntegration({
+          colorScheme: "system",
+        }),
+      ],
+
+      enableLogs: true,
+      tracesSampleRate: 1.0,
+      replaysSessionSampleRate: 0.1,
+      replaysOnErrorSampleRate: 1.0,
+    });
+  }
+
+  return router;
+};
+```
+
+### Configure Server-Side Sentry in `instrument.server.mjs`
+
+Create `instrument.server.mjs` in project root:
+
+```javascript
+import * as Sentry from "@sentry/tanstackstart-react";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  sendDefaultPii: true,
+  enableLogs: true,
+  tracesSampleRate: 1.0,
+});
+```
+
+### Configure Vite Plugin in `vite.config.ts`
+
+`sentryTanstackStart` should be the last plugin:
+
+```typescript
+import { defineConfig } from "vite";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+
+export default defineConfig({
+  plugins: [
+    tanstackStart(),
+    sentryTanstackStart({
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+});
+```
+
+If the token is stored in `.env`, load it with `loadEnv` in the Vite config before passing it to the plugin.
+
+### Instrument Server Entry Point in `src/server.ts`
+
+Wrap the fetch handler with `wrapFetchWithSentry`:
+
+```typescript
+import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
+import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+
+export default createServerEntry(
+  wrapFetchWithSentry({
+    fetch(request: Request) {
+      return handler.fetch(request);
+    },
+  }),
+);
+```
+
+### Add Global Server Middleware in `src/start.ts`
+
+These middleware capture server-side request and function errors:
+
+```tsx
+import {
+  sentryGlobalFunctionMiddleware,
+  sentryGlobalRequestMiddleware,
+} from "@sentry/tanstackstart-react";
+import { createStart } from "@tanstack/react-start";
+
+export const startInstance = createStart(() => {
+  return {
+    requestMiddleware: [sentryGlobalRequestMiddleware],
+    functionMiddleware: [sentryGlobalFunctionMiddleware],
+  };
+});
+```
+
+Sentry middleware should be first in each array.
+
+### Runtime Startup Patterns
+
+Choose one runtime method:
+
+| Runtime pattern | Use when... | Notes |
+|---|---|---|
+| `--import` flag | You can control Node startup flags | Preferred for production monitoring |
+| Direct import in `src/server.ts` | Host restricts startup flags (for example serverless hosts) | Limits instrumentation to native Node APIs |
+
+`--import` examples:
+
+```json
+{
+  "scripts": {
+    "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000",
+    "build": "vite build && cp instrument.server.mjs .output/server",
+    "start": "node --import ./.output/server/instrument.server.mjs .output/server/index.mjs"
+  }
+}
+```
+
+Direct import fallback (top of `src/server.ts`):
+
+```typescript
+import "../instrument.server.mjs";
+```
+
+### For Each Agreed Feature
+
+Walk through features one at a time. Load the reference file, follow steps exactly, and verify before moving on:
+
+| Feature | Reference | Load when... |
+|---------|-----------|-------------|
+| Error Monitoring | `${SKILL_ROOT}/references/error-monitoring.md` | Always |
+| Tracing | `${SKILL_ROOT}/references/tracing.md` | Route/API performance visibility needed |
+| Session Replay | `${SKILL_ROOT}/references/session-replay.md` | User-facing app |
+| Logs | `${SKILL_ROOT}/references/logging.md` | Structured logs and correlation needed |
+| User Feedback | `${SKILL_ROOT}/references/user-feedback.md` | In-app feedback collection needed |
+| TanStack Start Features | `${SKILL_ROOT}/references/tanstackstart-features.md` | Server entry, Vite plugin, source maps, runtime startup |
+
+For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
+
+---
+
+## Configuration Reference
+
+### Key `Sentry.init()` Options
+
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `dsn` | `string` | — | Required; SDK is disabled when empty |
+| `sendDefaultPii` | `boolean` | `false` | Sends request headers and IP-derived user context |
+| `integrations` | `Integration[]` | SDK defaults | Include TanStack Router tracing, replay, feedback as needed |
+| `enableLogs` | `boolean` | `false` | Enables `Sentry.logger.*` APIs |
+| `tracesSampleRate` | `number` | — | `1.0` in development, lower in production |
+| `replaysSessionSampleRate` | `number` | — | Fraction of all sessions recorded |
+| `replaysOnErrorSampleRate` | `number` | — | Fraction of error sessions recorded |
+| `tunnel` | `string` | — | Optional ad-blocker bypass endpoint |
+| `debug` | `boolean` | `false` | SDK diagnostic logging |
+
+### TanStack Start-Specific APIs
+
+| API | Purpose |
+|-----|---------|
+| `tanstackRouterBrowserTracingIntegration(router)` | Browser navigation tracing |
+| `wrapFetchWithSentry(...)` | Server request tracing + error capture on fetch handler |
+| `sentryGlobalRequestMiddleware` | Captures request-level server errors |
+| `sentryGlobalFunctionMiddleware` | Captures server function errors |
+| `sentryTanstackStart({...})` | Vite plugin for source maps and middleware instrumentation |
+
+---
+
+## Verification
+
+Trigger test events to confirm Sentry receives data.
+
+### Issues Test (Frontend)
+
+```tsx
+<button
+  type="button"
+  onClick={() => {
+    throw new Error("Sentry Test Error");
+  }}
+>
+  Break the world
+</button>
+```
+
+### Tracing Test (Frontend + API Route)
+
+```tsx
+<button
+  type="button"
+  onClick={async () => {
+    await Sentry.startSpan({ name: "Example Frontend Span", op: "test" }, async () => {
+      const res = await fetch("/api/sentry-example");
+      if (!res.ok) {
+        throw new Error("Sentry Example Frontend Error");
+      }
+    });
+  }}
+>
+  Break the world
+</button>
+```
+
+### Logs Test
+
+```javascript
+Sentry.logger.info("User example action completed");
+Sentry.logger.warn("Slow operation detected", { operation: "data_fetch", duration: 3500 });
+Sentry.logger.error("Validation failed", { field: "email", reason: "Invalid email" });
+```
+
+Confirm in Sentry:
+- **Issues**: frontend/server errors appear
+- **Traces**: browser and server spans appear
+- **Replays**: session replay appears when enabled
+- **Logs**: log lines appear when `enableLogs: true`
+- **User Feedback**: submissions appear when feedback integration is enabled
+
+---
+
+## Phase 4: Cross-Link
+
+After completing TanStack Start setup, check whether a companion backend exists without Sentry:
+
+```bash
+ls ../backend ../server ../api ../go ../python 2>/dev/null
+cat ../go.mod ../requirements.txt ../pyproject.toml ../Gemfile ../pom.xml 2>/dev/null | head -5
+```
+
+If a backend exists without Sentry configured, suggest the matching skill:
+
+| Backend detected | Suggest skill |
+|------------------|--------------|
+| Go (`go.mod`) | `sentry-go-sdk` |
+| Python (`requirements.txt`, `pyproject.toml`) | `sentry-python-sdk` |
+| Ruby (`Gemfile`) | `sentry-ruby-sdk` |
+| Java (`pom.xml`, `build.gradle`) | Use `@sentry/java` docs |
+| Node.js backend services | `sentry-node-sdk` |
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Events not appearing | Set `debug: true`, verify DSN, and ensure client/server init files both run |
+| No server traces | Confirm `src/server.ts` uses `wrapFetchWithSentry` and runtime loads `instrument.server.mjs` |
+| Server errors missing from route handlers | Ensure `sentryGlobalRequestMiddleware` and `sentryGlobalFunctionMiddleware` are first in arrays |
+| Source maps not resolving | Verify `SENTRY_AUTH_TOKEN`, `org`, and `project` in `sentryTanstackStart` config |
+| `SENTRY_AUTH_TOKEN` undefined in Vite config | Use `loadEnv(mode, process.cwd(), "")` or `.env.sentry-build-plugin` |
+| Replay not recording | Ensure `replayIntegration()` is in `integrations` and sample rates are non-zero |
+| Feedback widget not visible | Confirm `feedbackIntegration()` is configured and check CSS z-index conflicts |
+| Logs missing in Sentry | Set `enableLogs: true` and use `Sentry.logger.*` APIs |
+| Direct-import setup misses library spans | Prefer `--import` startup when possible; direct import supports native Node instrumentation only |
+| SSR rendering exceptions not auto-captured | Capture manually with `Sentry.captureException` in error boundaries / fallback handlers |

--- a/skills/sentry-tanstack-start-sdk/references/error-monitoring.md
+++ b/skills/sentry-tanstack-start-sdk/references/error-monitoring.md
@@ -1,0 +1,149 @@
+# Error Monitoring — Sentry TanStack Start React SDK
+
+> Minimum SDK: `@sentry/tanstackstart-react` (alpha)  
+> Framework target: TanStack Start React `1.0 RC`
+
+---
+
+## Automatic vs Manual Capture
+
+| Area | Auto Captured? | Mechanism |
+|------|----------------|-----------|
+| Unhandled client exceptions | ✅ Yes | Browser global handlers after `Sentry.init` |
+| Unhandled promise rejections (client) | ✅ Yes | Browser global handlers |
+| Server request exceptions | ✅ Yes | `sentryGlobalRequestMiddleware` + `wrapFetchWithSentry` |
+| Server function exceptions | ✅ Yes | `sentryGlobalFunctionMiddleware` |
+| Errors swallowed by custom boundaries | ❌ No | Call `Sentry.captureException` manually |
+| SSR render exceptions | ❌ No | Call `Sentry.captureException` manually |
+
+Core rule:
+
+> If an error is caught and not re-thrown, capture it manually.
+
+---
+
+## Required Server Error Hooks
+
+### Global server middleware (`src/start.ts`)
+
+```tsx
+import {
+  sentryGlobalFunctionMiddleware,
+  sentryGlobalRequestMiddleware,
+} from "@sentry/tanstackstart-react";
+import { createStart } from "@tanstack/react-start";
+
+export const startInstance = createStart(() => {
+  return {
+    requestMiddleware: [sentryGlobalRequestMiddleware],
+    functionMiddleware: [sentryGlobalFunctionMiddleware],
+  };
+});
+```
+
+### Server entry wrapper (`src/server.ts`)
+
+```typescript
+import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
+import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+
+export default createServerEntry(
+  wrapFetchWithSentry({
+    fetch(request: Request) {
+      return handler.fetch(request);
+    },
+  }),
+);
+```
+
+---
+
+## Client-Side Manual Capture
+
+### `captureException`
+
+```tsx
+import * as Sentry from "@sentry/tanstackstart-react";
+
+try {
+  await riskyOperation();
+} catch (error) {
+  Sentry.captureException(error, {
+    tags: { area: "checkout" },
+    extra: { retryCount: 1 },
+  });
+}
+```
+
+### `captureMessage`
+
+```tsx
+Sentry.captureMessage("Unexpected state encountered", "warning");
+```
+
+---
+
+## Error Boundaries and TanStack Router `errorComponent`
+
+Errors handled by custom boundaries are not automatically reported unless you send them.
+
+```tsx
+import { useEffect } from "react";
+import * as Sentry from "@sentry/tanstackstart-react";
+import { createRoute } from "@tanstack/react-router";
+
+const route = createRoute({
+  errorComponent: ({ error }) => {
+    useEffect(() => {
+      Sentry.captureException(error);
+    }, [error]);
+
+    return <div>Something went wrong.</div>;
+  },
+});
+```
+
+For class boundaries, wrap with `withErrorBoundary`:
+
+```tsx
+import React from "react";
+import * as Sentry from "@sentry/tanstackstart-react";
+
+class MyErrorBoundary extends React.Component {
+  render() {
+    return this.props.children;
+  }
+}
+
+export const MySentryWrappedErrorBoundary = Sentry.withErrorBoundary(MyErrorBoundary, {
+  fallback: <p>Something went wrong.</p>,
+});
+```
+
+---
+
+## Enrichment APIs
+
+Use standard Sentry context enrichment calls:
+
+```tsx
+Sentry.setUser({ id: "user_123", email: "user@example.com" });
+Sentry.setTag("tenant", "acme");
+Sentry.setContext("checkout", { step: "payment" });
+Sentry.addBreadcrumb({
+  category: "ui.click",
+  message: "Clicked complete purchase",
+  level: "info",
+});
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Server errors missing | Verify both `wrapFetchWithSentry` and global middleware are in place |
+| Error boundary issues not appearing | Add explicit `captureException` inside `errorComponent` or boundary hooks |
+| Missing user context | Call `setUser` after auth state is known |
+| Duplicate dev errors | Validate behavior in production build; development tooling may rethrow |

--- a/skills/sentry-tanstack-start-sdk/references/logging.md
+++ b/skills/sentry-tanstack-start-sdk/references/logging.md
@@ -1,0 +1,73 @@
+# Logs — Sentry TanStack Start React SDK
+
+> Minimum SDK: `@sentry/tanstackstart-react` with Logs support  
+> Framework target: TanStack Start React `1.0 RC`
+
+---
+
+## Enable Logs
+
+Enable log ingestion in both browser and server `Sentry.init` calls:
+
+```tsx
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  enableLogs: true,
+});
+```
+
+Configure this in:
+- `src/router.tsx` (browser runtime)
+- `instrument.server.mjs` (server runtime)
+
+---
+
+## Logging APIs
+
+Use structured logging methods from the Sentry logger:
+
+```javascript
+Sentry.logger.info("User example action completed");
+
+Sentry.logger.warn("Slow operation detected", {
+  operation: "data_fetch",
+  duration: 3500,
+});
+
+Sentry.logger.error("Validation failed", {
+  field: "email",
+  reason: "Invalid email",
+});
+```
+
+---
+
+## Correlating Logs with Traces and Errors
+
+For best analysis value:
+
+1. Enable tracing (`tracesSampleRate` + integrations).
+2. Include useful structured context on logs (operation, tenant, request IDs).
+3. Use consistent field names across browser and server logs.
+
+This allows filtering by request context and linking logs to traces/issues.
+
+---
+
+## Verification
+
+1. Trigger `Sentry.logger.info` and `Sentry.logger.error` in the app.
+2. Open **Logs** in Sentry.
+3. Filter by message or metadata fields to confirm ingestion.
+4. Open a related issue or trace and verify shared context fields.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Logs not visible | Confirm `enableLogs: true` in active runtime init |
+| Missing metadata fields | Pass structured objects as second argument to logger methods |
+| Too much log volume | Reduce noisy log calls or gate debug/info logs by environment |
+| Logs disconnected from traces | Ensure tracing is enabled and context keys are consistent |

--- a/skills/sentry-tanstack-start-sdk/references/session-replay.md
+++ b/skills/sentry-tanstack-start-sdk/references/session-replay.md
@@ -1,0 +1,76 @@
+# Session Replay — Sentry TanStack Start React SDK
+
+> Minimum SDK: `@sentry/tanstackstart-react` with Replay support  
+> Framework target: TanStack Start React `1.0 RC`
+
+---
+
+## Replay Setup (`src/router.tsx`)
+
+Session Replay is configured on the browser side in `Sentry.init`.
+
+```tsx
+import * as Sentry from "@sentry/tanstackstart-react";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [Sentry.replayIntegration()],
+
+  // Record 10% of all sessions
+  replaysSessionSampleRate: 0.1,
+  // Record 100% of sessions where an error occurs
+  replaysOnErrorSampleRate: 1.0,
+});
+```
+
+---
+
+## Sampling Strategy
+
+| Goal | Suggested config |
+|------|------------------|
+| Fast rollout / validation | `replaysSessionSampleRate: 0.1`, `replaysOnErrorSampleRate: 1.0` |
+| Cost-sensitive production | Lower session sample rate (`0.02` to `0.05`), keep error sample high |
+| Incident investigation mode | Temporarily increase session sample rate |
+
+---
+
+## Privacy and Data Controls
+
+Adjust Replay privacy behavior based on product requirements:
+
+```tsx
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.replayIntegration({
+      maskAllText: true,
+      blockAllMedia: true,
+    }),
+  ],
+  replaysSessionSampleRate: 0.1,
+  replaysOnErrorSampleRate: 1.0,
+});
+```
+
+Use stricter masking for apps handling sensitive user or payment data.
+
+---
+
+## Verification
+
+1. Load the app in a browser.
+2. Trigger one error and complete a few UI interactions.
+3. Open **Replays** in Sentry and confirm a replay appears.
+4. Open the linked issue and verify replay context is attached.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Replay not appearing | Ensure `replayIntegration()` is included and sample rates are non-zero |
+| Replays only on error | Increase `replaysSessionSampleRate` |
+| Sensitive content visible | Enable masking/blocking options and audit replay config |
+| Replay volume too high | Lower `replaysSessionSampleRate` and keep error replay rate high |

--- a/skills/sentry-tanstack-start-sdk/references/tanstackstart-features.md
+++ b/skills/sentry-tanstack-start-sdk/references/tanstackstart-features.md
@@ -1,0 +1,126 @@
+# TanStack Start Features — Sentry TanStack Start React SDK
+
+> Framework target: TanStack Start React `1.0 RC`
+
+---
+
+## `sentryTanstackStart` Vite Plugin
+
+Add the plugin in `vite.config.ts` and keep it last:
+
+```typescript
+import { defineConfig } from "vite";
+import { sentryTanstackStart } from "@sentry/tanstackstart-react/vite";
+import { tanstackStart } from "@tanstack/react-start/plugin/vite";
+
+export default defineConfig({
+  plugins: [
+    tanstackStart(),
+    sentryTanstackStart({
+      org: "___ORG_SLUG___",
+      project: "___PROJECT_SLUG___",
+      authToken: process.env.SENTRY_AUTH_TOKEN,
+    }),
+  ],
+});
+```
+
+This plugin manages source map upload and instruments middleware tracing when tracing is enabled.
+
+---
+
+## Environment Token Handling
+
+Set auth token in CI or local environment:
+
+```bash
+SENTRY_AUTH_TOKEN=___ORG_AUTH_TOKEN___
+```
+
+If loading from `.env` in Vite config, use `loadEnv`:
+
+```typescript
+import { defineConfig, loadEnv } from "vite";
+
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), "");
+
+  return {
+    plugins: [
+      sentryTanstackStart({
+        authToken: env.SENTRY_AUTH_TOKEN,
+      }),
+    ],
+  };
+});
+```
+
+---
+
+## Runtime Startup Options
+
+### Preferred: `--import` startup
+
+Use this when you can control Node startup flags.
+
+1. Keep root `instrument.server.mjs`.
+2. Copy it to runtime output location during build.
+3. Start node with `--import`.
+
+Example scripts:
+
+```json
+{
+  "scripts": {
+    "build": "vite build && cp instrument.server.mjs .output/server",
+    "dev": "NODE_OPTIONS='--import ./instrument.server.mjs' vite dev --port 3000",
+    "start": "node --import ./.output/server/instrument.server.mjs .output/server/index.mjs"
+  }
+}
+```
+
+### Fallback: direct import in server entry
+
+Use when host/runtime does not allow startup flags.
+
+```typescript
+import "../instrument.server.mjs";
+```
+
+Limitation: only native Node.js APIs are instrumented; third-party library instrumentation is limited.
+
+---
+
+## Server Entry and Middleware Checklist
+
+For full server coverage, confirm all three are present:
+
+1. `instrument.server.mjs` with server `Sentry.init`.
+2. `src/server.ts` wraps handler with `wrapFetchWithSentry`.
+3. `src/start.ts` includes both Sentry global middleware first in arrays.
+
+---
+
+## Optional Tunnel Configuration
+
+To reduce ad-blocker drops, configure tunnel route:
+
+```javascript
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tunnel: "/tunnel",
+});
+```
+
+Then implement a server endpoint that forwards tunnel traffic to Sentry ingest.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Build succeeds but no source maps in Sentry | Verify `sentryTanstackStart` is configured and token is available at build time |
+| `process.env.SENTRY_AUTH_TOKEN` undefined | Use `loadEnv` in Vite config or `.env.sentry-build-plugin` |
+| Works in dev but not production | Ensure `instrument.server.mjs` is copied into final server output and imported at runtime |
+| Missing middleware spans | Ensure Sentry plugin is enabled and tracing is configured |

--- a/skills/sentry-tanstack-start-sdk/references/tracing.md
+++ b/skills/sentry-tanstack-start-sdk/references/tracing.md
@@ -1,0 +1,123 @@
+# Tracing — Sentry TanStack Start React SDK
+
+> Minimum SDK: `@sentry/tanstackstart-react` (alpha)  
+> Framework target: TanStack Start React `1.0 RC`
+
+---
+
+## What Tracing Captures
+
+| Layer | Integration | Result |
+|------|-------------|--------|
+| Browser route transitions | `tanstackRouterBrowserTracingIntegration(router)` | Navigation and route-level transaction timing |
+| Server request handling | `wrapFetchWithSentry(...)` | Server request spans and request-level errors |
+| Server middleware/functions | `sentryGlobalRequestMiddleware` / `sentryGlobalFunctionMiddleware` | Middleware and server function timing context |
+| Custom operations | `Sentry.startSpan` | Business operations and async block timing |
+
+---
+
+## Browser Tracing Setup (`src/router.tsx`)
+
+```tsx
+import * as Sentry from "@sentry/tanstackstart-react";
+import { createRouter } from "@tanstack/react-router";
+
+export const getRouter = () => {
+  const router = createRouter();
+
+  if (!router.isServer) {
+    Sentry.init({
+      dsn: "___PUBLIC_DSN___",
+      integrations: [Sentry.tanstackRouterBrowserTracingIntegration(router)],
+      tracesSampleRate: 1.0,
+    });
+  }
+
+  return router;
+};
+```
+
+---
+
+## Server Tracing Setup
+
+### `instrument.server.mjs`
+
+```javascript
+import * as Sentry from "@sentry/tanstackstart-react";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  tracesSampleRate: 1.0,
+});
+```
+
+### `src/server.ts`
+
+```typescript
+import { wrapFetchWithSentry } from "@sentry/tanstackstart-react";
+import handler, { createServerEntry } from "@tanstack/react-start/server-entry";
+
+export default createServerEntry(
+  wrapFetchWithSentry({
+    fetch(request: Request) {
+      return handler.fetch(request);
+    },
+  }),
+);
+```
+
+---
+
+## Custom Span Example
+
+```tsx
+import * as Sentry from "@sentry/tanstackstart-react";
+
+await Sentry.startSpan(
+  {
+    name: "Example Frontend Span",
+    op: "test",
+  },
+  async () => {
+    const res = await fetch("/api/sentry-example");
+    if (!res.ok) {
+      throw new Error("Sentry Example Frontend Error");
+    }
+  },
+);
+```
+
+Use `startSpan` for key flows such as checkout, search, and expensive data loads.
+
+---
+
+## Sampling Guidance
+
+| Environment | Suggested `tracesSampleRate` |
+|-------------|-------------------------------|
+| Development | `1.0` |
+| Production (starting point) | `0.1` to `0.3` |
+| High-volume traffic | Tune with lower fixed rate or use server-side dynamic sampling |
+
+---
+
+## Verifying Traces
+
+1. Trigger a page navigation and one API call in the app.
+2. Open **Traces** in Sentry.
+3. Confirm one trace shows:
+   - browser transaction/span
+   - server request span
+   - linked errors (if thrown)
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No browser transactions | Ensure router integration gets the actual router instance |
+| No server spans | Verify runtime loads `instrument.server.mjs` (`--import` path or direct import path) |
+| Trace disconnected between client and server | Confirm both browser and server init are active in the same environment |
+| Too many traces | Reduce `tracesSampleRate` for production |

--- a/skills/sentry-tanstack-start-sdk/references/user-feedback.md
+++ b/skills/sentry-tanstack-start-sdk/references/user-feedback.md
@@ -1,0 +1,81 @@
+# User Feedback — Sentry TanStack Start React SDK
+
+> Minimum SDK: `@sentry/tanstackstart-react` with Feedback integration  
+> Framework target: TanStack Start React `1.0 RC`
+
+---
+
+## Feedback Widget Setup
+
+Enable feedback in the browser-side init (`src/router.tsx`):
+
+```tsx
+import * as Sentry from "@sentry/tanstackstart-react";
+
+Sentry.init({
+  dsn: "___PUBLIC_DSN___",
+  integrations: [
+    Sentry.feedbackIntegration({
+      colorScheme: "system",
+    }),
+  ],
+});
+```
+
+---
+
+## Common Configuration Options
+
+```tsx
+Sentry.feedbackIntegration({
+  autoInject: true,
+  colorScheme: "system",
+  showName: true,
+  showEmail: true,
+  isNameRequired: false,
+  isEmailRequired: false,
+  triggerLabel: "Report a bug",
+  formTitle: "Report a bug",
+  submitButtonLabel: "Send report",
+  successMessageText: "Thanks for the report.",
+  tags: {
+    area: "tanstack-start-web",
+    env: import.meta.env.MODE,
+  },
+});
+```
+
+---
+
+## Feedback From Error Flows
+
+If you want post-error feedback dialogs, capture an error and open the report dialog:
+
+```tsx
+const eventId = Sentry.captureException(new Error("Checkout flow failed"));
+Sentry.showReportDialog({
+  eventId,
+  title: "Something went wrong",
+  subtitle: "Want to help us fix this?",
+});
+```
+
+---
+
+## Verification
+
+1. Open the app and locate the feedback trigger.
+2. Submit a sample report.
+3. Open **User Feedback** in Sentry and confirm receipt.
+4. If using report dialogs, verify feedback is linked to the issue event.
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| Feedback button not shown | Ensure `feedbackIntegration()` is in browser `integrations` |
+| Styling/position conflicts | Customize trigger placement and check app z-index layers |
+| Missing user details | Set Sentry user context before feedback submission |
+| Feedback not linked to errors | Use `showReportDialog` with the returned `eventId` |


### PR DESCRIPTION
## Summary
- add a new `sentry-tanstack-start-sdk` skill bundle with framework-specific setup, verification, and feature references
- add a new `sentry-react-router-framework-sdk` skill bundle for `@sentry/react-router`, including wizard/manual setup, server entry wiring, and feature references
- clarify that React Router v5/v6/v7 non-framework guidance stays in `sentry-react-sdk`, then register both SDKs across router discovery, docs indexes, and skill drift/reviewer mappings

## Test plan
- [x] Run `./scripts/build-skill-tree.sh`
- [x] Run `./scripts/build-skill-tree.sh --check`
- [x] Verify new SDK entries appear in `skills/sentry-sdk-setup/SKILL.md`
- [x] Verify generated `SKILL_TREE.md` includes both new SDKs and quick lookup keywords

Made with [Cursor](https://cursor.com)