### PR TITLE
Deprecate root .claude-plugin and .cursor-plugin directories

### DIFF
--- a/.claude-plugin/README.md
+++ b/.claude-plugin/README.md
@@ -1,10 +1,18 @@
-# Claude Code Plugin Metadata
+# Deprecated: this directory is going away
 
-This directory contains Claude Code-specific plugin configuration.
+This `.claude-plugin/` directory exists only for backwards compatibility. The
+Sentry plugin used to be installed directly from the root of this repository, so
+removing these manifests outright would break existing installs the next time
+they pull. This keeps them working in the meantime.
 
-- `plugin.json` - Plugin manifest (name, description, keywords, logo, MCP servers)
-- `marketplace.json` - Marketplace listing for plugin discovery
+**This directory will be removed on or after 2026-07-11.** Do not build anything
+new on top of it.
 
-Shared content (skills, commands) lives at the repo root and is auto-discovered by Claude Code. MCP servers are also defined inline in `plugin.json` for Claude Code.
+The Sentry plugin for Claude Code now lives in its own repository,
+[`getsentry/plugin-claude`](https://github.com/getsentry/plugin-claude), which
+is generated from this repo's skill library. Re-point your marketplace there:
 
-For the plugin specification, see the [Claude Code Plugin Docs](https://code.claude.com/docs/en/plugins-reference).
+```bash
+claude plugin marketplace add getsentry/plugin-claude
+claude plugin install sentry@sentry-plugin-marketplace
+```

--- a/.cursor-plugin/README.md
+++ b/.cursor-plugin/README.md
@@ -1,10 +1,14 @@
-# Cursor Plugin Metadata
+# Deprecated: this directory is going away
 
-This directory contains Cursor-specific plugin configuration.
+This `.cursor-plugin/` directory exists only for backwards compatibility. The
+Sentry plugin used to be installed directly from the root of this repository, so
+removing these manifests outright would break existing installs the next time
+they pull. This keeps them working in the meantime.
 
-- `plugin.json` - Plugin manifest (name, description, keywords, logo)
-- `marketplace.json` - Marketplace listing for plugin discovery
+**This directory will be removed on or after 2026-07-11.** Do not build anything
+new on top of it.
 
-Shared content (skills, commands, MCP config) lives at the repo root and is auto-discovered by Cursor.
-
-For the plugin specification, see the [Cursor Plugin Docs](https://cursor.com/docs/plugins).
+The Sentry plugin for Cursor now lives in its own repository,
+[`getsentry/plugin-cursor`](https://github.com/getsentry/plugin-cursor), which
+is generated from this repo's skill library. Re-point your install there: add
+`getsentry/plugin-cursor` from Cursor Settings > Plugins.


### PR DESCRIPTION
Adds a deprecation notice to the root `.claude-plugin/` and `.cursor-plugin/` READMEs. These directories let the Sentry plugin be installed directly from this repo's root; the per-agent plugins now live in their own generated repositories ([getsentry/plugin-claude](https://github.com/getsentry/plugin-claude), [getsentry/plugin-cursor](https://github.com/getsentry/plugin-cursor)).

We're keeping the root manifests for now so existing installs don't break on a `git pull`, but the READMEs make clear the directories will be **removed on or after 2026-07-11** and point users to the new repos.

Scoped to just the two READMEs, kept separate from the plugin-distribution rework (#158).