### PR TITLE
feat: Add stream_gen_ai_spans to Python AI monitoring skills

### DIFF
--- a/skills/sentry-python-sdk/references/ai-monitoring.md
+++ b/skills/sentry-python-sdk/references/ai-monitoring.md
@@ -1,13 +1,13 @@
 # AI Monitoring — Sentry Python SDK
 
-> Minimum SDK: `sentry-sdk` 2.1.0+ (core AI spans); 2.45.0+ for auto-enabling all integrations
+> Minimum SDK: `sentry-sdk` >=2.60.0
 
 ## Prerequisites
 
 Tracing must be enabled — AI spans require an active transaction:
 
 ```python
-sentry_sdk.init(dsn="...", traces_sample_rate=1.0)
+sentry_sdk.init(dsn="...", traces_sample_rate=1.0, stream_gen_ai_spans=True)
 ```
 
 ## Integration Matrix
@@ -49,6 +49,7 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="https://<key>@<org>.ingest.sentry.io/<project>",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,    # required to capture prompts/outputs
 )
 
@@ -65,6 +66,7 @@ from sentry_sdk.integrations.anthropic import AnthropicIntegration
 sentry_sdk.init(
     dsn="...",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         OpenAIIntegration(
@@ -85,6 +87,7 @@ from sentry_sdk.integrations.litellm import LiteLLMIntegration
 sentry_sdk.init(
     dsn="...",
     traces_sample_rate=1.0,
+    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(include_prompts=True),   # 100+ providers via proxy

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -180,6 +180,7 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="YOUR_DSN",
     traces_sample_rate=1.0,  # Lower in production (e.g., 0.1)
+    stream_gen_ai_spans=True,  # SDK ≥2.60.0
     # send_default_pii=True,  # Opt-in: required for prompt capture (sends user PII)
     # Integrations auto-enable when the AI package is installed.
     # Only specify explicitly to customize (e.g., include_prompts):


### PR DESCRIPTION
Add `stream_gen_ai_spans=True` to all `sentry_sdk.init()` code examples in the Python AI monitoring skill files and bump the minimum SDK version to `2.60.0`.

**Updated files:**
- `skills/sentry-python-sdk/references/ai-monitoring.md` — all init examples + version ref
- `skills/sentry-setup-ai-monitoring/SKILL.md` — Python init snippet

Refs TET-2344