### PR TITLE
chore: Remove beta labels from metrics across all SDKs

### DIFF
--- a/skills/sentry-android-sdk/SKILL.md
+++ b/skills/sentry-android-sdk/SKILL.md
@@ -502,7 +502,7 @@ Walk through features one at a time. Load the reference file for each, follow it
 | Profiling | `${SKILL_ROOT}/references/profiling.md` | Performance-sensitive production apps |
 | Session Replay | `${SKILL_ROOT}/references/session-replay.md` | User-facing apps (API 26+) |
 | Logging | `${SKILL_ROOT}/references/logging.md` | Structured logging / log-to-trace correlation |
-| Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom metric tracking (Beta, SDK ≥ 8.30.0) |
+| Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom metric tracking (SDK ≥ 8.30.0) |
 | Crons | `${SKILL_ROOT}/references/crons.md` | Scheduled jobs, WorkManager check-ins |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.

--- a/skills/sentry-android-sdk/references/metrics.md
+++ b/skills/sentry-android-sdk/references/metrics.md
@@ -1,15 +1,8 @@
 # Metrics — Sentry Android SDK
 
 > **Minimum SDK:** `io.sentry:sentry-android:8.30.0`  
-> **⚠️ Status: Open Beta** — API surface is stable but subject to change  
 > **Enabled by default:** Yes — no opt-in required  
 > **Docs:** https://docs.sentry.io/platforms/android/metrics/
-
----
-
-## ⚠️ Beta Notice
-
-Metrics is currently in **Open Beta**. The feature is enabled by default as of SDK 8.30.0 and the API is stable in practice, but Sentry may revise the data model or UI. Test thoroughly before relying on metrics data in production dashboards.
 
 ---
 

--- a/skills/sentry-flutter-sdk/SKILL.md
+++ b/skills/sentry-flutter-sdk/SKILL.md
@@ -93,7 +93,7 @@ Present a concrete recommendation based on what you found. Don't ask open-ended 
 **Optional (enhanced observability):**
 - ⚡ **Profiling** — CPU profiling; iOS and macOS only (alpha)
 - ⚡ **Logging** — structured logs via `Sentry.logger.*` and `sentry_logging` integration
-- ⚡ **Metrics** — counters, gauges, distributions (open beta, SDK ≥9.11.0)
+- ⚡ **Metrics** — counters, gauges, distributions (SDK ≥9.11.0)
 
 **Platform limitations — be upfront:**
 
@@ -421,7 +421,7 @@ Walk through features one at a time. Load the reference file for each, follow it
 | Session Replay | `${SKILL_ROOT}/references/session-replay.md` | iOS/Android user-facing apps |
 | Profiling | `${SKILL_ROOT}/references/profiling.md` | iOS/macOS performance-sensitive apps |
 | Logging | `${SKILL_ROOT}/references/logging.md` | Structured logging / log-trace correlation |
-| Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom business metrics (open beta) |
+| Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom business metrics |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
 
@@ -795,7 +795,6 @@ This links mobile transactions to backend traces in the Sentry waterfall view.
 | Too many transactions in dashboard | Lower `tracesSampleRate` to `0.1` or use `tracesSampler` to drop health checks |
 | `beforeSend` not firing for native crashes | Expected — `beforeSend` intercepts only Dart-layer events; native crashes bypass it |
 | Crons not available | The Flutter/Dart SDK does not support Sentry Crons; use a server-side SDK instead |
-| Metrics marked as experimental | `sentry_flutter` Metrics API is open beta (SDK ≥9.11.0); stable on other SDKs |
 | `SentryWidget` warning in tests | Wrap test widget with `SentryFlutter.init()` in `setUpAll`, or use `enabled: false` |
 | Firebase Remote Config: Linux/Windows | `sentry_firebase_remote_config` not supported on Linux/Windows (Firebase limitation) |
 | Isar tracing on Web | `sentry_isar` does NOT support Web (Isar does not support Web) |

--- a/skills/sentry-flutter-sdk/references/metrics.md
+++ b/skills/sentry-flutter-sdk/references/metrics.md
@@ -1,7 +1,6 @@
 # Metrics — Sentry Flutter SDK
 
 > **Minimum SDK:** `sentry_flutter` ≥ **9.11.0** for trace-connected metrics  
