### PR TITLE
feat(skills): Add span streaming migration skill for Dart

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ Skills use YAML frontmatter with `allowed-tools` — this is required by Cursor 
 | `sentry-otel-exporter-setup` | Setup OTel Collector with Sentry Exporter |
 | `sentry-span-streaming-js` | Migrate JavaScript SDK from transaction-based to streamed span delivery |
 | `sentry-span-streaming-python` | Migrate Python SDK from transaction-based to streamed span delivery |
+| `sentry-span-streaming-dart` | Migrate Dart/Flutter SDK from transaction-based to streamed span delivery |
 | `sentry-instrumentation-guide` | Decide which signal to reach for — error vs span vs log vs metric |
 
 ### Workflow Skills

--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -112,6 +112,7 @@ Configure specific Sentry capabilities beyond basic SDK setup.
 | Decide which Sentry signal to reach for when instrumenting code — error, span, span attribute, log, or metric | [`sentry-instrumentation-guide`](skills/sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
 | Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
 | Setup Sentry AI Agent Monitoring in any project | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+| Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-dart`](skills/sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
 | Migrate JavaScript SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-js`](skills/sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
 | Migrate Python SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-python`](skills/sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |
 

--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -26,7 +26,7 @@ Append the path from the `Path` column in the table below to `https://skills.sen
 1. If the user mentions **AI monitoring, LLM tracing, conversations, or instrumenting an AI SDK** (OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI) → `sentry-setup-ai-monitoring`
 2. If the user mentions **OpenTelemetry, OTel Collector, or multi-service telemetry routing** → `sentry-otel-exporter-setup`
 3. If the user mentions **alerts, notifications, on-call, Slack/PagerDuty/Discord integration, or workflow rules** → `sentry-create-alert`
-4. If the user mentions **span streaming, traceLifecycle, trace_lifecycle, spanStreamingIntegration, or switching from transactions to streamed spans** → `sentry-span-streaming-js` (JavaScript) or `sentry-span-streaming-python` (Python)
+4. If the user mentions **span streaming, traceLifecycle, trace_lifecycle, spanStreamingIntegration, or switching from transactions to streamed spans** → `sentry-span-streaming-js` (JavaScript), `sentry-span-streaming-python` (Python), or `sentry-span-streaming-dart` (Dart/Flutter)
 5. If the user is unsure **which signal to use** — log vs span vs metric, "what to instrument where", or how to choose between errors, traces, logs, and metrics → `sentry-instrumentation-guide`
 
 When unclear, **ask the user** which feature they want to configure. Do not guess.
@@ -42,6 +42,7 @@ When unclear, **ask the user** which feature they want to configure. Do not gues
 | Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
 | Span streaming (JavaScript) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-js`](../sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
 | Span streaming (Python) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-python`](../sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |
+| Span streaming (Dart/Flutter) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-dart`](../sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
 | Instrumentation guide — decide which signal to reach for (error vs span vs log vs metric), "what to instrument where" | [`sentry-instrumentation-guide`](../sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
 
 Each skill contains its own detection logic, prerequisites, and step-by-step instructions. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -229,22 +229,7 @@ When an ignored span has children, the children are re-parented to the nearest r
 
 No code changes needed: frames tracking, app start, TTID/TTFD, navigation, user interaction, HTTP, database, and GraphQL instrumentations all switch to the streaming API automatically when `traceLifecycle` is `stream`.
 
-### 2.8 `configureScope` Inside Span Callbacks
-
-`Sentry.configureScope` continues to work in streaming mode. Each `startSpan` / `startSpanSync` callback runs in its own zone; scope changes made with `configureScope` within a span callback are applied to all zones in that span callback and its children, so the data lands on the current span and any child spans.
-
-```dart
-await Sentry.startSpan('checkout', (span) async {
-  await Sentry.configureScope((scope) {
-    scope.setAttributes({'user.tier': SentryAttribute.string('premium')});
-  });
-
-  // 'checkout' and 'process-payment' both receive the scope attributes.
-  await Sentry.startSpan('process-payment', (_) => paymentService.charge(total));
-});
-```
-
-### 2.9 Sampling
+### 2.8 Sampling
 
 `tracesSampleRate` and `tracesSampler` work unchanged. Only **root spans** are sampled; child spans inherit the root's decision. When a root span is not sampled, the callback still executes with a no-op span.
 

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -38,7 +38,7 @@ grep -A8 '^  sentry:' pubspec.lock 2>/dev/null | grep -m1 version
 grep -A8 '^  sentry_flutter:' pubspec.lock 2>/dev/null | grep -m1 version
 ```
 
-Span streaming requires `sentry` / `sentry_flutter` `>=9.19.0`. The feature is marked `@experimental` in the SDK — the API may change in a minor release, and the analyzer may emit `experimental_member_use` hints.
+Span streaming requires `sentry` / `sentry_flutter` `>=9.19.0`.
 
 ### 1.2 Find Existing Sentry Config and Tracing Usage
 
@@ -245,7 +245,7 @@ dart analyze 2>&1 | head -30
 flutter analyze 2>&1 | head -30
 ```
 
-`experimental_member_use` hints on `traceLifecycle` / `startSpan` are expected — the feature is experimental. Suppress per-file with `// ignore_for_file: experimental_member_use` if the project treats hints as errors.
+Expect no new analyzer errors from the migration.
 
 ### 3.2 Runtime Verification
 
@@ -263,7 +263,6 @@ Instruct the user to verify with `options.debug = true` or network inspection:
 | `Sentry.startSpan` produces no spans | `traceLifecycle` still `static` (the default), or tracing disabled | Set `options.traceLifecycle = SentryTraceLifecycle.stream` and a `tracesSampleRate` |
 | `beforeSendTransaction` never called | Expected in streaming mode | Migrate logic to `beforeSendSpan` or `ignoreSpans`, then remove it |
 | Returning a value from `beforeSendSpan` to drop a span does nothing | `beforeSendSpan` is mutation-only (`FutureOr<void>` return) | Use `ignoreSpans` to drop spans |
-| Analyzer error `experimental_member_use` | Span streaming APIs are `@experimental` | Suppress with `// ignore_for_file: experimental_member_use` |
 | Compile error: `startSpan` callback type mismatch | Callback must return `Future<T>` for `startSpan` | Use `startSpanSync` for synchronous work |
 
 ---
@@ -313,5 +312,5 @@ Future<void> main() async {
 - [ ] `setData` / `setTag` on spans replaced with typed `setAttribute` / `SentryAttribute`
 - [ ] `beforeSendTransaction` logic migrated to `beforeSendSpan` or `ignoreSpans`, option removed
 - [ ] `startInactiveSpan` spans have a guaranteed `end()` call path
-- [ ] `dart analyze` / `flutter analyze` passes (experimental hints acceptable)
+- [ ] `dart analyze` / `flutter analyze` passes
 - [ ] Spans visible in Sentry Traces view

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -273,7 +273,7 @@ Instruct the user to verify with `options.debug = true` or network inspection:
 
 1. **Envelope content type**: span envelopes are sent with content type `application/vnd.sentry.items.span.v2+json` instead of transaction envelopes. Spans are buffered briefly and flushed in batches, so expect a short delay before envelopes appear.
 2. **Sentry dashboard**: spans appear in the Traces view shortly after each span completes, without waiting for a whole transaction to finish.
-3. **No-op warnings**: a log line `startTransaction is not supported when traceLifecycle is 'streaming'` means old transaction API calls remain — find and migrate them.
+3. **No-op warnings**: a log line `startTransaction is not supported when traceLifecycle is 'stream'` means old transaction API calls remain — find and migrate them.
 
 ### 3.3 Common Issues
 

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -1,0 +1,328 @@
+---
+name: sentry-span-streaming-dart
+description: Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", "use traceLifecycle stream", "use Sentry.startSpan", or switch from transaction-based to streamed span delivery in a Dart or Flutter project.
+license: Apache-2.0
+category: feature-setup
+parent: sentry-feature-setup
+disable-model-invocation: true
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob
+---
+
+> [All Skills](../../SKILL_TREE.md) > [Feature Setup](../sentry-feature-setup/SKILL.md) > Span Streaming (Dart)
+
+# Sentry Span Streaming Migration (Dart/Flutter)
+
+Migrate from the default transaction-based trace lifecycle (`SentryTraceLifecycle.static`) to span streaming (`SentryTraceLifecycle.stream`), where spans are sent individually as they complete instead of being batched into a transaction at the end.
+
+This skill covers the Dart and Flutter SDKs (`sentry`, `sentry_flutter`, and integration packages such as `sentry_dio`, `sentry_sqflite`, `sentry_drift`). For JavaScript, see [Span Streaming (JavaScript)](../sentry-span-streaming-js/SKILL.md). For Python, see [Span Streaming (Python)](../sentry-span-streaming-python/SKILL.md).
+
+## Invoke This Skill When
+
+- User asks to "enable span streaming" or "migrate to span streaming" in a Dart or Flutter project
+- User wants to switch from transaction-based to streamed span delivery
+- User mentions `traceLifecycle`, `SentryTraceLifecycle.stream`, `Sentry.startSpan`, or `SentrySpanV2`
+- User wants lower latency span delivery or per-span processing
+
+---
+
+## Phase 1: Detect
+
+### 1.1 Detect SDK and Version
+
+```bash
+# Which Sentry packages does the project use?
+grep -n "sentry" pubspec.yaml 2>/dev/null
+
+# Resolved versions — span streaming requires >= 9.19.0
+grep -A8 '^  sentry:' pubspec.lock 2>/dev/null | grep -m1 version
+grep -A8 '^  sentry_flutter:' pubspec.lock 2>/dev/null | grep -m1 version
+```
+
+Span streaming requires `sentry` / `sentry_flutter` `>=9.19.0`. The feature is marked `@experimental` in the SDK — the API may change in a minor release, and the analyzer may emit `experimental_member_use` hints.
+
+### 1.2 Find Existing Sentry Config and Tracing Usage
+
+```bash
+# Find init calls
+grep -rn "SentryFlutter\.init\|Sentry\.init" lib/ bin/ test/ --include="*.dart" 2>/dev/null | head -10
+
+# Find old transaction API usage (these become no-ops in streaming mode)
+grep -rn "startTransaction\|\.startChild(" lib/ bin/ test/ --include="*.dart" 2>/dev/null | head -20
+
+# Find callbacks affected by the migration
+grep -rn "beforeSendTransaction\|beforeSendSpan\|ignoreSpans" lib/ bin/ test/ --include="*.dart" 2>/dev/null
+
+# Find untyped span data/tag usage on transactions
+grep -rn "\.setData(\|\.setTag(" lib/ bin/ test/ --include="*.dart" 2>/dev/null | head -20
+```
+
+### 1.3 Classify the Migration Work
+
+| Finding | Migration Work |
+|---|---|
+| `Sentry.startTransaction(...)` calls | Replace with `Sentry.startSpan` / `Sentry.startSpanSync` / `Sentry.startInactiveSpan` |
+| `span.startChild(...)` calls | Replace with nested `Sentry.startSpan` calls — parenting is automatic via zones |
+| `setData` / `setTag` on spans | Replace with typed `span.setAttribute(...)` / `SentryAttribute` |
+| `beforeSendTransaction` callback | Never called in streaming mode — migrate logic to `beforeSendSpan` or `ignoreSpans` |
+| Existing `beforeSendSpan` / `ignoreSpans` usage | Review against streaming semantics — `beforeSendSpan` is mutation-only, `ignoreSpans` matches names only (see 2.5/2.6) |
+| Only auto-instrumentation (no manual spans) | Just enable the option — integrations switch automatically |
+
+---
+
+## Phase 2: Migrate
+
+**Prerequisites:** `sentry` / `sentry_flutter` `>=9.19.0` with tracing enabled (`tracesSampleRate` or `tracesSampler` configured).
+
+### 2.1 Enable Span Streaming
+
+Set `traceLifecycle` in the init options. This is the only required config change.
+
+```dart
+// Flutter
+await SentryFlutter.init((options) {
+  options.dsn = '__DSN__';
+  options.tracesSampleRate = 1.0;
+  options.traceLifecycle = SentryTraceLifecycle.stream;
+}, appRunner: () => runApp(const MyApp()));
+
+// Plain Dart
+await Sentry.init((options) {
+  options.dsn = '__DSN__';
+  options.tracesSampleRate = 1.0;
+  options.traceLifecycle = SentryTraceLifecycle.stream;
+});
+```
+
+You can only use one tracing system at a time:
+
+- In `stream` mode, the transaction APIs (`Sentry.startTransaction`, `ISentrySpan.startChild`) do nothing and log a warning.
+- In `static` mode (the default), the new span APIs (`Sentry.startSpan`) do nothing.
+- Auto-instrumentations automatically switch to the correct API based on this setting.
+
+### 2.2 Replace Transactions with Spans
+
+`Sentry.startSpan` runs an async callback and ends the span when the returned future completes. Nested calls auto-parent through zones — there is no `startChild` equivalent to migrate to; just nest.
+
+```dart
+// Before (static mode)
+final transaction = Sentry.startTransaction('checkout', 'task');
+try {
+  final child = transaction.startChild('db.query', description: 'load cart');
+  final cart = await loadCart();
+  await child.finish();
+  transaction.setData('cart.item_count', cart.items.length);
+  transaction.status = const SpanStatus.ok();
+} catch (exception) {
+  transaction.status = const SpanStatus.internalError();
+  rethrow;
+} finally {
+  await transaction.finish();
+}
+
+// After (streaming mode)
+await Sentry.startSpan('checkout', (span) async {
+  final cart = await Sentry.startSpan('load cart', (_) => loadCart());
+  span.setAttribute('cart.item_count', SentryAttribute.int(cart.items.length));
+});
+```
+
+Error handling is automatic: if the callback throws (or the future errors), the span status is set to `SentrySpanStatusV2.error` before the span ends, and the error is rethrown.
+
+For synchronous work, use `Sentry.startSpanSync`:
+
+```dart
+final config = Sentry.startSpanSync('parse-config', (_) {
+  return Config.parse(raw);
+});
+```
+
+Both variants can be freely nested — parent-child relationships resolve correctly across sync/async boundaries. If a span is not sampled, the callback still runs and receives a no-op span, so all span operations are safe.
+
+### 2.3 Spans That Outlive a Callback
+
+Use `Sentry.startInactiveSpan` when the work cannot be wrapped in a single callback — widget lifecycles, stream subscriptions, platform channel round-trips. You must call `end()` manually, and other spans do **not** automatically become its children.
+
+```dart
+final paymentSpan = Sentry.startInactiveSpan('payment',
+    attributes: {'payment.provider': SentryAttribute.string('stripe')});
+
+// ...later, from a different entry point
+void onDeepLink(Uri uri) {
+  paymentSpan.end();
+}
+```
+
+By default the span is created as a child of the currently active span. To parent explicitly, pass `parentSpan:`; pass `parentSpan: null` to force a root span.
+
+### 2.4 Migrate `setData` / `setTag` to Typed Attributes
+
+Streamed spans use typed attributes instead of untyped data and tags:
+
+```dart
+// Before
+transaction.setData('retry_count', 3);
+transaction.setTag('payment.provider', 'stripe');
+
+// After
+span.setAttribute('retry_count', SentryAttribute.int(3));
+span.setAttributes({
+  'payment.provider': SentryAttribute.string('stripe'),
+  'cache.hit': SentryAttribute.bool(true),
+  'response_time_ms': SentryAttribute.double(12.5),
+});
+span.removeAttribute('old_key');
+```
+
+| Factory | Dart Type |
+|---|---|
+| `SentryAttribute.string(v)` | `String` |
+| `SentryAttribute.int(v)` | `int` |
+| `SentryAttribute.bool(v)` | `bool` |
+| `SentryAttribute.double(v)` | `double` |
+
+### 2.5 Migrate `beforeSendTransaction`
+
+`beforeSendTransaction` has **no effect** in streaming mode — transactions are never created, so the callback is never invoked. Migrate its logic:
+
+| Use Case | Streaming Replacement |
+|---|---|
+| Drop spans by name | `ignoreSpans` with `IgnoreSpanRule` |
+| Scrub sensitive data / PII | `beforeSendSpan` |
+| Modify span data before send | `beforeSendSpan` |
+
+`beforeSendSpan` receives each `SentrySpanV2` before it is sent. Unlike other `beforeSend` callbacks, it **cannot drop spans** — it is mutation-only (`FutureOr<void>` return). Use `ignoreSpans` to drop.
+
+```dart
+await Sentry.init((options) {
+  options.traceLifecycle = SentryTraceLifecycle.stream;
+  options.beforeSendSpan = (span) {
+    span.removeAttribute('http.request.body');
+  };
+});
+```
+
+Remove the `beforeSendTransaction` option after migrating its logic.
+
+### 2.6 Configure `ignoreSpans` (Optional)
+
+`ignoreSpans` drops spans by name before sampling. Matching is name-only (attribute matching is not yet supported in the Dart SDK).
+
+```dart
+options.ignoreSpans = [
+  IgnoreSpanRule.nameEquals('health-check'),
+  IgnoreSpanRule.nameStartsWith('internal.'),
+  IgnoreSpanRule.nameContains('metrics'),
+  IgnoreSpanRule.nameEndsWith('.bg'),
+];
+```
+
+| Factory | Matches |
+|---|---|
+| `IgnoreSpanRule.nameEquals(String)` | Exact span name |
+| `IgnoreSpanRule.nameStartsWith(Pattern)` | Name prefix (String or RegExp) |
+| `IgnoreSpanRule.nameContains(Pattern)` | Name substring (String or RegExp) |
+| `IgnoreSpanRule.nameEndsWith(String)` | Name suffix |
+
+When an ignored span has children, the children are re-parented to the nearest recording ancestor rather than dropped.
+
+### 2.7 Flutter Auto-Instrumentation
+
+No code changes needed: frames tracking, app start, TTID/TTFD, navigation, user interaction, HTTP, database, and GraphQL instrumentations all switch to the streaming API automatically when `traceLifecycle` is `stream`.
+
+One related behavior to be aware of: `SentryNavigatorObserver(enableNewTraceOnNavigation: ...)` defaults to `false`, which keeps one continuous trace across navigations. Pass `true` to start a fresh trace on every route change:
+
+```dart
+MaterialApp(
+  navigatorObservers: [
+    SentryNavigatorObserver(enableNewTraceOnNavigation: true),
+  ],
+);
+```
+
+### 2.8 Sampling
+
+`tracesSampleRate` and `tracesSampler` work unchanged. Only **root spans** are sampled; child spans inherit the root's decision. When a root span is not sampled, the callback still executes with a no-op span.
+
+---
+
+## Phase 3: Verify
+
+### 3.1 Static Check
+
+```bash
+dart analyze 2>&1 | head -30
+# or for Flutter projects
+flutter analyze 2>&1 | head -30
+```
+
+`experimental_member_use` hints on `traceLifecycle` / `startSpan` are expected — the feature is experimental. Suppress per-file with `// ignore_for_file: experimental_member_use` if the project treats hints as errors.
+
+### 3.2 Runtime Verification
+
+Instruct the user to verify with `options.debug = true` or network inspection:
+
+1. **Envelope content type**: span envelopes are sent with content type `application/vnd.sentry.items.span.v2+json` instead of transaction envelopes. Spans are buffered briefly and flushed in batches (after ~5 seconds, 100 spans, or 1 MiB — whichever comes first).
+2. **Sentry dashboard**: spans appear in the Traces view shortly after each span completes, without waiting for a whole transaction to finish.
+3. **No-op warnings**: a log line `startTransaction is not supported when traceLifecycle is 'streaming'` means old transaction API calls remain — find and migrate them.
+
+### 3.3 Common Issues
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Log: `startTransaction is not supported when traceLifecycle is 'streaming'` | Old transaction API still called in streaming mode | Replace with `Sentry.startSpan` / `startSpanSync` |
+| `Sentry.startSpan` produces no spans | `traceLifecycle` still `static` (the default), or tracing disabled | Set `options.traceLifecycle = SentryTraceLifecycle.stream` and a `tracesSampleRate` |
+| `beforeSendTransaction` never called | Expected in streaming mode | Migrate logic to `beforeSendSpan` or `ignoreSpans`, then remove it |
+| Returning a value from `beforeSendSpan` to drop a span does nothing | `beforeSendSpan` is mutation-only (`FutureOr<void>` return) | Use `ignoreSpans` to drop spans |
+| Analyzer error `experimental_member_use` | Span streaming APIs are `@experimental` | Suppress with `// ignore_for_file: experimental_member_use` |
+| Compile error: `startSpan` callback type mismatch | Callback must return `Future<T>` for `startSpan` | Use `startSpanSync` for synchronous work |
+| New trace on every navigation no longer happens | `enableNewTraceOnNavigation` defaults to `false` | Pass `SentryNavigatorObserver(enableNewTraceOnNavigation: true)` |
+
+---
+
+## Quick Reference
+
+### Minimal Flutter Setup
+
+```dart
+import 'package:flutter/widgets.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+Future<void> main() async {
+  await SentryFlutter.init((options) {
+    options.dsn = '__DSN__';
+    options.tracesSampleRate = 1.0;
+    options.traceLifecycle = SentryTraceLifecycle.stream;
+  }, appRunner: () => runApp(const MyApp()));
+}
+```
+
+### Minimal Dart Setup
+
+```dart
+import 'package:sentry/sentry.dart';
+
+Future<void> main() async {
+  await Sentry.init((options) {
+    options.dsn = '__DSN__';
+    options.tracesSampleRate = 1.0;
+    options.traceLifecycle = SentryTraceLifecycle.stream;
+  });
+
+  await Sentry.startSpan('main-task', (span) async {
+    span.setAttribute('job.id', SentryAttribute.string('42'));
+    await doWork();
+  });
+}
+```
+
+### Full Migration Checklist
+
+- [ ] SDK version is `>=9.19.0` (`sentry` / `sentry_flutter`)
+- [ ] `options.traceLifecycle = SentryTraceLifecycle.stream` set in every init call
+- [ ] All `Sentry.startTransaction` calls replaced with `Sentry.startSpan` / `startSpanSync` / `startInactiveSpan`
+- [ ] All `startChild` calls replaced with nested `Sentry.startSpan` calls
+- [ ] `setData` / `setTag` on spans replaced with typed `setAttribute` / `SentryAttribute`
+- [ ] `beforeSendTransaction` logic migrated to `beforeSendSpan` or `ignoreSpans`, option removed
+- [ ] `startInactiveSpan` spans have a guaranteed `end()` call path
+- [ ] `dart analyze` / `flutter analyze` passes (experimental hints acceptable)
+- [ ] Spans visible in Sentry Traces view

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -251,7 +251,7 @@ Expect no new analyzer errors from the migration.
 
 Instruct the user to verify with `options.debug = true` or network inspection:
 
-1. **Envelope content type**: span envelopes are sent with content type `application/vnd.sentry.items.span.v2+json` instead of transaction envelopes. Spans are buffered briefly and flushed in batches (after ~5 seconds, 100 spans, or 1 MiB — whichever comes first).
+1. **Envelope content type**: span envelopes are sent with content type `application/vnd.sentry.items.span.v2+json` instead of transaction envelopes. Spans are buffered briefly and flushed in batches, so expect a short delay before envelopes appear.
 2. **Sentry dashboard**: spans appear in the Traces view shortly after each span completes, without waiting for a whole transaction to finish.
 3. **No-op warnings**: a log line `startTransaction is not supported when traceLifecycle is 'streaming'` means old transaction API calls remain — find and migrate them.
 

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -279,7 +279,7 @@ Instruct the user to verify with `options.debug = true` or network inspection:
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Log: `startTransaction is not supported when traceLifecycle is 'streaming'` | Old transaction API still called in streaming mode | Replace with `Sentry.startSpan` / `startSpanSync` |
+| Log: `startTransaction is not supported when traceLifecycle is 'stream'` | Old transaction API still called in streaming mode | Replace with `Sentry.startSpan` / `startSpanSync` |
 | `Sentry.startSpan` produces no spans | `traceLifecycle` still `static` (the default), or tracing disabled | Set `options.traceLifecycle = SentryTraceLifecycle.stream` and a `tracesSampleRate` |
 | `beforeSendTransaction` never called | Expected in streaming mode | Migrate logic to `beforeSendSpan` or `ignoreSpans`, then remove it |
 | Returning a value from `beforeSendSpan` to drop a span does nothing | `beforeSendSpan` is mutation-only (`FutureOr<void>` return) | Use `ignoreSpans` to drop spans |

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -229,17 +229,22 @@ When an ignored span has children, the children are re-parented to the nearest r
 
 No code changes needed: frames tracking, app start, TTID/TTFD, navigation, user interaction, HTTP, database, and GraphQL instrumentations all switch to the streaming API automatically when `traceLifecycle` is `stream`.
 
-One related behavior to be aware of: `SentryNavigatorObserver(enableNewTraceOnNavigation: ...)` defaults to `false`, which keeps one continuous trace across navigations. Pass `true` to start a fresh trace on every route change:
+### 2.8 `configureScope` Inside Span Callbacks
+
+`Sentry.configureScope` continues to work in streaming mode. Each `startSpan` / `startSpanSync` callback runs in its own zone; scope changes made with `configureScope` within a span callback are applied to all zones in that span callback and its children, so the data lands on the current span and any child spans.
 
 ```dart
-MaterialApp(
-  navigatorObservers: [
-    SentryNavigatorObserver(enableNewTraceOnNavigation: true),
-  ],
-);
+await Sentry.startSpan('checkout', (span) async {
+  await Sentry.configureScope((scope) {
+    scope.setAttributes({'user.tier': SentryAttribute.string('premium')});
+  });
+
+  // 'checkout' and 'process-payment' both receive the scope attributes.
+  await Sentry.startSpan('process-payment', (_) => paymentService.charge(total));
+});
 ```
 
-### 2.8 Sampling
+### 2.9 Sampling
 
 `tracesSampleRate` and `tracesSampler` work unchanged. Only **root spans** are sampled; child spans inherit the root's decision. When a root span is not sampled, the callback still executes with a no-op span.
 
@@ -275,7 +280,6 @@ Instruct the user to verify with `options.debug = true` or network inspection:
 | Returning a value from `beforeSendSpan` to drop a span does nothing | `beforeSendSpan` is mutation-only (`FutureOr<void>` return) | Use `ignoreSpans` to drop spans |
 | Analyzer error `experimental_member_use` | Span streaming APIs are `@experimental` | Suppress with `// ignore_for_file: experimental_member_use` |
 | Compile error: `startSpan` callback type mismatch | Callback must return `Future<T>` for `startSpan` | Use `startSpanSync` for synchronous work |
-| New trace on every navigation no longer happens | `enableNewTraceOnNavigation` defaults to `false` | Pass `SentryNavigatorObserver(enableNewTraceOnNavigation: true)` |
 
 ---
 

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -113,7 +113,7 @@ try {
   transaction.setData('cart.item_count', cart.items.length);
   transaction.status = const SpanStatus.ok();
 } catch (exception) {
-  transaction.status = const SpanStatus.internalError();
+  transaction.status = const SpanStatus.internalError(); // -> span.status (see below)
   rethrow;
 } finally {
   await transaction.finish();
@@ -126,7 +126,15 @@ await Sentry.startSpan('checkout', (span) async {
 });
 ```
 
-Error handling is automatic: if the callback throws (or the future errors), the span status is set to `SentrySpanStatusV2.error` before the span ends, and the error is rethrown.
+Error handling is automatic: if the callback throws (or the future errors), the span status is set to `SentrySpanStatusV2.error` before the span ends, and the error is rethrown. Otherwise the status defaults to `ok`.
+
+You can also set the status manually via the `status` setter:
+
+```dart
+span.status = SentrySpanStatusV2.error;
+```
+
+There is no untyped `SpanStatus` string equivalent. Explicit statuses from the old API (e.g. `transaction.status = const SpanStatus.internalError()`) migrate to `span.status = SentrySpanStatusV2.error` — though `error` is set automatically on throw and `ok` automatically otherwise, so manual assignment is only needed to override the default.
 
 For synchronous work, use `Sentry.startSpanSync`:
 
@@ -152,7 +160,19 @@ void onDeepLink(Uri uri) {
 }
 ```
 
-By default the span is created as a child of the currently active span. To parent explicitly, pass `parentSpan:`; pass `parentSpan: null` to force a root span.
+**Parenting.** `parentSpan` defaults to an internal *unset* sentinel (`const UnsetSentrySpanV2()`), which means "inherit the currently active span." This is explicitly distinct from passing `parentSpan: null`, which forces a root span with no parent. Pass an explicit `SentrySpanV2` to parent under a specific span. (The same default applies to `startSpan` / `startSpanSync`.)
+
+**Retroactive timing.** `startSpan` and `startSpanSync` accept an optional `startTimestamp`, and `span.end(endTimestamp: ...)` accepts an explicit end time. Use these when the real start or end of the work happened before you could create or end the span — for example, a duration measured by a platform channel:
+
+```dart
+final paymentSpan = Sentry.startInactiveSpan('payment');
+// ...native reports it started at `nativeStart` and ended at `nativeEnd`
+paymentSpan.end(endTimestamp: nativeEnd);
+
+// startTimestamp is available on the callback variants:
+Sentry.startSpanSync('replay-import', (_) => importRows(),
+    startTimestamp: measuredStart);
+```
 
 ### 2.4 Migrate `setData` / `setTag` to Typed Attributes
 
@@ -306,6 +326,20 @@ Future<void> main() async {
     await doWork();
   });
 }
+```
+
+### Span Control Reference
+
+```dart
+// Status (auto-set to error on throw, ok otherwise)
+span.status = SentrySpanStatusV2.error; // error | ok
+
+// Retroactive timing
+Sentry.startSpanSync('task', (_) => work(), startTimestamp: start); // also on startSpan
+span.end(endTimestamp: end);                                        // on any span
+
+// Parenting (startSpan / startSpanSync / startInactiveSpan)
+// default: inherit active span | parentSpan: someSpan -> explicit parent | parentSpan: null -> root
 ```
 
 ### Full Migration Checklist

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -281,6 +281,11 @@ Future<void> main() async {
     options.tracesSampleRate = 1.0;
     options.traceLifecycle = SentryTraceLifecycle.stream;
   }, appRunner: () => runApp(const MyApp()));
+
+  await Sentry.startSpan('load-config', (span) async {
+    span.setAttribute('source', SentryAttribute.string('remote'));
+    await loadConfig();
+  });
 }
 ```
 

--- a/skills/sentry-span-streaming-js/SKILL.md
+++ b/skills/sentry-span-streaming-js/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 Migrate from the default transaction-based trace lifecycle (`static`) to span streaming (`stream`), where spans are sent individually as they complete instead of being batched into a transaction at the end.
 
-This skill covers the JavaScript SDK (Browser, Node.js, Bun, Deno, Cloudflare). For Python, see [Span Streaming (Python)](../sentry-span-streaming-python/SKILL.md).
+This skill covers the JavaScript SDK (Browser, Node.js, Bun, Deno, Cloudflare). For Python, see [Span Streaming (Python)](../sentry-span-streaming-python/SKILL.md). For Dart/Flutter, see [Span Streaming (Dart)](../sentry-span-streaming-dart/SKILL.md).
 
 ## Invoke This Skill When
 

--- a/skills/sentry-span-streaming-python/SKILL.md
+++ b/skills/sentry-span-streaming-python/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 
 Migrate from the default transaction-based trace lifecycle (`static`) to span streaming (`stream`), where spans are sent individually as they complete instead of being batched into a transaction at the end.
 
-This skill covers the Python SDK. For JavaScript, see [Span Streaming (JavaScript)](../sentry-span-streaming-js/SKILL.md).
+This skill covers the Python SDK. For JavaScript, see [Span Streaming (JavaScript)](../sentry-span-streaming-js/SKILL.md). For Dart/Flutter, see [Span Streaming (Dart)](../sentry-span-streaming-dart/SKILL.md).
 
 ## Invoke This Skill When
 


### PR DESCRIPTION
Adds `sentry-span-streaming-dart`, a migration skill that walks an agent through moving a Dart/Flutter app from transaction-based tracing to span-streaming.

Related: https://github.com/getsentry/sentry-dart/issues/3691

🤖 Generated with [Claude Code](https://claude.com/claude-code)
