### PR TITLE
feat: Add Conversations tracking to AI monitoring skills

### DIFF
--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -23,7 +23,7 @@ Append the path from the `Path` column in the table below to `https://skills.sen
 
 **Do not skip this section.** Do not assume which feature the user needs. Ask first.
 
-1. If the user mentions **AI monitoring, LLM tracing, or instrumenting an AI SDK** (OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI) → `sentry-setup-ai-monitoring`
+1. If the user mentions **AI monitoring, LLM tracing, conversations, or instrumenting an AI SDK** (OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI) → `sentry-setup-ai-monitoring`
 2. If the user mentions **OpenTelemetry, OTel Collector, or multi-service telemetry routing** → `sentry-otel-exporter-setup`
 3. If the user mentions **alerts, notifications, on-call, Slack/PagerDuty/Discord integration, or workflow rules** → `sentry-create-alert`
 
@@ -35,7 +35,7 @@ When unclear, **ask the user** which feature they want to configure. Do not gues
 
 | Feature | Skill | Path |
 |---|---|---|
-| AI/LLM monitoring — instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI | [`sentry-setup-ai-monitoring`](../sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+| AI/LLM monitoring and conversations — instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI | [`sentry-setup-ai-monitoring`](../sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
 | OpenTelemetry Collector with Sentry Exporter — multi-project routing, automatic project creation | [`sentry-otel-exporter-setup`](../sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
 | Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
 

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -341,6 +341,26 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 ---
 
+## Conversation Tracking
+
+Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
+
+**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+
+```typescript
+import * as Sentry from "@sentry/nestjs";
+
+// Set at the start of a conversation
+Sentry.setConversationId("conv_abc123");
+
+// All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
+
+// Unset when the conversation ends
+Sentry.setConversationId(null);
+```
+
+A single conversation can span multiple traces, and a single trace can contain multiple conversations.
+
 ## Troubleshooting
 
 | Issue | Solution |

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -354,9 +354,6 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.setConversationId("conv_abc123");
 
 // All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
-
-// Unset when the conversation ends
-Sentry.setConversationId(null);
 ```
 
 A single conversation can span multiple traces, and a single trace can contain multiple conversations.

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -414,12 +414,9 @@ Sentry.setConversationId("conv_abc123");
 
 // All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
 await openai.chat.completions.create({
-  model: "gpt-4o",
+  model: "gpt-5.5",
   messages: [{ role: "user", content: "Hello" }],
 });