-> **Status:** ⚠️ **Open Beta** — API is stable but some edge cases may change  
 > **Supported metric types:** Counter, Distribution, Gauge (no `set` type)  
 > **Per-metric key limit:** 2 KB
 
@@ -279,7 +278,7 @@ No special configuration is required for metrics beyond initializing the SDK wit
 |------------|---------|
 | No `set` type | `Sentry.metrics.set()` is **not supported** in the Flutter/Dart SDK. Use counters or external tracking for unique-value counting. |
 | 2 KB per-metric key limit | The metric key name + all tag key-value pairs must fit within 2 KB total. |
-| Open Beta status | The metrics API is stable but under active development. Some edge cases may change in future minor versions. |
+| Active development | The metrics API is stable but under active development. Some edge cases may change in future minor versions. |
 | Aggregation window | Metrics are aggregated locally before being flushed. Individual data points are not preserved — you see aggregations (sum, count, min, max). |
 | No sampling for metrics | Unlike errors and transactions, there is no sample rate for metrics — all emitted metrics are sent. Use tags and filtering instead of emitting fewer data points. |
 | Tag values must be strings | Passing non-string tag values will be coerced or dropped. |

--- a/skills/sentry-go-sdk/references/metrics.md
+++ b/skills/sentry-go-sdk/references/metrics.md
@@ -1,7 +1,6 @@
 # Metrics — Sentry Go SDK
 
-> Minimum SDK: `github.com/getsentry/sentry-go` v0.42.0+  
-> **⚠️ Open Beta** — API may change in future releases.
+> Minimum SDK: `github.com/getsentry/sentry-go` v0.42.0+
 
 ## Configuration
 

--- a/skills/sentry-nestjs-sdk/references/metrics.md
+++ b/skills/sentry-nestjs-sdk/references/metrics.md
@@ -1,6 +1,6 @@
 # Metrics — Sentry NestJS SDK
 
-> Minimum SDK: `@sentry/nestjs` 10.25.0+ · Status: ⚠️ Open beta
+> Minimum SDK: `@sentry/nestjs` 10.25.0+
 
 ## Overview
 

--- a/skills/sentry-nextjs-sdk/references/metrics.md
+++ b/skills/sentry-nextjs-sdk/references/metrics.md
@@ -3,8 +3,7 @@
 > Minimum SDK: `@sentry/nextjs` ≥10.25.0 (stable `Sentry.metrics.*` API)  
 > `enableMetrics` top-level option: ≥10.24.0 (default: `true`)  
 > `beforeSendMetric` hook: ≥10.24.0  
-> Scope attributes on metrics: ≥10.33.0  
-> Status: **Open Beta** — "Features in beta are still in-progress and may have bugs"
+> Scope attributes on metrics: ≥10.33.0
 >
 > Available in **all three runtimes**: browser, Node.js server, and Edge.
 

--- a/skills/sentry-node-sdk/references/metrics.md
+++ b/skills/sentry-node-sdk/references/metrics.md
@@ -3,8 +3,7 @@
 > Minimum SDK: `@sentry/node` ≥10.25.0 (stable `Sentry.metrics.*` API)  
 > `enableMetrics` top-level option: ≥10.24.0 (default: `true`)  
 > `beforeSendMetric` hook: ≥10.24.0  
-> Scope attributes on metrics: ≥10.33.0  
-> Status: 🧪 **Open Beta** — "Features in beta are still in-progress and may have bugs"
+> Scope attributes on metrics: ≥10.33.0
 
 ---
 

--- a/skills/sentry-php-sdk/SKILL.md
+++ b/skills/sentry-php-sdk/SKILL.md
@@ -72,7 +72,7 @@ Based on what you found, present a concrete proposal. Don't ask open-ended quest
 - ✅ **Tracing** — web framework detected (Laravel/Symfony auto-instrument HTTP, DB, Twig/Blade, cache)
 - ⚡ **Profiling** — production apps where performance matters (requires `excimer` PHP extension, Linux/macOS only)
 - ⚡ **Crons** — scheduler patterns detected (Laravel Scheduler, Symfony Scheduler, custom cron jobs)
