### PR TITLE
feat(grok): place plugin.json at .grok-plugin/plugin.json in dist

### DIFF
--- a/plugin-src/grok/build.sh
+++ b/plugin-src/grok/build.sh
@@ -3,8 +3,9 @@
 # build.sh — Build the Grok distribution of the Sentry plugin.
 #
 # Grok plugins put their components at the repo ROOT (skills/, commands/, and a
-# `.mcp.json` file Grok auto-discovers) with an optional root `plugin.json`
-# manifest. Self-install works via a marketplace catalog at
+# `.mcp.json` file Grok auto-discovers). The plugin manifest lives at
+# `.grok-plugin/plugin.json` — that is where the xAI plugin marketplace scanner
+# (generate-plugin-index.py) looks for it. A marketplace catalog also lives at
 # `.grok-plugin/marketplace.json` whose `source: "./"` points back at this same
 # root. This differs from Claude (`.claude-plugin/`) and Codex (`plugins/sentry/`).
 # No skill mutation is needed; skills ship as-authored.
@@ -22,7 +23,7 @@ cd "$REPO_ROOT"
 
 mkdir -p "$TARGET_DIR/.grok-plugin"
 
-cp "$SRC_DIR/plugin.json" "$TARGET_DIR/plugin.json"
+cp "$SRC_DIR/plugin.json" "$TARGET_DIR/.grok-plugin/plugin.json"
 cp "$SRC_DIR/marketplace.json" "$TARGET_DIR/.grok-plugin/marketplace.json"
 rsync -a skills/ "$TARGET_DIR/skills/"
 rsync -a commands/ "$TARGET_DIR/commands/"

--- a/plugin-src/grok/validate.sh
+++ b/plugin-src/grok/validate.sh
@@ -4,9 +4,9 @@
 #
 # Grok has no published JSON Schema. We always run structural checks (the two
 # manifests are valid JSON and the marketplace catalog is present), and when the
-# `grok` CLI is available (local dev) we additionally run its native
-# `grok plugin validate`. CI runners do not have the grok CLI, so the structural
-# checks are the gate there.
+# `grok` CLI is available we additionally run its native `grok plugin validate`.
+# The deploy CI now provisions the grok CLI for every build, so the full validate
+# (including `grok plugin validate`) runs there as well as in local dev.
 #
 # Usage: validate.sh <TARGET_DIR>   (a tree produced by build.sh)
 
@@ -14,7 +14,7 @@ set -euo pipefail
 
 TARGET_DIR="${1:?usage: validate.sh <TARGET_DIR>}"
 
-for f in "$TARGET_DIR/plugin.json" "$TARGET_DIR/.grok-plugin/marketplace.json"; do
+for f in "$TARGET_DIR/.grok-plugin/plugin.json" "$TARGET_DIR/.grok-plugin/marketplace.json"; do
     [ -f "$f" ] || { echo "missing required file: $f" >&2; exit 1; }
     jq empty "$f"
 done


### PR DESCRIPTION
The xAI plugin marketplace scanner (`generate-plugin-index.py`) resolves plugin manifests from `MANIFEST_PATHS = ['.grok-plugin/plugin.json', '.claude-plugin/plugin.json']`. With the manifest sitting at the repo root it was silently ignored — components were still discovered via default paths (skills/, commands/, .mcp.json), but any manifest-level metadata (e.g. the `logo` field pointing at `assets/`) would not have been picked up by the indexer.

This moves the `cp` destination in `build.sh` and updates the presence check in `validate.sh` to match.