### PR TITLE
fix(skill-drift): add -n flag to argjson-only jq in plan job

### DIFF
--- a/.github/workflows/skill-drift.yml
+++ b/.github/workflows/skill-drift.yml
@@ -80,9 +80,13 @@ jobs:
               exit 1
             fi
             ALL_SKILLS=$(jq -c '[.[].skill]' "$MATRIX_FILE")
-            UNKNOWN=$(jq -c --argjson all "$ALL_SKILLS" --argjson wanted "$JSON_WANTED" \
+            # -n (null input) is required because this jq invocation has no
+            # stdin source; without it jq reads zero JSON values, applies
+            # the filter zero times, and produces no output — silently
+            # yielding UNKNOWN="" instead of UNKNOWN="[]".
+            UNKNOWN=$(jq -nc --argjson all "$ALL_SKILLS" --argjson wanted "$JSON_WANTED" \
               '$wanted | map(select(. as $s | $all | index($s) | not))')
-            if [[ "$(jq 'length' <<<"$UNKNOWN")" != "0" ]]; then
+            if [[ "$(jq 'length' <<<"${UNKNOWN:-[]}")" != "0" ]]; then
               echo "::error::Unknown skill(s) in workflow_dispatch input: $UNKNOWN"
               exit 1
             fi


### PR DESCRIPTION
## Summary
- The plan job's "unknown skills" guard was running `jq --argjson all ... --argjson wanted ...` without `-n` and without stdin. jq waited for stdin, got EOF, applied the filter zero times, and produced no output — `UNKNOWN=""` instead of `UNKNOWN="[]"`. The subsequent `jq 'length' <<<""` produced no output either, so `[[ "" != "0" ]]` was true and the workflow died with `Unknown skill(s) in workflow_dispatch input: ` (empty list) on every dispatch.
- Failed run: https://github.com/getsentry/sentry-for-ai/actions/runs/26625830364
- Adds `-nc` to the jq invocation, and a `${UNKNOWN:-[]}` guard on the length check as belt-and-suspenders.

## Test plan
- [x] Local repro of the bug
- [x] Local verification of fix: happy path → `UNKNOWN=[]`, length=0; bogus skill → `UNKNOWN=["bogus"]`, length=1
- [x] `actionlint` clean
- [ ] Manual `gh workflow run skill-drift.yml -f skills=sentry-go-sdk` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)