-- ⚡ **Metrics** — business KPIs or SLO tracking (beta; uses `TraceMetrics` API)
+- ⚡ **Metrics** — business KPIs or SLO tracking (uses `TraceMetrics` API)
 
 **Recommendation matrix:**
 
@@ -82,7 +82,7 @@ Based on what you found, present a concrete proposal. Don't ask open-ended quest
 | Tracing | Laravel/Symfony detected, or manual spans needed | `${SKILL_ROOT}/references/tracing.md` |
 | Profiling | Production + `excimer` extension available | `${SKILL_ROOT}/references/profiling.md` |
 | Logging | **Always**; Monolog for Laravel/Symfony | `${SKILL_ROOT}/references/logging.md` |
-| Metrics | Business events or SLO tracking needed (beta) | `${SKILL_ROOT}/references/metrics.md` |
+| Metrics | Business events or SLO tracking needed | `${SKILL_ROOT}/references/metrics.md` |
 | Crons | Scheduler or cron patterns detected | `${SKILL_ROOT}/references/crons.md` |
 
 Propose: *"I recommend Error Monitoring + Tracing [+ Logging]. Want Profiling, Crons, or Metrics too?"*
@@ -226,7 +226,7 @@ Walk through features one at a time. Load the reference, follow its steps, verif
 | Tracing | `${SKILL_ROOT}/references/tracing.md` | HTTP handlers / distributed tracing |
 | Profiling | `${SKILL_ROOT}/references/profiling.md` | Performance-sensitive production |
 | Logging | `${SKILL_ROOT}/references/logging.md` | Always; Monolog for Laravel/Symfony |
-| Metrics | `${SKILL_ROOT}/references/metrics.md` | Business KPIs / SLO tracking (beta) |
+| Metrics | `${SKILL_ROOT}/references/metrics.md` | Business KPIs / SLO tracking |
 | Crons | `${SKILL_ROOT}/references/crons.md` | Scheduler / cron patterns detected |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.

--- a/skills/sentry-php-sdk/references/metrics.md
+++ b/skills/sentry-php-sdk/references/metrics.md
@@ -1,7 +1,6 @@
 # Metrics — Sentry PHP SDK
 
 > Minimum SDK versions: `sentry/sentry` ≥ 4.19.0 · `sentry/sentry-laravel` ≥ 4.20.0 · `sentry/sentry-symfony` ≥ 5.8.0
-> Status: ⚠️ Open beta
 
 ## Overview
 

--- a/skills/sentry-php-sdk/references/symfony.md
+++ b/skills/sentry-php-sdk/references/symfony.md
@@ -509,7 +509,7 @@ Respects `trace_propagation_targets` — only injects headers to matching hostna
 
 ---
 
-## Metrics (≥ 5.8.0, Open Beta)
+## Metrics (≥ 5.8.0)
 
 ```php
 use function Sentry\traceMetrics;

--- a/skills/sentry-python-sdk/references/metrics.md
+++ b/skills/sentry-python-sdk/references/metrics.md
@@ -1,6 +1,6 @@
 # Metrics — Sentry Python SDK
 
-> Minimum SDK: `sentry-sdk` 2.44.0+ · Status: ⚠️ Open beta
+> Minimum SDK: `sentry-sdk` 2.44.0+
 
 ## Overview
 

--- a/skills/sentry-sdk-skill-creator/SKILL.md
+++ b/skills/sentry-sdk-skill-creator/SKILL.md
@@ -40,7 +40,7 @@ Establish the **feature matrix** — which Sentry pillars does this SDK support?
 | Tracing/Performance | Usually available | Check for span API |
 | Profiling | Varies | May be removed or experimental |
 | Logging | Newer feature | Check minimum version |
-| Metrics | Newer feature | May be beta/experimental |
+| Metrics | Newer feature | Check minimum version |
 | Crons | Backend only | Not available for frontend SDKs |
 | Session Replay | Frontend only | Not available for backend SDKs |
 | AI Monitoring | Some SDKs | Usually JS + Python only |


### PR DESCRIPTION
Metrics is GA. Remove all beta, open beta, and experimental status labels from metrics documentation across Android, Flutter, Go, NestJS, Next.js, Node.js, PHP, Python SDK skills and reference files.

Also updates the SDK skill creator feature matrix to list metrics as "Check minimum version" (matching Logging) instead of "May be beta/experimental".