### PR TITLE
meta: Add CODEOWNERS for SDK skills

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,28 @@
+# SDK Skills — Mobile
+/skills/sentry-android-sdk/       @getsentry/team-mobile-core
+/skills/sentry-cocoa-sdk/         @getsentry/team-mobile-core
+/skills/sentry-flutter-sdk/       @getsentry/team-mobile-cross-platform
+/skills/sentry-react-native-sdk/  @getsentry/team-mobile-cross-platform
+
+# SDK Skills — JavaScript (Browser)
+/skills/sentry-browser-sdk/       @getsentry/team-javascript-sdks-browser
+
+# SDK Skills — JavaScript (Server)
+/skills/sentry-cloudflare-sdk/    @getsentry/team-javascript-sdks-server
+/skills/sentry-node-sdk/          @getsentry/team-javascript-sdks-server
+
+# SDK Skills — JavaScript (Framework)
+/skills/sentry-nestjs-sdk/        @getsentry/team-javascript-sdks-framework
+/skills/sentry-nextjs-sdk/        @getsentry/team-javascript-sdks-framework
+/skills/sentry-react-sdk/         @getsentry/team-javascript-sdks-framework
+/skills/sentry-react-router-framework-sdk/ @getsentry/team-javascript-sdks-framework
+/skills/sentry-svelte-sdk/        @getsentry/team-javascript-sdks-framework
+/skills/sentry-tanstack-start-sdk/ @getsentry/team-javascript-sdks-framework
+
+# SDK Skills — Web Backend
+/skills/sentry-dotnet-sdk/        @getsentry/team-web-sdk-backend
+/skills/sentry-elixir-sdk/        @getsentry/team-web-sdk-backend
+/skills/sentry-go-sdk/            @getsentry/team-web-sdk-backend
+/skills/sentry-php-sdk/           @getsentry/team-web-sdk-backend
+/skills/sentry-python-sdk/        @getsentry/team-web-sdk-backend
+/skills/sentry-ruby-sdk/          @getsentry/team-web-sdk-backend


### PR DESCRIPTION
Each SDK skill directory is now owned by the GitHub team that maintains the
corresponding SDK repository. This gives the right team automatic review
requests when skill content for their platform changes.

Team mappings follow the same ownership boundaries used in `sentry-javascript`,
`sentry-docs`, and the individual SDK repos: mobile-core for Android/Cocoa,
mobile-cross-platform for Flutter/React Native, the three JavaScript SDK teams
(browser, server, framework) matching `sentry-javascript/.github/CODEOWNERS`,
and web-sdk-backend for the server-side language SDKs.