### PR TITLE
feat: Add streamGenAiSpans to JS AI monitoring skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .claude/*
 !.claude/settings.json
+.DS_Store

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -1,7 +1,7 @@
 # AI Monitoring — Sentry NestJS SDK
 
 > OpenAI integration: `@sentry/nestjs` ≥10.53.0+ (recommended)
-> Vercel AI SDK integration: ≥10.6.0+
+> Vercel AI SDK integration: ≥10.53.0+
 > Anthropic integration: see platform docs
 > Google GenAI integration: see platform docs
 
@@ -28,7 +28,7 @@ All integrations listed below are **auto-enabled** when the corresponding AI lib
 | Library | Integration API | Auto-enabled? | Min SDK Version |
 |---------|----------------|---------------|----------------|
 | **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.53.0** |
-| **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes | **10.6.0** |
+| **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes | **10.53.0** |
 | **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | See docs |
 | **Google GenAI** (`@google/generative-ai`) | — | ✅ Yes | See docs |
 | **LangChain** (`langchain`, `@langchain/core`) | `langchainIntegration` | ✅ Yes | See docs |

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring — Sentry NestJS SDK
 
-> OpenAI integration: `@sentry/nestjs` ≥10.28.0+
+> OpenAI integration: `@sentry/nestjs` ≥10.53.0+ (recommended)
 > Vercel AI SDK integration: ≥10.6.0+
 > Anthropic integration: see platform docs
 > Google GenAI integration: see platform docs
@@ -27,7 +27,7 @@ All integrations listed below are **auto-enabled** when the corresponding AI lib
 
 | Library | Integration API | Auto-enabled? | Min SDK Version |
 |---------|----------------|---------------|----------------|
-| **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.28.0** |
+| **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.53.0** |
 | **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes | **10.6.0** |
 | **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | See docs |
 | **Google GenAI** (`@google/generative-ai`) | — | ✅ Yes | See docs |
@@ -48,6 +48,7 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   sendDefaultPii: true, // enables recordInputs/recordOutputs by default
   integrations: [
     Sentry.openAIIntegration({
@@ -120,6 +121,7 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.vercelAIIntegration({
       recordInputs: true,
@@ -190,6 +192,7 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.anthropicAIIntegration({
       recordInputs: true,
@@ -260,6 +263,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   sendDefaultPii: true, // ← enables input/output recording by default
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
 });
 ```
 
@@ -276,6 +280,7 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   sendDefaultPii: true,
   enableLogs: true,
   integrations: [

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring — Sentry NestJS SDK
 
-> OpenAI integration: `@sentry/nestjs` ≥10.53.0+ (recommended)
+> OpenAI integration: `@sentry/nestjs` ≥10.53.0+
 > Vercel AI SDK integration: ≥10.53.0+
 > Anthropic integration: ≥10.53.0+
 > Google GenAI integration: ≥10.53.0+

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -2,8 +2,8 @@
 
 > OpenAI integration: `@sentry/nestjs` ≥10.53.0+ (recommended)
 > Vercel AI SDK integration: ≥10.53.0+
-> Anthropic integration: see platform docs
-> Google GenAI integration: see platform docs
+> Anthropic integration: ≥10.53.0+
+> Google GenAI integration: ≥10.53.0+
 
 > ⚠️ **Tracing must be enabled.** AI monitoring piggybacks on tracing infrastructure. `tracesSampleRate` must be > 0.
 
@@ -29,9 +29,9 @@ All integrations listed below are **auto-enabled** when the corresponding AI lib
 |---------|----------------|---------------|----------------|
 | **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.53.0** |
 | **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes | **10.53.0** |
-| **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | See docs |
-| **Google GenAI** (`@google/generative-ai`) | — | ✅ Yes | See docs |
-| **LangChain** (`langchain`, `@langchain/core`) | `langchainIntegration` | ✅ Yes | See docs |
+| **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | **10.53.0** |
+| **Google GenAI** (`@google/generative-ai`) | — | ✅ Yes | **10.53.0** |
+| **LangChain** (`langchain`, `@langchain/core`) | `langchainIntegration` | ✅ Yes | **10.53.0** |
 
 ---
 

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -1,7 +1,7 @@
 # AI Monitoring — Sentry Next.js SDK
 
-> OpenAI integration: `@sentry/nextjs` ≥10.53.0+ (recommended)  
-> Vercel AI SDK integration: ≥10.53.0+ (recommended)  
+> OpenAI integration: `@sentry/nextjs` ≥10.53.0+  
+> Vercel AI SDK integration: ≥10.53.0+  
 > Anthropic integration: ≥10.53.0+
 
 > ⚠️ **Tracing must be enabled.** AI monitoring piggybacks on tracing infrastructure. `tracesSampleRate` must be > 0.

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -1,7 +1,7 @@
 # AI Monitoring — Sentry Next.js SDK
 
 > OpenAI integration: `@sentry/nextjs` ≥10.53.0+ (recommended)  
-> Vercel AI SDK integration: ≥10.6.0+ (Node/Edge/Bun), ≥10.12.0+ (Deno)  
+> Vercel AI SDK integration: ≥10.53.0+ (recommended)  
 > Anthropic integration: see platform docs
 
 > ⚠️ **Tracing must be enabled.** AI monitoring piggybacks on tracing infrastructure. `tracesSampleRate` must be > 0.
@@ -25,7 +25,7 @@ Sentry AI Agents Monitoring automatically tracks:
 | Library | Integration API | Auto-enabled (Node server)? | Min SDK Version |
 |---------|----------------|----------------------------|----------------|
 | **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.53.0** |
-| **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes (Node), ❌ Edge manual | **10.6.0** |
+| **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes (Node), ❌ Edge manual | **10.53.0** |
 | **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | See platform docs |
 
 ---
@@ -391,8 +391,8 @@ Access at **Sentry → AI → Agents** (or **Insights → AI**).
 
 | Feature | Min SDK Version |
 |---------|----------------|
-| Vercel AI SDK integration (Node/CF/Edge/Bun) | **10.6.0** |
-| Vercel AI SDK integration (Deno) | **10.12.0** |
+| Vercel AI SDK integration (Node/CF/Edge/Bun) | **10.53.0** |
+| Vercel AI SDK integration (Deno) | **10.53.0** |
 | Vercel AI `recordInputs`/`recordOutputs` | 9.27.0 |
 | Vercel AI `force` option | 9.29.0 |
 | OpenAI integration (`openAIIntegration` / `instrumentOpenAiClient`) | **10.53.0** |

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -2,7 +2,7 @@
 
 > OpenAI integration: `@sentry/nextjs` ≥10.53.0+ (recommended)  
 > Vercel AI SDK integration: ≥10.53.0+ (recommended)  
-> Anthropic integration: see platform docs
+> Anthropic integration: ≥10.53.0+
 
 > ⚠️ **Tracing must be enabled.** AI monitoring piggybacks on tracing infrastructure. `tracesSampleRate` must be > 0.
 
@@ -26,7 +26,7 @@ Sentry AI Agents Monitoring automatically tracks:
 |---------|----------------|----------------------------|----------------|
 | **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.53.0** |
 | **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes (Node), ❌ Edge manual | **10.53.0** |
-| **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | See platform docs |
+| **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | **10.53.0** |
 
 ---
 

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring — Sentry Next.js SDK
 
-> OpenAI integration: `@sentry/nextjs` ≥10.28.0+  
+> OpenAI integration: `@sentry/nextjs` ≥10.53.0+ (recommended)  
 > Vercel AI SDK integration: ≥10.6.0+ (Node/Edge/Bun), ≥10.12.0+ (Deno)  
 > Anthropic integration: see platform docs
 
@@ -24,7 +24,7 @@ Sentry AI Agents Monitoring automatically tracks:
 
 | Library | Integration API | Auto-enabled (Node server)? | Min SDK Version |
 |---------|----------------|----------------------------|----------------|
-| **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.28.0** |
+| **OpenAI** (`openai`) | `openAIIntegration` / `instrumentOpenAiClient` | ✅ Yes | **10.53.0** |
 | **Vercel AI SDK** (`ai`) | `vercelAIIntegration` | ✅ Yes (Node), ❌ Edge manual | **10.6.0** |
 | **Anthropic** (`@anthropic-ai/sdk`) | `anthropicAIIntegration` / `instrumentAnthropicAiClient` | ✅ Yes | See platform docs |
 
@@ -52,6 +52,7 @@ Sentry.init({
 
   // Tracing MUST be enabled for AI monitoring
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
 
   integrations: [
     Sentry.openAIIntegration({
@@ -121,6 +122,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.vercelAIIntegration({
       force: true, // ← Required for Vercel production deployments (see note below)
@@ -138,6 +140,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.vercelAIIntegration(),
   ],
@@ -212,6 +215,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.anthropicAIIntegration({
       recordInputs: true,
@@ -286,6 +290,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   sendDefaultPii: true, // ← enables input/output recording by default
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
 });
 ```
 
@@ -313,6 +318,7 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.openAIIntegration({ recordInputs: true, recordOutputs: true }),
     Sentry.vercelAIIntegration({ force: true, recordInputs: true, recordOutputs: true }),
@@ -389,7 +395,7 @@ Access at **Sentry → AI → Agents** (or **Insights → AI**).
 | Vercel AI SDK integration (Deno) | **10.12.0** |
 | Vercel AI `recordInputs`/`recordOutputs` | 9.27.0 |
 | Vercel AI `force` option | 9.29.0 |
-| OpenAI integration (`openAIIntegration` / `instrumentOpenAiClient`) | **10.28.0** |
+| OpenAI integration (`openAIIntegration` / `instrumentOpenAiClient`) | **10.53.0** |
 
 ---
 

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -1,13 +1,13 @@
 # AI Monitoring - Sentry Node.js SDK
 
-> Minimum SDK: `@sentry/node` >=10.28.0 (OpenAI, Anthropic, LangChain, LangGraph, Google GenAI). Vercel AI SDK: >=10.6.0.
+> Minimum SDK: `@sentry/node` >=10.53.0 (recommended). OpenAI, Anthropic, LangChain, LangGraph, Google GenAI auto-instrument. Vercel AI SDK: >=10.6.0.
 
 ## Prerequisites
 
 Tracing must be enabled - AI spans require an active trace:
 
 ```typescript
-Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0, streamGenAiSpans: true });
 ```
 
 ## Integration Matrix
@@ -41,6 +41,7 @@ import * as Sentry from "@sentry/node";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   sendDefaultPii: true, // required to capture prompts/outputs
 });
 // OpenAI, Anthropic, LangChain, LangGraph, Google GenAI activate automatically
@@ -52,6 +53,7 @@ Sentry.init({
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
+  streamGenAiSpans: true,
   integrations: [
     Sentry.openAIIntegration({ recordInputs: true, recordOutputs: true }),
     Sentry.vercelAIIntegration({ recordInputs: true, recordOutputs: true }),
@@ -204,7 +206,7 @@ If `tracesSampleRate` < 1.0, see the [AI sampling guide](../../sentry-setup-ai-m
 
 | Issue | Solution |
 |-------|----------|
-| No AI spans appearing | Verify `tracesSampleRate > 0`; check SDK >=10.28.0 |
+| No AI spans appearing | Verify `tracesSampleRate > 0`; check SDK >=10.53.0 |
 | Token counts missing in streams | Add `stream_options: { include_usage: true }` (OpenAI) |
 | Vercel AI spans not tracked | Add `experimental_telemetry: { isEnabled: true }` per call |
 | Browser OpenAI not traced | Use `Sentry.instrumentOpenAiClient()` - auto-instrumentation is server-only |

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring - Sentry Node.js SDK
 
-> Minimum SDK: `@sentry/node` >=10.53.0 (recommended). OpenAI, Anthropic, LangChain, LangGraph, Google GenAI, Vercel AI SDK auto-instrument.
+> Minimum SDK: `@sentry/node` >=10.53.0. OpenAI, Anthropic, LangChain, LangGraph, Google GenAI, Vercel AI SDK auto-instrument.
 
 ## Prerequisites
 

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring - Sentry Node.js SDK
 
-> Minimum SDK: `@sentry/node` >=10.53.0 (recommended). OpenAI, Anthropic, LangChain, LangGraph, Google GenAI auto-instrument. Vercel AI SDK: >=10.6.0.
+> Minimum SDK: `@sentry/node` >=10.53.0 (recommended). OpenAI, Anthropic, LangChain, LangGraph, Google GenAI, Vercel AI SDK auto-instrument.
 
 ## Prerequisites
 

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -73,12 +73,12 @@ If user confirms, read `${SKILL_ROOT}/references/sampling.md` for implementation
 
 | Package | Integration | Min Sentry SDK | Auto? |
 |---------|-------------|----------------|-------|
-| `openai` | `openAIIntegration()` | 10.28.0 | Yes |
-| `@anthropic-ai/sdk` | `anthropicAIIntegration()` | 10.28.0 | Yes |
+| `openai` | `openAIIntegration()` | 10.53.0 | Yes |
+| `@anthropic-ai/sdk` | `anthropicAIIntegration()` | 10.53.0 | Yes |
 | `ai` (Vercel) | `vercelAIIntegration()` | 10.6.0 | Yes* |
-| `@langchain/*` | `langChainIntegration()` | 10.28.0 | Yes |
-| `@langchain/langgraph` | `langGraphIntegration()` | 10.28.0 | Yes |
-| `@google/genai` | `googleGenAIIntegration()` | 10.28.0 | Yes |
+| `@langchain/*` | `langChainIntegration()` | 10.53.0 | Yes |
+| `@langchain/langgraph` | `langGraphIntegration()` | 10.53.0 | Yes |
+| `@google/genai` | `googleGenAIIntegration()` | 10.53.0 | Yes |
 
 *Vercel AI: 10.6.0+ for Node.js, Cloudflare Workers, Vercel Edge Functions, Bun. 10.12.0+ for Deno. Requires `experimental_telemetry` per-call.
 
@@ -107,6 +107,7 @@ Just ensure tracing is enabled. Integrations auto-enable when the AI package is 
 Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0, // Lower in production (e.g., 0.1)
+  streamGenAiSpans: true, // Required for conversations (SDK ≥10.53.0)
   // OpenAI, Anthropic, Google GenAI, LangChain integrations auto-enable in Node.js
 });
 ```

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -80,7 +80,7 @@ If user confirms, read `${SKILL_ROOT}/references/sampling.md` for implementation
 | `@langchain/langgraph` | `langGraphIntegration()` | 10.53.0 | Yes |
 | `@google/genai` | `googleGenAIIntegration()` | 10.53.0 | Yes |
 
-*Vercel AI: 10.53.0+ recommended. Requires `experimental_telemetry` per-call.
+*Vercel AI: 10.53.0+ required. Requires `experimental_telemetry` per-call.
 
 ### Python
 
@@ -107,7 +107,7 @@ Just ensure tracing is enabled. Integrations auto-enable when the AI package is 
 Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0, // Lower in production (e.g., 0.1)
-  streamGenAiSpans: true, // Required for conversations (SDK ≥10.53.0)
+  streamGenAiSpans: true, // SDK ≥10.53.0
   // OpenAI, Anthropic, Google GenAI, LangChain integrations auto-enable in Node.js
 });
 ```

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -75,12 +75,12 @@ If user confirms, read `${SKILL_ROOT}/references/sampling.md` for implementation
 |---------|-------------|----------------|-------|
 | `openai` | `openAIIntegration()` | 10.53.0 | Yes |
 | `@anthropic-ai/sdk` | `anthropicAIIntegration()` | 10.53.0 | Yes |
-| `ai` (Vercel) | `vercelAIIntegration()` | 10.6.0 | Yes* |
+| `ai` (Vercel) | `vercelAIIntegration()` | 10.53.0 | Yes* |
 | `@langchain/*` | `langChainIntegration()` | 10.53.0 | Yes |
 | `@langchain/langgraph` | `langGraphIntegration()` | 10.53.0 | Yes |
 | `@google/genai` | `googleGenAIIntegration()` | 10.53.0 | Yes |
 
-*Vercel AI: 10.6.0+ for Node.js, Cloudflare Workers, Vercel Edge Functions, Bun. 10.12.0+ for Deno. Requires `experimental_telemetry` per-call.
+*Vercel AI: 10.53.0+ recommended. Requires `experimental_telemetry` per-call.
 
 ### Python
 


### PR DESCRIPTION
Add `streamGenAiSpans: true` to all `Sentry.init()` code examples in the JS AI monitoring skill files and bump the minimum recommended SDK version to `10.53.0`.

**Updated files:**
- `skills/sentry-setup-ai-monitoring/SKILL.md` — init snippet + version table
- `skills/sentry-node-sdk/references/ai-monitoring.md` — all init examples + troubleshooting
- `skills/sentry-nestjs-sdk/references/ai-monitoring.md` — all init examples + version refs
- `skills/sentry-nextjs-sdk/references/ai-monitoring.md` — all init examples + version matrix

Refs TET-2344