-
-// Unset when the conversation ends
-Sentry.setConversationId(null);
 ```
 
 A single conversation can span multiple traces, and a single trace can contain multiple conversations.

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -400,6 +400,30 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 ---
 
+## Conversation Tracking
+
+Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
+
+**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set in your server config — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+
+```typescript
+import * as Sentry from "@sentry/nextjs";
+
+// Set at the start of a conversation (server-side)
+Sentry.setConversationId("conv_abc123");
+
+// All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
+await openai.chat.completions.create({
+  model: "gpt-4o",
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+// Unset when the conversation ends
+Sentry.setConversationId(null);
+```
+
+A single conversation can span multiple traces, and a single trace can contain multiple conversations.
+
 ## Troubleshooting
 
 | Issue | Solution |

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -210,6 +210,40 @@ Transaction
 
 If `tracesSampleRate` < 1.0, see the [AI sampling guide](../../sentry-setup-ai-monitoring/references/sampling.md).
 
+## Conversation Tracking
+
+Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
+
+**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+// Set at the start of a conversation
+Sentry.setConversationId("conv_abc123");
+
+// All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
+await openai.chat.completions.create({
+  model: "gpt-4o",
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+// Later turns in the same conversation are linked automatically
+await openai.chat.completions.create({
+  model: "gpt-4o",
+  messages: [
+    { role: "user", content: "Hello" },
+    { role: "assistant", content: "Hi there!" },
+    { role: "user", content: "What's the weather?" },
+  ],
+});
+
+// Unset when the conversation ends
+Sentry.setConversationId(null);
+```
+
+A single conversation can span multiple traces (e.g., page refresh), and a single trace can contain multiple conversations.
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -221,3 +255,4 @@ If `tracesSampleRate` < 1.0, see the [AI sampling guide](../../sentry-setup-ai-m
 | Prompts not captured | Set `sendDefaultPii: true`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
 | AI Agents Dashboard empty | Ensure traces are being sent; check DSN and `tracesSampleRate` |
 | Wrong cost calculations | Cached/reasoning tokens are subsets of totals, not additions |
+| Conversations view empty | Ensure `streamGenAiSpans: true`, `sendDefaultPii: true`, and a conversation ID is set via `Sentry.setConversationId()` |

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -224,22 +224,19 @@ Sentry.setConversationId("conv_abc123");
 
 // All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
 await openai.chat.completions.create({
-  model: "gpt-4o",
+  model: "gpt-5.5",
   messages: [{ role: "user", content: "Hello" }],
 });
 
 // Later turns in the same conversation are linked automatically
 await openai.chat.completions.create({
-  model: "gpt-4o",
+  model: "gpt-5.5",
   messages: [
     { role: "user", content: "Hello" },
     { role: "assistant", content: "Hi there!" },
     { role: "user", content: "What's the weather?" },
   ],
 });
-
-// Unset when the conversation ends
-Sentry.setConversationId(null);
 ```
 
 A single conversation can span multiple traces (e.g., page refresh), and a single trace can contain multiple conversations.

--- a/skills/sentry-python-sdk/references/ai-monitoring.md
+++ b/skills/sentry-python-sdk/references/ai-monitoring.md
@@ -257,17 +257,37 @@ Transaction
 
 This populates the **AI Agents Dashboard** in Sentry with per-agent latency, tool call rates, token consumption, and model cost attribution.
 
-### Conversation tracking (Alpha)
+### Conversation Tracking
 
-> Requires SDK ≥ 2.51.0
+Link AI spans across turns in a multi-turn conversation. Sentry groups spans by `gen_ai.conversation.id` into a chat-style timeline at **Explore > Conversations**.
+
+**Prerequisites:** `stream_gen_ai_spans=True` (SDK >=2.60.0) and `send_default_pii=True` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```python
+import sentry_sdk.ai
+
+# Set at the start of a conversation
+sentry_sdk.ai.set_conversation_id("conv_abc123")
+# All subsequent AI spans carry gen_ai.conversation.id = "conv_abc123"
+```
+
+Some integrations infer the conversation ID automatically. For example, the OpenAI integration picks it up when you use the `conversation` parameter:
+
+```python
+import openai
 import sentry_sdk
 
-# Link spans across turns in a multi-turn conversation
-sentry_sdk.ai.set_conversation_id("user-session-abc123")
-# All subsequent AI spans carry gen_ai.conversation.id = "user-session-abc123"
+sentry_sdk.init(...)
+
+conversation = openai.conversations.create()
+response = openai.responses.create(
+    model="gpt-4.1",
+    input=[{"role": "user", "content": "What are the 5 Ds of dodgeball?"}],
+    conversation=conversation.id  # automatically sets gen_ai.conversation.id
+)
 ```
+
+A single conversation can span multiple traces, and a single trace can contain multiple conversations.
 
 ## Streaming
 

--- a/skills/sentry-python-sdk/references/ai-monitoring.md
+++ b/skills/sentry-python-sdk/references/ai-monitoring.md
@@ -281,7 +281,7 @@ sentry_sdk.init(...)
 
 conversation = openai.conversations.create()
 response = openai.responses.create(
-    model="gpt-4.1",
+    model="gpt-5.4",
     input=[{"role": "user", "content": "What are the 5 Ds of dodgeball?"}],
     conversation=conversation.id  # automatically sets gen_ai.conversation.id
 )

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -303,6 +303,73 @@ The same rule applies to `gen_ai.usage.output_tokens` vs. `gen_ai.usage.output_t
 
 After configuring, make an LLM call and check the Sentry Traces dashboard. AI spans appear with `gen_ai.*` operations showing model, token counts, and latency.
 
+## Conversations
+
+Conversations gives a readable, chat-style view of past sessions with your AI agent. It groups spans by `gen_ai.conversation.id` — so whether a user talked across multiple traces or multiple conversations happened inside one trace, you get a timeline of every message, tool call, and response.
+
+Find it at **Explore > Conversations** in Sentry.
+
+### Prerequisites for Conversations
+
+- Tracing enabled with `tracesSampleRate > 0`
+- `streamGenAiSpans: true` (JS SDK >=10.53.0) / `stream_gen_ai_spans=True` (Python SDK >=2.60.0) — required so AI spans are sent as standalone items. Without this, spans with large inputs/outputs can hit transaction payload size limits and be dropped.
+- **Input and output capture enabled** — Conversations reconstructs the chat from `gen_ai.input.messages` and `gen_ai.output.messages` attributes. Set `sendDefaultPii: true` (JS) / `send_default_pii=True` (Python). Without it, conversations appear empty.
+
+### Setting a Conversation ID
+
+Some integrations (OpenAI Agents SDK for Python, OpenAI SDK for Node) infer the conversation ID automatically. For all others, set it manually.
+
+#### JavaScript
+
+```javascript
+import * as Sentry from "@sentry/node"; // or @sentry/nextjs, @sentry/nestjs, etc.
+
+// Set at the start of a conversation
+Sentry.setConversationId("conv_abc123");
+
+// All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
+await openai.chat.completions.create({
+  model: "gpt-4o",
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+// Unset when the conversation ends
+Sentry.setConversationId(null);
+```
+
+#### Python
+
+```python
+import sentry_sdk.ai
+
+# Set at the start of a conversation
+sentry_sdk.ai.set_conversation_id("conv_abc123")
+
+# All subsequent AI calls carry gen_ai.conversation.id = "conv_abc123"
+```
+
+Some integrations infer the conversation ID automatically. For example, the Python OpenAI integration picks it up when you use the `conversation` parameter:
+
+```python
+import openai
+import sentry_sdk
+
+sentry_sdk.init(...)
+
+conversation = openai.conversations.create()
+response = openai.responses.create(
+    model="gpt-4.1",
+    input=[{"role": "user", "content": "What are the 5 Ds of dodgeball?"}],
+    conversation=conversation.id  # automatically sets gen_ai.conversation.id
+)
+```
+
+### Conversations vs Traces
+
+These are independent concepts:
+- A single conversation can span **multiple traces** (e.g., user refreshes the page mid-conversation — new trace, same conversation ID)
+- A single trace can contain spans from **different conversations** (e.g., user starts a new chat without refreshing)
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -312,3 +379,4 @@ After configuring, make an LLM call and check the Sentry Traces dashboard. AI sp
 | Negative or wrong costs in dashboard | Cached/reasoning tokens are subsets of totals — see Token Usage and Cost Calculation |
 | Prompts not captured | Set `sendDefaultPii: true` (JS) or `send_default_pii=True` (Python); use `recordInputs`/`include_prompts` only for explicit overrides |
 | Vercel AI not working | Add `experimental_telemetry` to each call |
+| Conversations view empty | Ensure `streamGenAiSpans: true` / `stream_gen_ai_spans=True`, `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -329,12 +329,9 @@ Sentry.setConversationId("conv_abc123");
 
 // All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
 await openai.chat.completions.create({
-  model: "gpt-4o",
+  model: "gpt-5.5",
   messages: [{ role: "user", content: "Hello" }],
 });
-
-// Unset when the conversation ends
-Sentry.setConversationId(null);
 ```
 
 #### Python
@@ -358,7 +355,7 @@ sentry_sdk.init(...)
 
 conversation = openai.conversations.create()
 response = openai.responses.create(
-    model="gpt-4.1",
+    model="gpt-5.4",
     input=[{"role": "user", "content": "What are the 5 Ds of dodgeball?"}],
     conversation=conversation.id  # automatically sets gen_ai.conversation.id
 )

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-setup-ai-monitoring
-description: Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, or instrument OpenAI/Anthropic/Vercel AI/LangChain/Google GenAI/Pydantic AI. Detects installed AI SDKs and configures appropriate integrations.
+description: Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, track conversations, or instrument OpenAI/Anthropic/Vercel AI/LangChain/Google GenAI/Pydantic AI. Detects installed AI SDKs and configures appropriate integrations.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup


### PR DESCRIPTION

Add conversation tracking documentation across all AI monitoring skills.
- **Main AI monitoring skill** (`sentry-setup-ai-monitoring`): New Conversations section with JS + Python examples, prerequisites, and troubleshooting
- **Python** (`sentry-python-sdk`): Upgraded from Alpha to full support, added OpenAI auto-inference example
- `streamGenAiSpans` (JS >=10.53.0) / `stream_gen_ai_spans` (Python >=2.60.0) is required
- Input/output capture (`sendDefaultPii` / `send_default_pii`) is required — without it the Conversations view is empty
- JS API: `Sentry.setConversationId()` / Python API: `sentry_sdk.ai.set_conversation_id()`
- Some integrations (OpenAI) auto-infer the conversation ID
- Conversations and traces are independent concepts

Closes TET-2390