### PR TITLE
feat(installer): add CLI to install the Sentry plugin across AI agents

### DIFF
--- a/.github/workflows/smoke-installer.yml
+++ b/.github/workflows/smoke-installer.yml
@@ -1,0 +1,99 @@
+# End-to-end smoke test of the installer across Linux, macOS, and Windows.
+#
+# Installs the real agent CLIs, then runs the installer in non-interactive mode
+# (--no-interactive) so it installs the Sentry plugin for every detected agent
+# without a prompt, and verifies each plugin actually landed.
+#
+# Claude Code, Codex, and Grok ship cross-platform npm CLIs, so they get a real
+# install against their default marketplaces. Cursor has no headless CLI to
+# install in CI, but our Cursor install is only a `git clone` of the public
+# plugin repo into ~/.cursor/plugins/local/sentry — so we put a `cursor` stub on
+# PATH to satisfy detection and verify the real clone (this is what exercises
+# the per-OS path handling, including Windows).
+
+name: Smoke installer
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/installer/**"
+      - ".github/workflows/smoke-installer.yml"
+  pull_request:
+    paths:
+      - "packages/installer/**"
+      - ".github/workflows/smoke-installer.yml"
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  smoke:
+    name: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    env:
+      SENTRY_DSN: "" # don't report CI smoke runs to Sentry
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter @sentry/ai build
+
+      - name: Install Claude Code, Codex, and Grok CLIs
+        run: npm install -g @anthropic-ai/claude-code @openai/codex @xai-official/grok
+
+      - name: Put a Cursor stub on PATH
+        run: |
+          dir="$RUNNER_TEMP/cursor-bin"
+          mkdir -p "$dir"
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            printf '@exit /b 0\r\n' > "$dir/cursor.cmd"
+          else
+            printf '#!/bin/sh\nexit 0\n' > "$dir/cursor"
+            chmod +x "$dir/cursor"
+          fi
+          echo "$dir" >> "$GITHUB_PATH"
+
+      - name: Run installer (non-interactive)
+        # No working-directory: on Windows the bash shell mangles the
+        # backslashes in a `cd` to the workspace path, so run from the root.
+        run: node packages/installer/dist/index.js install --no-interactive
+
+      - name: Verify the Sentry plugin installed for each agent
+        run: |
+          set -euo pipefail
+
+          echo "== claude =="
+          claude plugin list
+          claude plugin list | grep -iq sentry || { echo "claude: sentry plugin missing"; exit 1; }
+
+          echo "== codex =="
+          codex plugin list
+          codex plugin list | grep -iq sentry || { echo "codex: sentry plugin missing"; exit 1; }
+
+          echo "== grok =="
+          grok plugin list
+          grok plugin list | grep -iq sentry || { echo "grok: sentry plugin missing"; exit 1; }
+
+          echo "== cursor =="
+          node -e "const p=require('path').join(require('os').homedir(),'.cursor','plugins','local','sentry'); if(!require('fs').existsSync(p)){console.error('cursor: plugin dir missing at '+p);process.exit(1)} console.log(p)"
+
+          echo "All agents have the Sentry plugin."

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "sentry-for-ai",
+  "private": true,
+  "packageManager": "pnpm@11.0.2",
+  "pnpm": {}
+}

--- a/packages/installer/.gitignore
+++ b/packages/installer/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+dist-bin/
+.node-cache/

--- a/packages/installer/.oxfmtrc.json
+++ b/packages/installer/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "ignorePatterns": []
+}

--- a/packages/installer/README.md
+++ b/packages/installer/README.md
@@ -1,0 +1,51 @@
+# @sentry/ai
+
+Install the [Sentry plugin](https://github.com/getsentry/sentry-for-ai) into your AI coding assistants.
+
+The plugin teaches your assistant Sentry — how to set it up in any project, how to find and fix production issues, and how to configure alerts, AI monitoring, and more. This package detects which assistants you have installed and wires the plugin into each one for you.
+
+Supports **Claude Code**, **Codex**, **Cursor**, and **Grok**.
+
+## Usage
+
+Run it with `npx`, no install required:
+
+```bash
+npx @sentry/ai install
+```
+
+This detects the AI coding tools on your machine, lets you choose which ones to set up, and installs the Sentry plugin into each. Already have it installed? The same command updates it to the latest version.
+
+Restart your AI tools afterward to load the plugin.
+
+## Options
+
+```bash
+npx @sentry/ai install                  # interactive — pick which agents to set up
+npx @sentry/ai install --no-interactive # install into every detected agent
+```
+
+The non-interactive mode is intended for CI and unattended runs.
+
+## What it installs
+
+For each detected assistant, the installer runs that tool's native plugin command:
+
+| Assistant   | How it's installed                                                            |
+| ----------- | ----------------------------------------------------------------------------- |
+| Claude Code | `claude plugin install sentry` from the official plugin marketplace           |
+| Codex       | `codex plugin add sentry` from the Sentry plugin marketplace                  |
+| Cursor      | Clones [`getsentry/plugin-cursor`](https://github.com/getsentry/plugin-cursor) into `~/.cursor/plugins/local/sentry` |
+| Grok        | `grok plugin install getsentry/plugin-grok`                                   |
+
+Each per-agent plugin is built and published from the [`sentry-for-ai`](https://github.com/getsentry/sentry-for-ai) repository, which is the source of truth for all skills and commands.
+
+## Requirements
+
+- Node.js 18 or newer
+- The assistant CLI you want to set up must already be installed and on your `PATH`
+- `git` is required for the Cursor install
+
+## License
+
+MIT

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@sentry/ai",
+  "version": "0.1.0",
+  "description": "Install the Sentry plugin for your AI coding assistants",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/getsentry/sentry-for-ai.git",
+    "directory": "packages/installer"
+  },
+  "homepage": "https://github.com/getsentry/sentry-for-ai#readme",
+  "author": "Sentry",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "bin": {
+    "sentry-ai": "dist/index.js"
+  },
+  "scripts": {
+    "build": "rolldown --config rolldown.config.mjs",
+    "dev": "ts-node src/index.ts",
+    "test": "vitest run",
+    "format": "oxfmt --write src",
+    "format:check": "oxfmt --check src"
+  },
+  "dependencies": {
+    "@inquirer/prompts": "^8.5.2",
+    "@listr2/prompt-adapter-inquirer": "^4.2.4",
+    "@sentry/node": "^10.57.0",
+    "citty": "^0.1.6",
+    "listr2": "^10.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "oxfmt": "^0.54.0",
+    "rolldown": "^1.1.1",
+    "ts-node": "^10.9.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16",
+    "vitest": "^4.1.8"
+  }
+}

--- a/packages/installer/rolldown.config.mjs
+++ b/packages/installer/rolldown.config.mjs
@@ -1,0 +1,20 @@
+import { isAbsolute } from "node:path";
+import { defineConfig } from "rolldown";
+
+export default defineConfig({
+  input: "src/index.ts",
+  platform: "node",
+  resolve: {
+    conditionNames: ["node", "require"],
+  },
+  output: {
+    file: "dist/index.js",
+    format: "cjs",
+    banner: "#!/usr/bin/env node",
+  },
+  // Keep dependencies and node builtins as bare runtime requires; only bundle
+  // our own source. Matching node_modules by resolved path instead bakes
+  // absolute build-machine paths into the output — non-portable when published,
+  // and the backslashes make it fail outright on Windows.
+  external: (id) => !id.startsWith(".") && !isAbsolute(id),
+});

--- a/packages/installer/src/__tests__/fake-harness.ts
+++ b/packages/installer/src/__tests__/fake-harness.ts
@@ -1,0 +1,28 @@
+import { vi } from "vitest";
+import type { Harness, InstallOutcome, InstallReadiness } from "../harnesses/types";
+
+export interface FakeHarnessOptions {
+  id: string;
+  name?: string;
+  detected?: boolean;
+  installed?: boolean;
+  readiness?: InstallReadiness;
+  outcome?: InstallOutcome;
+  error?: Error;
+}
+
+export function fakeHarness(options: FakeHarnessOptions): Harness {
+  return {
+    id: options.id,
+    name: options.name ?? options.id,
+    detect: vi.fn(async () => options.detected ?? false),
+    isInstalled: vi.fn(async () => options.installed ?? false),
+    canInstall: vi.fn(async () => options.readiness ?? { ok: true }),
+    install: vi.fn(async () => {
+      if (options.error) {
+        throw options.error;
+      }
+      return options.outcome ?? { kind: "done", command: `${options.id} install` };
+    }),
+  };
+}

--- a/packages/installer/src/__tests__/fake-system.ts
+++ b/packages/installer/src/__tests__/fake-system.ts
@@ -1,0 +1,21 @@
+import { vi } from "vitest";
+import type { ShellResult, SystemDeps } from "../system";
+
+export interface FakeSystemOptions {
+  run?: (command: string) => ShellResult;
+  existing?: string[];
+  platform?: NodeJS.Platform;
+  homedir?: string;
+}
+
+export function fakeSystem(options: FakeSystemOptions = {}): SystemDeps {
+  const existing = new Set(options.existing ?? []);
+  const run = options.run ?? (() => ({ ok: true }));
+
+  return {
+    run: vi.fn(async (command: string) => run(command)),
+    exists: vi.fn((path: string) => existing.has(path)),
+    platform: options.platform ?? "linux",
+    homedir: options.homedir ?? "/home/user",
+  };
+}

--- a/packages/installer/src/__tests__/harnesses.test.ts
+++ b/packages/installer/src/__tests__/harnesses.test.ts
@@ -1,0 +1,298 @@
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { ShellResult } from "../system";
+import { createClaude } from "../harnesses/claude";
+import { createCodex } from "../harnesses/codex";
+import { createCursor } from "../harnesses/cursor";
+import { createGrok } from "../harnesses/grok";
+import { fakeSystem } from "./fake-system";
+
+const ok: ShellResult = { ok: true };
+const notFound: ShellResult = { ok: false, message: "not found" };
+
+describe("claude harness", () => {
+  it("detects when the claude binary is on PATH", async () => {
+    const harness = createClaude(fakeSystem({ run: () => ok }));
+    expect(await harness.detect()).toBe(true);
+  });
+
+  it("does not detect when which fails", async () => {
+    const harness = createClaude(fakeSystem({ run: () => notFound }));
+    expect(await harness.detect()).toBe(false);
+  });
+
+  it("reports installed when plugin list includes sentry", async () => {
+    const harness = createClaude(fakeSystem({ run: () => ({ ok: true, stdout: "sentry" }) }));
+    expect(await harness.isInstalled()).toBe(true);
+  });
+
+  it("reports not installed when plugin list does not include sentry", async () => {
+    const harness = createClaude(fakeSystem({ run: () => ({ ok: true, stdout: "other-plugin" }) }));
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("is always ready to install", async () => {
+    const harness = createClaude(fakeSystem({ run: () => ok }));
+    expect(await harness.canInstall()).toEqual({ ok: true });
+  });
+
+  it("installs by running the marketplace install command", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createClaude(system).install();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "claude plugin install sentry@claude-plugins-official",
+    });
+    expect(system.run).toHaveBeenCalledWith("claude plugin install sentry@claude-plugins-official");
+  });
+
+  it("adds the official marketplace when it is not registered", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (cmd.includes("marketplace list") ? { ok: true, stdout: "" } : ok),
+    });
+    await createClaude(system).install();
+    expect(system.run).toHaveBeenCalledWith(
+      "claude plugin marketplace add anthropics/claude-plugins-official",
+    );
+  });
+
+  it("refreshes the marketplace when it is already registered", async () => {
+    const system = fakeSystem({
+      run: (cmd) =>
+        cmd.includes("marketplace list") ? { ok: true, stdout: "claude-plugins-official" } : ok,
+    });
+    await createClaude(system).install();
+    expect(system.run).toHaveBeenCalledWith(
+      "claude plugin marketplace update claude-plugins-official",
+    );
+  });
+
+  it("updates in place when the plugin is already present", async () => {
+    const system = fakeSystem({
+      run: () => ({ ok: true, stdout: "sentry@claude-plugins-official" }),
+    });
+    const outcome = await createClaude(system).install();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "claude plugin update sentry@claude-plugins-official",
+    });
+    expect(system.run).toHaveBeenCalledWith("claude plugin update sentry@claude-plugins-official");
+  });
+
+  it("surfaces stderr when install fails", async () => {
+    const harness = createClaude(
+      fakeSystem({ run: () => ({ ok: false, stderr: "boom", message: "exit 1" }) }),
+    );
+    await expect(harness.install()).rejects.toThrow("boom");
+  });
+
+  it("falls back to the error message when stderr is empty", async () => {
+    const harness = createClaude(fakeSystem({ run: () => ({ ok: false, message: "exit 1" }) }));
+    await expect(harness.install()).rejects.toThrow("exit 1");
+  });
+});
+
+describe("codex harness", () => {
+  it("detects via which", async () => {
+    const harness = createCodex(fakeSystem({ run: () => ok }));
+    expect(await harness.detect()).toBe(true);
+  });
+
+  it("does not detect when which fails", async () => {
+    const harness = createCodex(fakeSystem({ run: () => notFound }));
+    expect(await harness.detect()).toBe(false);
+  });
+
+  it("reports installed when plugin list includes sentry", async () => {
+    const harness = createCodex(fakeSystem({ run: () => ({ ok: true, stdout: "sentry" }) }));
+    expect(await harness.isInstalled()).toBe(true);
+  });
+
+  it("reports not installed when plugin list does not include sentry", async () => {
+    const harness = createCodex(fakeSystem({ run: () => ({ ok: true, stdout: "other-plugin" }) }));
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("installs the plugin from its marketplace", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createCodex(system).install();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "codex plugin add sentry@sentry-plugin-marketplace",
+    });
+    expect(system.run).toHaveBeenCalledWith("codex plugin add sentry@sentry-plugin-marketplace");
+  });
+
+  it("adds the marketplace when it is not registered", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (cmd.includes("marketplace list") ? { ok: true, stdout: "" } : ok),
+    });
+    await createCodex(system).install();
+    expect(system.run).toHaveBeenCalledWith("codex plugin marketplace add getsentry/plugin-codex");
+  });
+
+  it("refreshes the marketplace when it is already registered", async () => {
+    const system = fakeSystem({
+      run: (cmd) =>
+        cmd.includes("marketplace list") ? { ok: true, stdout: "sentry-plugin-marketplace" } : ok,
+    });
+    await createCodex(system).install();
+    expect(system.run).toHaveBeenCalledWith(
+      "codex plugin marketplace upgrade sentry-plugin-marketplace",
+    );
+  });
+
+  it("throws when the install fails", async () => {
+    const harness = createCodex(fakeSystem({ run: () => ({ ok: false, stderr: "nope" }) }));
+    await expect(harness.install()).rejects.toThrow("nope");
+  });
+});
+
+describe("grok harness", () => {
+  it("detects via which", async () => {
+    const harness = createGrok(fakeSystem({ run: () => ok }));
+    expect(await harness.detect()).toBe(true);
+  });
+
+  it("does not detect when which fails", async () => {
+    const harness = createGrok(fakeSystem({ run: () => notFound }));
+    expect(await harness.detect()).toBe(false);
+  });
+
+  it("reports installed when plugin list includes sentry", async () => {
+    const harness = createGrok(fakeSystem({ run: () => ({ ok: true, stdout: "sentry" }) }));
+    expect(await harness.isInstalled()).toBe(true);
+  });
+
+  it("reports not installed when plugin list does not include sentry", async () => {
+    const harness = createGrok(fakeSystem({ run: () => ({ ok: true, stdout: "other-plugin" }) }));
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("installs with the --trust flag when not yet present", async () => {
+    const system = fakeSystem({ run: () => ok });
+    await createGrok(system).install();
+    expect(system.run).toHaveBeenCalledWith("grok plugin install getsentry/plugin-grok --trust");
+  });
+
+  it("updates in place when the plugin is already present", async () => {
+    const system = fakeSystem({ run: () => ({ ok: true, stdout: "plugin-grok-x: sentry" }) });
+    const outcome = await createGrok(system).install();
+
+    expect(outcome).toMatchObject({ kind: "done", command: "grok plugin update sentry" });
+    expect(system.run).toHaveBeenCalledWith("grok plugin update sentry");
+  });
+
+  it("throws when the install fails", async () => {
+    const harness = createGrok(fakeSystem({ run: () => ({ ok: false, stderr: "nope" }) }));
+    await expect(harness.install()).rejects.toThrow("nope");
+  });
+});
+
+describe("cursor harness", () => {
+  it("detects when the cursor binary is on PATH", async () => {
+    const harness = createCursor(fakeSystem({ run: () => ok }));
+    expect(await harness.detect()).toBe(true);
+  });
+
+  it("uses where instead of which on Windows to detect the binary", async () => {
+    const system = fakeSystem({ run: () => ok, platform: "win32" });
+    await createCursor(system).detect();
+    expect(system.run).toHaveBeenCalledWith("where cursor");
+  });
+
+  it("detects via the macOS app bundle when the binary is missing", async () => {
+    const harness = createCursor(
+      fakeSystem({
+        run: () => notFound,
+        platform: "darwin",
+        existing: ["/Applications/Cursor.app"],
+      }),
+    );
+    expect(await harness.detect()).toBe(true);
+  });
+
+  it("detects via the Windows install location when the binary is missing", async () => {
+    const homedir = "C:\\Users\\user";
+    // Derive via join so the expectation matches regardless of host OS separator.
+    const exe = join(homedir, "AppData", "Local", "Programs", "cursor", "Cursor.exe");
+    const harness = createCursor(
+      fakeSystem({ run: () => notFound, platform: "win32", homedir, existing: [exe] }),
+    );
+    expect(await harness.detect()).toBe(true);
+  });
+
+  it("does not detect the app bundle on Linux (relies on PATH)", async () => {
+    const harness = createCursor(
+      fakeSystem({
+        run: () => notFound,
+        platform: "linux",
+        existing: ["/Applications/Cursor.app"],
+      }),
+    );
+    expect(await harness.detect()).toBe(false);
+  });
+
+  it("does not detect when neither binary nor app bundle exists", async () => {
+    const harness = createCursor(fakeSystem({ run: () => notFound, platform: "darwin" }));
+    expect(await harness.detect()).toBe(false);
+  });
+
+  it("reports installed when the plugin directory exists", async () => {
+    const target = "/home/user/.cursor/plugins/local/sentry";
+    const harness = createCursor(fakeSystem({ homedir: "/home/user", existing: [target] }));
+    expect(await harness.isInstalled()).toBe(true);
+  });
+
+  it("reports not installed when the plugin directory is absent", async () => {
+    const harness = createCursor(fakeSystem({ homedir: "/home/user" }));
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("can install when git is available", async () => {
+    const harness = createCursor(fakeSystem({ run: () => ok }));
+    expect(await harness.canInstall()).toEqual({ ok: true });
+  });
+
+  it("cannot install when git is missing", async () => {
+    const harness = createCursor(fakeSystem({ run: () => notFound }));
+    const readiness = await harness.canInstall();
+
+    expect(readiness.ok).toBe(false);
+    if (!readiness.ok) {
+      expect(readiness.reason).toContain("git");
+    }
+  });
+
+  it("clones the plugin repo when the target directory does not exist", async () => {
+    const system = fakeSystem({ homedir: "/home/user" });
+    const outcome = await createCursor(system).install();
+
+    expect(outcome.kind).toBe("done");
+    expect(system.run).toHaveBeenCalledWith(
+      'git clone https://github.com/getsentry/plugin-cursor.git "/home/user/.cursor/plugins/local/sentry"',
+    );
+  });
+
+  it("pulls when the target directory already exists", async () => {
+    const target = "/home/user/.cursor/plugins/local/sentry";
+    const system = fakeSystem({ homedir: "/home/user", existing: [target] });
+    const outcome = await createCursor(system).install();
+
+    expect(outcome.kind).toBe("done");
+    expect(system.run).toHaveBeenCalledWith(`git -C "${target}" pull`);
+  });
+
+  it("includes a restart note in the done outcome", async () => {
+    const system = fakeSystem({ homedir: "/home/user" });
+    const outcome = await createCursor(system).install();
+
+    expect(outcome.kind).toBe("done");
+    if (outcome.kind === "done") {
+      expect(outcome.note).toContain("Restart Cursor");
+    }
+  });
+});

--- a/packages/installer/src/__tests__/run.test.ts
+++ b/packages/installer/src/__tests__/run.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { detectHarnesses, installHarness, installSucceeded } from "../run";
+import { fakeHarness } from "./fake-harness";
+
+describe("detectHarnesses", () => {
+  it("surfaces detected and installed state for each harness", async () => {
+    const claude = fakeHarness({ id: "claude", detected: true, installed: true });
+    const codex = fakeHarness({ id: "codex", detected: true, installed: false });
+    const grok = fakeHarness({ id: "grok", detected: false });
+
+    const detections = await detectHarnesses([claude, codex, grok]);
+
+    expect(detections).toEqual([
+      { harness: claude, detected: true, installed: true },
+      { harness: codex, detected: true, installed: false },
+      { harness: grok, detected: false, installed: false },
+    ]);
+  });
+
+  it("skips the installed probe when a harness is not detected", async () => {
+    const grok = fakeHarness({ id: "grok", detected: false });
+
+    await detectHarnesses([grok]);
+
+    expect(grok.detect).toHaveBeenCalledOnce();
+    expect(grok.isInstalled).not.toHaveBeenCalled();
+  });
+});
+
+describe("installHarness", () => {
+  it("returns a done result with the executed command", async () => {
+    const claude = fakeHarness({ id: "claude" });
+
+    const result = await installHarness({ harness: claude, detected: true, installed: false });
+
+    expect(result).toEqual({ kind: "done", command: "claude install", note: undefined });
+    expect(claude.install).toHaveBeenCalledOnce();
+  });
+
+  it("passes the note through on a done outcome", async () => {
+    const cursor = fakeHarness({
+      id: "cursor",
+      outcome: { kind: "done", command: "git clone", note: "Restart Cursor to activate." },
+    });
+
+    const result = await installHarness({ harness: cursor, detected: true, installed: false });
+
+    expect(result).toEqual({
+      kind: "done",
+      command: "git clone",
+      note: "Restart Cursor to activate.",
+    });
+  });
+
+  it("passes through a manual outcome", async () => {
+    const cursor = fakeHarness({
+      id: "cursor",
+      outcome: { kind: "manual", instructions: "do it by hand" },
+    });
+
+    const result = await installHarness({ harness: cursor, detected: true, installed: false });
+
+    expect(result).toEqual({ kind: "manual", instructions: "do it by hand" });
+  });
+
+  it("blocks before install when a prerequisite is missing", async () => {
+    const cursor = fakeHarness({
+      id: "cursor",
+      readiness: { ok: false, reason: "git is required" },
+    });
+
+    const result = await installHarness({ harness: cursor, detected: true, installed: false });
+
+    expect(result).toEqual({ kind: "blocked", reason: "git is required" });
+    expect(cursor.install).not.toHaveBeenCalled();
+  });
+
+  it("captures a thrown install as a failed result", async () => {
+    const claude = fakeHarness({ id: "claude", error: new Error("boom") });
+
+    const result = await installHarness({ harness: claude, detected: true, installed: false });
+
+    expect(result).toEqual({ kind: "failed", message: "boom" });
+  });
+});
+
+describe("installSucceeded", () => {
+  it("treats done and manual as success, blocked and failed as failure", () => {
+    expect(installSucceeded({ kind: "done", command: "x" })).toBe(true);
+    expect(installSucceeded({ kind: "manual", instructions: "x" })).toBe(true);
+    expect(installSucceeded({ kind: "blocked", reason: "x" })).toBe(false);
+    expect(installSucceeded({ kind: "failed", message: "x" })).toBe(false);
+  });
+});

--- a/packages/installer/src/__tests__/ui.test.ts
+++ b/packages/installer/src/__tests__/ui.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import { runInstaller } from "../ui";
+import { fakeHarness } from "./fake-harness";
+
+// These cover the non-interactive path, which skips the prompt and installs
+// every detected agent. The interactive selector is exercised manually.
+describe("runInstaller (non-interactive)", () => {
+  it("installs every detected agent and leaves the rest alone", async () => {
+    const claude = fakeHarness({ id: "claude", detected: true });
+    const codex = fakeHarness({ id: "codex", detected: false });
+    const grok = fakeHarness({ id: "grok", detected: true });
+
+    const ok = await runInstaller([claude, codex, grok], { interactive: false });
+
+    expect(ok).toBe(true);
+    expect(claude.install).toHaveBeenCalledOnce();
+    expect(grok.install).toHaveBeenCalledOnce();
+    expect(codex.install).not.toHaveBeenCalled();
+  });
+
+  it("returns false when an install fails but still installs the others", async () => {
+    const claude = fakeHarness({ id: "claude", detected: true, error: new Error("boom") });
+    const codex = fakeHarness({ id: "codex", detected: true });
+
+    const ok = await runInstaller([claude, codex], { interactive: false });
+
+    expect(ok).toBe(false);
+    expect(codex.install).toHaveBeenCalledOnce();
+  });
+
+  it("returns false when a prerequisite blocks an install", async () => {
+    const cursor = fakeHarness({
+      id: "cursor",
+      detected: true,
+      readiness: { ok: false, reason: "git is required" },
+    });
+    const codex = fakeHarness({ id: "codex", detected: true });
+
+    const ok = await runInstaller([cursor, codex], { interactive: false });
+
+    expect(ok).toBe(false);
+    expect(cursor.install).not.toHaveBeenCalled();
+    expect(codex.install).toHaveBeenCalledOnce();
+  });
+
+  it("succeeds without installing anything when nothing is detected", async () => {
+    const claude = fakeHarness({ id: "claude", detected: false });
+
+    const ok = await runInstaller([claude], { interactive: false });
+
+    expect(ok).toBe(true);
+    expect(claude.install).not.toHaveBeenCalled();
+  });
+
+  it("runs installs concurrently rather than one after another", async () => {
+    let active = 0;
+    let peak = 0;
+    const slowInstall = vi.fn(async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      active -= 1;
+      return { kind: "done" as const, command: "ok" };
+    });
+
+    const harnesses = ["a", "b", "c"].map((id) => {
+      const harness = fakeHarness({ id, detected: true });
+      harness.install = slowInstall;
+      return harness;
+    });
+
+    const ok = await runInstaller(harnesses, { interactive: false });
+
+    expect(ok).toBe(true);
+    expect(peak).toBeGreaterThan(1);
+  });
+});

--- a/packages/installer/src/harnesses/claude.ts
+++ b/packages/installer/src/harnesses/claude.ts
@@ -1,0 +1,46 @@
+import { realSystem, type SystemDeps } from "../system";
+import type { Harness } from "./types";
+import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
+
+const MARKETPLACE = "claude-plugins-official";
+const MARKETPLACE_SOURCE = "anthropics/claude-plugins-official";
+const INSTALL_COMMAND = `claude plugin install sentry@${MARKETPLACE}`;
+const UPDATE_COMMAND = `claude plugin update sentry@${MARKETPLACE}`;
+
+export function createClaude(system: SystemDeps): Harness {
+  return {
+    id: "claude",
+    name: "Claude Code",
+
+    detect: async () => detectOnPath(system, "claude"),
+
+    isInstalled: async () => outputIncludes(system, "claude plugin list", "sentry"),
+
+    canInstall: async () => ({ ok: true }),
+
+    install: async () => {
+      // A fresh CLI has no marketplaces registered, so register the official one
+      // if it is missing; otherwise refresh its index so the plugin resolves.
+      const registered = await outputIncludes(
+        system,
+        "claude plugin marketplace list",
+        MARKETPLACE,
+      );
+      await runInstallCommand(
+        system,
+        registered
+          ? `claude plugin marketplace update ${MARKETPLACE}`
+          : `claude plugin marketplace add ${MARKETPLACE_SOURCE}`,
+      );
+
+      const command = (await outputIncludes(system, "claude plugin list", "sentry"))
+        ? UPDATE_COMMAND
+        : INSTALL_COMMAND;
+
+      await runInstallCommand(system, command);
+      return { kind: "done", command };
+    },
+  };
+}
+
+export const claude = createClaude(realSystem);

--- a/packages/installer/src/harnesses/codex.ts
+++ b/packages/installer/src/harnesses/codex.ts
@@ -1,0 +1,45 @@
+import { realSystem, type SystemDeps } from "../system";
+import type { Harness } from "./types";
+import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
+
+// TODO: Codex is the only agent we install from our OWN marketplace
+// (getsentry/plugin-codex) rather than the agent vendor's official marketplace
+// like Claude (claude-plugins-official) and Grok (xai-official). That repo
+// vendors a copy of the skill files, so every plugin update means regenerating
+// and republishing the vendored marketplace. Move Codex onto an official
+// marketplace once one is available so updates flow without re-vendoring.
+const MARKETPLACE = "sentry-plugin-marketplace";
+const MARKETPLACE_SOURCE = "getsentry/plugin-codex";
+const INSTALL_COMMAND = `codex plugin add sentry@${MARKETPLACE}`;
+
+export function createCodex(system: SystemDeps): Harness {
+  return {
+    id: "codex",
+    name: "Codex",
+
+    detect: async () => detectOnPath(system, "codex"),
+
+    isInstalled: async () => outputIncludes(system, "codex plugin list", "sentry"),
+
+    canInstall: async () => ({ ok: true }),
+
+    install: async () => {
+      // The Sentry plugin lives in its own marketplace, not a Codex default, so
+      // register it if missing; otherwise refresh its snapshot so it resolves.
+      const registered = await outputIncludes(system, "codex plugin marketplace list", MARKETPLACE);
+      await runInstallCommand(
+        system,
+        registered
+          ? `codex plugin marketplace upgrade ${MARKETPLACE}`
+          : `codex plugin marketplace add ${MARKETPLACE_SOURCE}`,
+      );
+
+      // Codex has no plugin update command; `add` is idempotent and re-points an
+      // already-installed plugin at the refreshed snapshot.
+      await runInstallCommand(system, INSTALL_COMMAND);
+      return { kind: "done", command: INSTALL_COMMAND };
+    },
+  };
+}
+
+export const codex = createCodex(realSystem);

--- a/packages/installer/src/harnesses/cursor.ts
+++ b/packages/installer/src/harnesses/cursor.ts
@@ -1,0 +1,62 @@
+import { join } from "node:path";
+import { realSystem, type SystemDeps } from "../system";
+import type { Harness, InstallOutcome } from "./types";
+import { detectOnPath, runInstallCommand } from "./shell";
+
+const PLUGIN_REPO = "https://github.com/getsentry/plugin-cursor.git";
+const RESTART_NOTE = 'Restart Cursor or run "Developer: Reload Window" to activate the plugin.';
+
+function pluginDir(system: SystemDeps): string {
+  return join(system.homedir, ".cursor", "plugins", "local", "sentry");
+}
+
+// Where the Cursor app installs by default, for platforms where the `cursor`
+// CLI shim is not reliably on PATH. Linux has no single canonical location, so
+// it relies on the CLI being on PATH.
+function appLocations(system: SystemDeps): string[] {
+  if (system.platform === "darwin") {
+    return ["/Applications/Cursor.app"];
+  }
+
+  if (system.platform === "win32") {
+    return [join(system.homedir, "AppData", "Local", "Programs", "cursor", "Cursor.exe")];
+  }
+
+  return [];
+}
+
+export function createCursor(system: SystemDeps): Harness {
+  return {
+    id: "cursor",
+    name: "Cursor",
+
+    detect: async () => {
+      if (await detectOnPath(system, "cursor")) {
+        return true;
+      }
+
+      return appLocations(system).some((path) => system.exists(path));
+    },
+
+    isInstalled: async () => system.exists(pluginDir(system)),
+
+    canInstall: async () =>
+      (await detectOnPath(system, "git"))
+        ? { ok: true }
+        : { ok: false, reason: "git is required to clone the Cursor plugin" },
+
+    install: async (): Promise<InstallOutcome> => {
+      const target = pluginDir(system);
+
+      // Quote the target: Windows home paths routinely contain spaces.
+      const command = system.exists(target)
+        ? `git -C "${target}" pull`
+        : `git clone ${PLUGIN_REPO} "${target}"`;
+
+      await runInstallCommand(system, command);
+      return { kind: "done", command, note: RESTART_NOTE };
+    },
+  };
+}
+
+export const cursor = createCursor(realSystem);

--- a/packages/installer/src/harnesses/grok.ts
+++ b/packages/installer/src/harnesses/grok.ts
@@ -1,0 +1,39 @@
+import { realSystem, type SystemDeps } from "../system";
+import type { Harness } from "./types";
+import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
+
+// Grok has no headless install-by-name; its marketplace install is TUI-only. So
+// we install from the plugin repo directly — the exact source grok's built-in
+// "xai-official" marketplace catalogs for sentry. Hence a MARKETPLACE_SOURCE (the
+// repo) but no MARKETPLACE registration step.
+// TODO: install sentry by name from the official "xai-official" marketplace once
+// grok exposes a headless command for it (today that is TUI-only).
+const MARKETPLACE_SOURCE = "getsentry/plugin-grok";
+const INSTALL_COMMAND = `grok plugin install ${MARKETPLACE_SOURCE} --trust`;
+const UPDATE_COMMAND = "grok plugin update sentry";
+
+export function createGrok(system: SystemDeps): Harness {
+  return {
+    id: "grok",
+    name: "Grok",
+
+    detect: async () => detectOnPath(system, "grok"),
+
+    isInstalled: async () => outputIncludes(system, "grok plugin list", "sentry"),
+
+    canInstall: async () => ({ ok: true }),
+
+    install: async () => {
+      // `grok plugin install` errors on an already-installed repo, so update
+      // in place when the plugin is already present.
+      const command = (await outputIncludes(system, "grok plugin list", "sentry"))
+        ? UPDATE_COMMAND
+        : INSTALL_COMMAND;
+
+      await runInstallCommand(system, command);
+      return { kind: "done", command };
+    },
+  };
+}
+
+export const grok = createGrok(realSystem);

--- a/packages/installer/src/harnesses/index.ts
+++ b/packages/installer/src/harnesses/index.ts
@@ -1,0 +1,9 @@
+import { claude, createClaude } from "./claude";
+import { codex, createCodex } from "./codex";
+import { cursor, createCursor } from "./cursor";
+import { grok, createGrok } from "./grok";
+
+export type { Harness, InstallOutcome } from "./types";
+export { createClaude, createCodex, createCursor, createGrok };
+
+export const harnesses = [claude, codex, cursor, grok];

--- a/packages/installer/src/harnesses/shell.ts
+++ b/packages/installer/src/harnesses/shell.ts
@@ -1,0 +1,27 @@
+import type { SystemDeps } from "../system";
+
+export async function detectOnPath(system: SystemDeps, binary: string): Promise<boolean> {
+  const locator = system.platform === "win32" ? "where" : "which";
+  return (await system.run(`${locator} ${binary}`)).ok;
+}
+
+export async function runInstallCommand(system: SystemDeps, command: string): Promise<void> {
+  const result = await system.run(command);
+
+  if (result.ok) {
+    return;
+  }
+
+  throw new Error(result.stderr || result.message || `Command failed: ${command}`);
+}
+
+// True when `command` succeeds and its output contains `needle` (case-insensitive).
+// Used to probe plugin/marketplace listings for an already-present entry.
+export async function outputIncludes(
+  system: SystemDeps,
+  command: string,
+  needle: string,
+): Promise<boolean> {
+  const result = await system.run(command);
+  return result.ok && (result.stdout?.toLowerCase().includes(needle) ?? false);
+}

--- a/packages/installer/src/harnesses/types.ts
+++ b/packages/installer/src/harnesses/types.ts
@@ -1,0 +1,14 @@
+export type InstallOutcome =
+  | { kind: "done"; command: string; note?: string }
+  | { kind: "manual"; instructions: string };
+
+export type InstallReadiness = { ok: true } | { ok: false; reason: string };
+
+export interface Harness {
+  readonly id: string;
+  readonly name: string;
+  detect(): Promise<boolean>;
+  isInstalled(): Promise<boolean>;
+  canInstall(): Promise<InstallReadiness>;
+  install(): Promise<InstallOutcome>;
+}

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -1,0 +1,65 @@
+import "./instrument";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { defineCommand, runMain } from "citty";
+import { harnesses } from "./harnesses";
+import { runInstaller } from "./ui";
+
+const { version, description } = JSON.parse(
+  readFileSync(join(__dirname, "../package.json"), "utf8"),
+) as { version: string; description: string };
+
+const install = defineCommand({
+  meta: {
+    name: "install",
+    description: "Install the Sentry plugin into your detected AI coding assistants",
+  },
+  args: {
+    // citty turns `--no-interactive` into `interactive: false` via its built-in
+    // boolean negation, so the flag is modeled as `interactive` (default true)
+    // rather than a separate `no-interactive` arg.
+    interactive: {
+      type: "boolean",
+      description: "Prompt to select agents; pass --no-interactive to install every detected agent",
+      default: true,
+    },
+    yes: {
+      type: "boolean",
+      alias: "y",
+      description: "Alias for --no-interactive",
+      default: false,
+    },
+  },
+  async run({ args }) {
+    const interactive = args.interactive && !args.yes;
+    const ok = await runInstaller(harnesses, { interactive });
+    process.exit(ok ? 0 : 1);
+  },
+});
+
+const main = defineCommand({
+  meta: {
+    name: "sentry-ai",
+    version,
+    description,
+  },
+  subCommands: {
+    install,
+  },
+});
+
+const SUBCOMMANDS = new Set(["install"]);
+const PASSTHROUGH = new Set(["--help", "-h", "--version"]);
+
+// citty has no concept of a default subcommand, so `npx @sentry/ai` with no
+// arguments would just print the help menu. Default to `install` instead unless
+// the user gave an explicit subcommand or asked for help/version.
+function withDefaultCommand(argv: string[]): string[] {
+  const [first] = argv;
+  if (first !== undefined && (SUBCOMMANDS.has(first) || PASSTHROUGH.has(first))) {
+    return argv;
+  }
+  return ["install", ...argv];
+}
+
+runMain(main, { rawArgs: withDefaultCommand(process.argv.slice(2)) });

--- a/packages/installer/src/instrument.ts
+++ b/packages/installer/src/instrument.ts
@@ -1,0 +1,14 @@
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn:
+    process.env.SENTRY_DSN ??
+    "https://229b213cf5670aeb117d4de56ba6814e@o1.ingest.us.sentry.io/4511570959335425",
+
+  tracesSampleRate: 1.0,
+});
+
+process.on("SIGTERM", async () => {
+  await Sentry.close(2000);
+  process.exit(0);
+});

--- a/packages/installer/src/run.ts
+++ b/packages/installer/src/run.ts
@@ -1,0 +1,50 @@
+import type { Harness } from "./harnesses/types";
+
+export interface Detection {
+  harness: Harness;
+  detected: boolean;
+  installed: boolean;
+}
+
+// The outcome of installing a single harness. `done`/`manual` are successes;
+// `blocked`/`failed` are failures the caller surfaces and counts toward a
+// non-zero exit. installHarness never throws — every path maps to one of these.
+export type InstallResult =
+  | { kind: "done"; command: string; note?: string }
+  | { kind: "manual"; instructions: string }
+  | { kind: "blocked"; reason: string }
+  | { kind: "failed"; message: string };
+
+// Probe every harness concurrently. isInstalled is only meaningful once a
+// harness is on the PATH, so it is skipped entirely when detection fails.
+export async function detectHarnesses(harnesses: Harness[]): Promise<Detection[]> {
+  return Promise.all(
+    harnesses.map(async (harness) => {
+      const detected = await harness.detect();
+      const installed = detected ? await harness.isInstalled() : false;
+      return { harness, detected, installed };
+    }),
+  );
+}
+
+// Install (or reinstall) a single harness. A blocked prerequisite short-circuits
+// before install runs; a thrown install is captured as a `failed` result so a
+// concurrent batch can keep going instead of rejecting the whole run.
+export async function installHarness(detection: Detection): Promise<InstallResult> {
+  const readiness = await detection.harness.canInstall();
+  if (!readiness.ok) {
+    return { kind: "blocked", reason: readiness.reason };
+  }
+
+  try {
+    // InstallOutcome (done | manual) is a subset of InstallResult, so a clean
+    // install passes straight through; only blocked/failed are added here.
+    return await detection.harness.install();
+  } catch (err) {
+    return { kind: "failed", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export function installSucceeded(result: InstallResult): boolean {
+  return result.kind === "done" || result.kind === "manual";
+}

--- a/packages/installer/src/system.ts
+++ b/packages/installer/src/system.ts
@@ -1,0 +1,41 @@
+import { exec } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+
+const execAsync = promisify(exec);
+
+export interface ShellResult {
+  ok: boolean;
+  stdout?: string;
+  stderr?: string;
+  message?: string;
+}
+
+export interface SystemDeps {
+  // Async so the event loop stays free while a command runs — this is what lets
+  // the spinner animate and concurrent installs actually overlap.
+  run(command: string): Promise<ShellResult>;
+  exists(path: string): boolean;
+  platform: NodeJS.Platform;
+  homedir: string;
+}
+
+export const realSystem: SystemDeps = {
+  async run(command) {
+    try {
+      const { stdout } = await execAsync(command, { encoding: "utf8" });
+      return { ok: true, stdout: stdout.trim() };
+    } catch (err: any) {
+      return {
+        ok: false,
+        stdout: err.stdout?.toString().trim(),
+        stderr: err.stderr?.toString().trim(),
+        message: err.message,
+      };
+    }
+  },
+  exists: existsSync,
+  platform: process.platform,
+  homedir: homedir(),
+};

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -1,0 +1,198 @@
+import { checkbox } from "@inquirer/prompts";
+import { ListrInquirerPromptAdapter } from "@listr2/prompt-adapter-inquirer";
+import { Listr, type ListrTask, type ListrTaskWrapper } from "listr2";
+import type { Harness } from "./harnesses/types";
+import {
+  detectHarnesses,
+  installHarness,
+  installSucceeded,
+  type Detection,
+  type InstallResult,
+} from "./run";
+
+const BANNER_LINES = [
+  "█▀ █▀▀ █▄░█ ▀█▀ █▀█ █▄█   █▀▀ █▀█ █▀█   ▄▀█ █",
+  "▄█ ██▄ █░▀█ ░█░ █▀▄ ░█░   █▀░ █▄█ █▀▄   █▀█ █",
+];
+
+// #7553FF text on a #181225 background, via truecolor escapes. Each line is
+// padded to a common width so the background reads as one clean block.
+const BANNER_FG = "\x1b[38;2;117;83;255m";
+const BANNER_BG = "\x1b[48;2;24;18;37m";
+// The background color rendered as a foreground, for the half-block pad rows.
+const BANNER_BG_FG = "\x1b[38;2;24;18;37m";
+const RESET = "\x1b[0m";
+
+const BANNER_WIDTH = Math.max(...BANNER_LINES.map((line) => line.length));
+const INNER_WIDTH = BANNER_WIDTH + 2;
+
+// The text glyphs are half-blocks, so the block alone has ragged top/bottom
+// edges. A ▄ row on top fills its lower half and a ▀ row on the bottom fills
+// its upper half — both in the background color — extending the block by half
+// a cell each way for even vertical padding.
+const PAD_TOP = `${BANNER_BG_FG}${"▄".repeat(INNER_WIDTH)}${RESET}`;
+const PAD_BOTTOM = `${BANNER_BG_FG}${"▀".repeat(INNER_WIDTH)}${RESET}`;
+const TEXT_LINES = BANNER_LINES.map(
+  (line) => `${BANNER_BG}${BANNER_FG} ${line.padEnd(BANNER_WIDTH)} ${RESET}`,
+);
+
+const BANNER = `\n${[PAD_TOP, ...TEXT_LINES, PAD_BOTTOM].join("\n")}\n`;
+
+export interface RunOptions {
+  // When false, skip the selector and install every detected agent (CI smoke
+  // tests, unattended runs). The selection task is disabled in this mode.
+  interactive?: boolean;
+}
+
+interface Ctx {
+  detections: Detection[];
+  selected: Detection[];
+  results: InstallResult[];
+  cancelled: boolean;
+}
+
+type TaskWrapper = ListrTaskWrapper<Ctx, any, any>;
+
+// inquirer raises ExitPromptError when the user hits Ctrl-C / Esc at the
+// prompt. We treat that as a clean cancellation rather than a crash.
+function isCancel(err: unknown): boolean {
+  return err instanceof Error && err.name === "ExitPromptError";
+}
+
+// Only agents found on the machine are offered: installing into an undetected
+// agent just runs shell commands that fail with confusing errors. Everything is
+// pre-checked since the whole list is installable; the user deselects to skip.
+async function promptForAgents(detected: Detection[], task: TaskWrapper): Promise<Detection[]> {
+  const selectedIds = await task.prompt(ListrInquirerPromptAdapter).run(checkbox, {
+    message: "Select the agents to install the Sentry plugin for",
+    choices: detected.map((detection) => ({
+      name: detection.installed ? `${detection.harness.name} (reinstall)` : detection.harness.name,
+      value: detection.harness.id,
+      checked: true,
+    })),
+  });
+
+  return detected.filter((detection) => selectedIds.includes(detection.harness.id));
+}
+
+// Translate one install result into Listr task display state.
+function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
+  const { harness, installed } = detection;
+
+  return {
+    title: installed ? `${harness.name} (reinstall)` : harness.name,
+    task: async (_ctx, task: TaskWrapper) => {
+      const result = await installHarness(detection);
+      ctx.results.push(result);
+
+      switch (result.kind) {
+        case "done":
+          task.title = `${harness.name} — ${result.command}`;
+          if (result.note) task.output = result.note;
+          return;
+        case "manual":
+          task.title = `${harness.name} — manual steps required`;
+          task.output = result.instructions;
+          return;
+        case "blocked":
+          task.skip(`${harness.name} — ${result.reason}`);
+          return;
+        case "failed":
+          throw new Error(result.message);
+      }
+    },
+  };
+}
+
+export async function runInstaller(
+  harnesses: Harness[],
+  options: RunOptions = {},
+): Promise<boolean> {
+  const interactive = options.interactive ?? true;
+
+  if (!process.env.VITEST) {
+    console.log(BANNER);
+  }
+
+  const tasks = new Listr<Ctx>(
+    [
+      {
+        title: "Detecting AI coding tools",
+        task: async (ctx, task) => {
+          ctx.detections = await detectHarnesses(harnesses);
+
+          const found = ctx.detections.filter((d) => d.detected).map((d) => d.harness.name);
+          task.title = found.length ? `Detected ${found.join(", ")}` : "No AI coding tools found";
+        },
+      },
+      {
+        title: "Select agents",
+        // Skip the prompt unless we are interactive and actually found something
+        // to install — an empty checkbox is pointless.
+        enabled: (ctx) => interactive && ctx.detections.some((d) => d.detected),
+        task: async (ctx, task) => {
+          const detected = ctx.detections.filter((d) => d.detected);
+          try {
+            ctx.selected = await promptForAgents(detected, task);
+          } catch (err) {
+            if (!isCancel(err)) throw err;
+            ctx.cancelled = true;
+            task.skip("Cancelled");
+          }
+        },
+      },
+      {
+        title: "Installing plugins",
+        // Interactive runs install the user's selection; non-interactive runs
+        // skip the prompt and install every detected agent.
+        enabled: (ctx) => !ctx.cancelled,
+        task: (ctx, task) => {
+          const selected = interactive ? ctx.selected : ctx.detections.filter((d) => d.detected);
+
+          if (selected.length === 0) {
+            task.skip("No agents selected");
+            return;
+          }
+
+          // exitOnError: false so one agent failing does not abort the rest;
+          // each subtask records its own result and the batch still settles.
+          return task.newListr(
+            selected.map((detection) => installTask(ctx, detection)),
+            { concurrent: true, exitOnError: false },
+          );
+        },
+      },
+    ],
+    // exitOnError aborts the run if a task throws unexpectedly (e.g. the prompt
+    // erroring); install failures are contained by the inner list above. Under
+    // vitest we silence the renderer so test runs do not paint the terminal.
+    {
+      concurrent: false,
+      exitOnError: true,
+      silentRendererCondition: !!process.env.VITEST,
+    },
+  );
+
+  const ctx: Ctx = { detections: [], selected: [], results: [], cancelled: false };
+
+  try {
+    await tasks.run(ctx);
+  } catch (err) {
+    // exitOnError rejects here on an unexpected task failure. Surface it cleanly
+    // and report failure rather than crashing with an unhandled rejection.
+    console.error(err instanceof Error ? err.message : String(err));
+    return false;
+  }
+
+  // A cancelled prompt installed nothing — report failure so the exit code
+  // distinguishes an aborted run from a clean install.
+  if (ctx.cancelled) {
+    return false;
+  }
+
+  if (ctx.results.length > 0) {
+    console.log("\nRestart your AI tools to load the Sentry plugin.");
+  }
+
+  return ctx.results.every(installSucceeded);
+}

--- a/packages/installer/tsconfig.json
+++ b/packages/installer/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["src/__tests__"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,2100 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/installer:
+    dependencies:
+      '@inquirer/prompts':
+        specifier: ^8.5.2
+        version: 8.5.2(@types/node@25.9.3)
+      '@listr2/prompt-adapter-inquirer':
+        specifier: ^4.2.4
+        version: 4.2.4(@inquirer/prompts@8.5.2(@types/node@25.9.3))(@types/node@25.9.3)(listr2@10.2.1)
+      '@sentry/node':
+        specifier: ^10.57.0
+        version: 10.57.0
+      citty:
+        specifier: ^0.1.6
+        version: 0.1.6
+      listr2:
+        specifier: ^10.2.1
+        version: 10.2.1
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      oxfmt:
+        specifier: ^0.54.0
+        version: 0.54.0
+      rolldown:
+        specifier: ^1.1.1
+        version: 1.1.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@25.9.3)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.0.16
+        version: 8.0.16(@types/node@25.9.3)
+      vitest:
+        specifier: ^4.1.8
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3))
+
+packages:
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/core@1.11.0':
+    resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.11.0':
+    resolution: {integrity: sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@inquirer/ansi@2.0.7':
+    resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/checkbox@5.2.1':
+    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/confirm@6.1.1':
+    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@11.2.1':
+    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/editor@5.2.2':
+    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/expand@5.1.1':
+    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/external-editor@3.0.3':
+    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@2.0.7':
+    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+
+  '@inquirer/input@5.1.2':
+    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/number@4.1.1':
+    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.1':
+    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/prompts@8.5.2':
+    resolution: {integrity: sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/rawlist@5.3.1':
+    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/search@4.2.1':
+    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/select@5.2.1':
+    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/type@4.0.7':
+    resolution: {integrity: sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@listr2/prompt-adapter-inquirer@4.2.4':
+    resolution: {integrity: sha512-/KRI2DMD7JGSYaREF0Ygl7AefJ/2ase4Gc5cBiKqT5l4tFjsSJfhFGcc5nSkgl0Sp9LkCQNzl/cqbVJYP2L3dw==}
+    engines: {node: '>=22.13.0'}
+    peerDependencies:
+      '@inquirer/prompts': '>= 3 < 9'
+      listr2: 10.2.1
+
+  '@napi-rs/wasm-runtime@1.1.5':
+    resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@opentelemetry/api-logs@0.214.0':
+    resolution: {integrity: sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@2.8.0':
+    resolution: {integrity: sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/instrumentation@0.214.0':
+    resolution: {integrity: sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@2.8.0':
+    resolution: {integrity: sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.8.0':
+    resolution: {integrity: sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.41.1':
+    resolution: {integrity: sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==}
+    engines: {node: '>=14'}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxc-project/types@0.135.0':
+    resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
+
+  '@oxfmt/binding-android-arm-eabi@0.54.0':
+    resolution: {integrity: sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.54.0':
+    resolution: {integrity: sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.54.0':
+    resolution: {integrity: sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.54.0':
+    resolution: {integrity: sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.54.0':
+    resolution: {integrity: sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.54.0':
+    resolution: {integrity: sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.54.0':
+    resolution: {integrity: sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.54.0':
+    resolution: {integrity: sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.54.0':
+    resolution: {integrity: sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
+    resolution: {integrity: sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
+    resolution: {integrity: sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.54.0':
+    resolution: {integrity: sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.54.0':
+    resolution: {integrity: sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.54.0':
+    resolution: {integrity: sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.54.0':
+    resolution: {integrity: sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.54.0':
+    resolution: {integrity: sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.54.0':
+    resolution: {integrity: sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.54.0':
+    resolution: {integrity: sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.54.0':
+    resolution: {integrity: sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.1.1':
+    resolution: {integrity: sha512-BLf9Wak/gfwVb7NQTQW4wBgL3oAfPy7ArEkhwV543OVw/uY6B47z5xYsqPSZ9PDOorvURPinws6ThaFuNgGLgA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    resolution: {integrity: sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.1.1':
+    resolution: {integrity: sha512-/MtefPxhKPyWWFM8L45OWiEqRf+eSU2Qv9ZAyTaoZOoGcoPKxbbhjTJO2/U2IThv0uDZ4NWHc3/oTsR6IEOtww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    resolution: {integrity: sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    resolution: {integrity: sha512-wl9NfeXNUwrXtUc063tddmZFUI6qiNs1CNOwni0OL4vC7MqVSYugra3ZgtDmtVy8e0DluJTENmzIv2BwqLzT4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    resolution: {integrity: sha512-5PUjZx366h9tkJTPJF5eibxOlK3sGoeRiBJLLjjEB5/kLDuhr6qB3LkhqLz1smXNgsX+pBhnbcJBrPE30HznAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    resolution: {integrity: sha512-1nS1X5z1uMJ369RU25hTpKCFvUwXZp12dIzlzk4S+UxCTcSVGsAE6tzkOSufv/7jnmAtK0ZlrsJxh2fGmsnVSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    resolution: {integrity: sha512-+n46LhDrJFQM+229y4oXtVpj1G50U/+XuHMlpnisFTEXhrg9f/YIjp/HymX+PVJjBEr7XHRs3CFLelV464pqwA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    resolution: {integrity: sha512-qGwEu47zOWYo7LdRHhCWTNhzwGtxXpdY6CERs8QEOqC0PXGGics/e3vHnyEUKt8xK6YkbZXFUCeklrpB6js8ag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    resolution: {integrity: sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    resolution: {integrity: sha512-4psXSh63mSbwJF+mB8/9yfUUEzBiHYcUjxa32EO9ZwKy0Ypwjcg4F10D8SvVXgd+isy2UUUjF9HJJnDu1T/4Gg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@sentry-internal/server-utils@10.57.0':
+    resolution: {integrity: sha512-Qu8ETmX/ITzteG7Im46b9HOxKKzeaIeqNvftaIlFURu1RUQdHbtGerS7QOmXzwnhuqNGNeiCQYkduB798IfRqA==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@10.57.0':
+    resolution: {integrity: sha512-kntItTA2kiT0YpL7encXaF6mkdZMB+y48lwj8w1wkfBpfJAC7sifdgrzLQZqmsqVNE3crg9VfufaAGA+78uFMg==}
+    engines: {node: '>=18'}
+
+  '@sentry/node-core@10.57.0':
+    resolution: {integrity: sha512-2v2IF6MfTiu7pimWEq2rYhZsmlwyNbs3bHUsrYFPeP/Rpa6ObDuUWPdVEzJjfyK+AqqYZYxZdV0l3+B13kTEmQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/exporter-trace-otlp-http': '>=0.57.0 <1'
+      '@opentelemetry/instrumentation': '>=0.57.1 <1'
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@opentelemetry/core':
+        optional: true
+      '@opentelemetry/exporter-trace-otlp-http':
+        optional: true
+      '@opentelemetry/instrumentation':
+        optional: true
+      '@opentelemetry/sdk-trace-base':
+        optional: true
+      '@opentelemetry/semantic-conventions':
+        optional: true
+
+  '@sentry/node@10.57.0':
+    resolution: {integrity: sha512-7KEStrJ97wPf1fA5nU5ONeTTcIIlh7oT8OMffEVA1PXmlhFoXhcQZVzr4rM+zj9tfMWT01og5Ng/Grgh3dN+FA==}
+    engines: {node: '>=18'}
+
+  '@sentry/opentelemetry@10.57.0':
+    resolution: {integrity: sha512-iwRz8cEK0GOISG34aJRO8GdYOk3nfpuT6dT2GDQrxw8f7JjkJKx9LPU8MaenOFa4MhY+Z02hI6NNcrbsoI3cXg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      '@opentelemetry/core': ^1.30.1 || ^2.1.0
+      '@opentelemetry/sdk-trace-base': ^1.30.1 || ^2.1.0
+      '@opentelemetry/semantic-conventions': ^1.39.0
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tsconfig/node10@1.0.12':
+    resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@tybys/wasm-util@0.10.2':
+    resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
+
+  '@vitest/expect@4.1.8':
+    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+
+  '@vitest/mocker@4.1.8':
+    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.8':
+    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+
+  '@vitest/runner@4.1.8':
+    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+
+  '@vitest/snapshot@4.1.8':
+    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+
+  '@vitest/spy@4.1.8':
+    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+
+  '@vitest/utils@4.1.8':
+    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
+  acorn-walk@8.3.5:
+    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.17.0:
+    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
+  chardet@2.1.1:
+    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
+
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
+    engines: {node: '>=0.3.1'}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  import-in-the-middle@3.0.2:
+    resolution: {integrity: sha512-LGLYRl0A2gtyUJb2WDliBHmk6TtlHwdDjxonacZ8QrEs/ZW+YDgNv2QAfjRQWpS8HqvNcq6GGnN6jrOa5FysDQ==}
+    engines: {node: '>=18'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  listr2@10.2.1:
+    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
+    engines: {node: '>=22.13.0'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mute-stream@3.0.0:
+    resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
+
+  oxfmt@0.54.0:
+    resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rolldown@1.0.3:
+    resolution: {integrity: sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.1.1:
+    resolution: {integrity: sha512-IN750c0p+s3jqJIsFLRZrQazmbAB1kkQDTtQjSt/gbS2ywLhlv4R5Shazer0FZKmuo/BsO3/w2UoYnUjuOZqHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  vite@8.0.16:
+    resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.8:
+    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.8
+      '@vitest/browser-preview': 4.1.8
+      '@vitest/browser-webdriverio': 4.1.8
+      '@vitest/coverage-istanbul': 4.1.8
+      '@vitest/coverage-v8': 4.1.8
+      '@vitest/ui': 4.1.8
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@10.0.0:
+    resolution: {integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==}
+    engines: {node: '>=20'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+snapshots:
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/core@1.11.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@inquirer/ansi@2.0.7': {}
+
+  '@inquirer/checkbox@5.2.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/confirm@6.1.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/core@11.2.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+      cli-width: 4.1.0
+      fast-wrap-ansi: 0.2.2
+      mute-stream: 3.0.0
+      signal-exit: 4.1.0
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/editor@5.2.2(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/external-editor': 3.0.3(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/expand@5.1.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/external-editor@3.0.3(@types/node@25.9.3)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/figures@2.0.7': {}
+
+  '@inquirer/input@5.1.2(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/number@4.1.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/password@5.1.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/prompts@8.5.2(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/checkbox': 5.2.1(@types/node@25.9.3)
+      '@inquirer/confirm': 6.1.1(@types/node@25.9.3)
+      '@inquirer/editor': 5.2.2(@types/node@25.9.3)
+      '@inquirer/expand': 5.1.1(@types/node@25.9.3)
+      '@inquirer/input': 5.1.2(@types/node@25.9.3)
+      '@inquirer/number': 4.1.1(@types/node@25.9.3)
+      '@inquirer/password': 5.1.1(@types/node@25.9.3)
+      '@inquirer/rawlist': 5.3.1(@types/node@25.9.3)
+      '@inquirer/search': 4.2.1(@types/node@25.9.3)
+      '@inquirer/select': 5.2.1(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/rawlist@5.3.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/search@4.2.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/select@5.2.1(@types/node@25.9.3)':
+    dependencies:
+      '@inquirer/ansi': 2.0.7
+      '@inquirer/core': 11.2.1(@types/node@25.9.3)
+      '@inquirer/figures': 2.0.7
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@inquirer/type@4.0.7(@types/node@25.9.3)':
+    optionalDependencies:
+      '@types/node': 25.9.3
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@listr2/prompt-adapter-inquirer@4.2.4(@inquirer/prompts@8.5.2(@types/node@25.9.3))(@types/node@25.9.3)(listr2@10.2.1)':
+    dependencies:
+      '@inquirer/prompts': 8.5.2(@types/node@25.9.3)
+      '@inquirer/type': 4.0.7(@types/node@25.9.3)
+      listr2: 10.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@tybys/wasm-util': 0.10.2
+    optional: true
+
+  '@opentelemetry/api-logs@0.214.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
+  '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.214.0
+      import-in-the-middle: 3.0.2
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/resources@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@opentelemetry/semantic-conventions@1.41.1': {}
+
+  '@oxc-project/types@0.133.0': {}
+
+  '@oxc-project/types@0.135.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.54.0':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.1.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.3':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.11.0
+      '@emnapi/runtime': 1.11.0
+      '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@sentry-internal/server-utils@10.57.0':
+    dependencies:
+      '@sentry/core': 10.57.0
+
+  '@sentry/core@10.57.0': {}
+
+  '@sentry/node-core@10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@sentry/core': 10.57.0
+      '@sentry/opentelemetry': 10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+
+  '@sentry/node@10.57.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation': 0.214.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry-internal/server-utils': 10.57.0
+      '@sentry/core': 10.57.0
+      '@sentry/node-core': 10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      '@sentry/opentelemetry': 10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)
+      import-in-the-middle: 3.0.2
+    transitivePeerDependencies:
+      - '@opentelemetry/exporter-trace-otlp-http'
+      - supports-color
+
+  '@sentry/opentelemetry@10.57.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.8.0(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.41.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.41.1
+      '@sentry/core': 10.57.0
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@tsconfig/node10@1.0.12': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@vitest/expect@4.1.8':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3))':
+    dependencies:
+      '@vitest/spy': 4.1.8
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@25.9.3)
+
+  '@vitest/pretty-format@4.1.8':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.8':
+    dependencies:
+      '@vitest/utils': 4.1.8
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/utils': 4.1.8
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.8': {}
+
+  '@vitest/utils@4.1.8':
+    dependencies:
+      '@vitest/pretty-format': 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
+  acorn-walk@8.3.5:
+    dependencies:
+      acorn: 8.17.0
+
+  acorn@8.17.0: {}
+
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
+  arg@4.1.3: {}
+
+  assertion-error@2.0.1: {}
+
+  chai@6.2.2: {}
+
+  chardet@2.1.1: {}
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  cjs-module-lexer@2.2.0: {}
+
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.1
+
+  cli-width@4.1.0: {}
+
+  consola@3.4.2: {}
+
+  convert-source-map@2.0.0: {}
+
+  create-require@1.1.1: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  detect-libc@2.1.2: {}
+
+  diff@4.0.4: {}
+
+  emoji-regex@10.6.0: {}
+
+  environment@1.1.0: {}
+
+  es-module-lexer@2.1.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventemitter3@5.0.4: {}
+
+  expect-type@1.3.0: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-east-asian-width@1.6.0: {}
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-in-the-middle@3.0.2:
+    dependencies:
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.6.0
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  listr2@10.2.1:
+    dependencies:
+      cli-truncate: 5.2.0
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 10.0.0
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-error@1.3.6: {}
+
+  mimic-function@5.0.1: {}
+
+  module-details-from-path@1.0.4: {}
+
+  ms@2.1.3: {}
+
+  mute-stream@3.0.0: {}
+
+  nanoid@3.3.12: {}
+
+  obug@2.1.3: {}
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  oxfmt@0.54.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.54.0
+      '@oxfmt/binding-android-arm64': 0.54.0
+      '@oxfmt/binding-darwin-arm64': 0.54.0
+      '@oxfmt/binding-darwin-x64': 0.54.0
+      '@oxfmt/binding-freebsd-x64': 0.54.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.54.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.54.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.54.0
+      '@oxfmt/binding-linux-arm64-musl': 0.54.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.54.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.54.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.54.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.54.0
+      '@oxfmt/binding-linux-x64-gnu': 0.54.0
+      '@oxfmt/binding-linux-x64-musl': 0.54.0
+      '@oxfmt/binding-openharmony-arm64': 0.54.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.54.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.54.0
+      '@oxfmt/binding-win32-x64-msvc': 0.54.0
+
+  pathe@2.0.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.4: {}
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
+
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
+  rfdc@1.4.1: {}
+
+  rolldown@1.0.3:
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.3
+      '@rolldown/binding-darwin-arm64': 1.0.3
+      '@rolldown/binding-darwin-x64': 1.0.3
+      '@rolldown/binding-freebsd-x64': 1.0.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.3
+      '@rolldown/binding-linux-arm64-gnu': 1.0.3
+      '@rolldown/binding-linux-arm64-musl': 1.0.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.3
+      '@rolldown/binding-linux-s390x-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-gnu': 1.0.3
+      '@rolldown/binding-linux-x64-musl': 1.0.3
+      '@rolldown/binding-openharmony-arm64': 1.0.3
+      '@rolldown/binding-wasm32-wasi': 1.0.3
+      '@rolldown/binding-win32-arm64-msvc': 1.0.3
+      '@rolldown/binding-win32-x64-msvc': 1.0.3
+
+  rolldown@1.1.1:
+    dependencies:
+      '@oxc-project/types': 0.135.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.1
+      '@rolldown/binding-darwin-arm64': 1.1.1
+      '@rolldown/binding-darwin-x64': 1.1.1
+      '@rolldown/binding-freebsd-x64': 1.1.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.1
+      '@rolldown/binding-linux-arm64-gnu': 1.1.1
+      '@rolldown/binding-linux-arm64-musl': 1.1.1
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.1
+      '@rolldown/binding-linux-s390x-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-gnu': 1.1.1
+      '@rolldown/binding-linux-x64-musl': 1.1.1
+      '@rolldown/binding-openharmony-arm64': 1.1.1
+      '@rolldown/binding-wasm32-wasi': 1.1.1
+      '@rolldown/binding-win32-arm64-msvc': 1.1.1
+      '@rolldown/binding-win32-x64-msvc': 1.1.1
+
+  safer-buffer@2.1.2: {}
+
+  siginfo@2.0.0: {}
+
+  signal-exit@4.1.0: {}
+
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.1.0: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
+
+  ts-node@10.9.2(@types/node@25.9.3)(typescript@6.0.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.9.3
+      acorn: 8.17.0
+      acorn-walk: 8.3.5
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 6.0.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  vite@8.0.16(@types/node@25.9.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      fsevents: 2.3.3
+
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)):
+    dependencies:
+      '@vitest/expect': 4.1.8
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3))
+      '@vitest/pretty-format': 4.1.8
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      '@vitest/spy': 4.1.8
+      '@vitest/utils': 4.1.8
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@25.9.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.3
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@10.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 8.2.1
+      strip-ansi: 7.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  yn@3.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - 'packages/*'
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
## What

A new `packages/installer` package (its own pnpm workspace) giving a single `npx` entrypoint for installing the Sentry plugin into any supported AI coding assistant: **Claude Code, Codex, Cursor, and Grok**. Running `npx @sentry/ai` detects which of these are on the machine and installs (or updates) the Sentry plugin for each.

Each agent is a self-contained harness implementing a common strategy interface — `detect`, `isInstalled`, `canInstall`, `install` — so adding a new agent is just another module. All system access (shell, fs, platform, homedir) goes through an injected `SystemDeps` seam, so every harness is unit-tested without side effects (52 tests).

## Behavior

- `install` is the default subcommand: bare `npx @sentry/ai` runs the installer instead of printing a help menu. `--no-interactive` (alias `-y` / `--yes`) skips the prompt and installs every detected agent — used by CI and unattended runs.
- Detection runs in parallel. The interactive selector (`@inquirer/prompts`, driven through a `listr2` task list) lists only the agents actually found on the machine, all pre-checked; the user deselects to skip.
- **Already-installed agents update in place** rather than erroring or silently no-opping: Cursor `git pull`s, Claude and Grok use their update/refresh commands, and Codex re-`add`s (idempotent — it has no update command).
- `canInstall` gates prerequisites (Cursor needs `git`) and reports a clear skip instead of a cryptic mid-install failure.
- One agent failing doesn't abort the rest. The process exits non-zero if any selected agent failed or was blocked, or if the user cancels the prompt.
- **Cross-platform:** binary detection uses `where` / `which` per OS, Cursor is located via its per-OS install path, and git paths are quoted for Windows spaces.

## How each agent installs

- **Claude Code** — registers the official `anthropics/claude-plugins-official` marketplace if missing (else refreshes it), then installs by name: `claude plugin install sentry@claude-plugins-official`.
- **Codex** — registers our `getsentry/plugin-codex` marketplace if missing (else upgrades it), then `codex plugin add sentry@sentry-plugin-marketplace`.
- **Cursor** — `git clone` / `git pull` into `~/.cursor/plugins/local/sentry` (Cursor has no headless plugin CLI), then prints the restart note.
- **Grok** — `grok plugin install getsentry/plugin-grok --trust`, or `grok plugin update sentry` when already present.

Two follow-ups are flagged as TODOs in code:

- **Grok** has no headless install-by-name from a marketplace (that path is TUI-only), so we install from the plugin repo directly — which is the exact source grok's built-in `xai-official` marketplace catalogs for sentry. Switch to a by-name marketplace install once grok exposes one.
- **Codex** is the only agent installed from our own marketplace (`getsentry/plugin-codex`), which vendors the skill files, so every plugin update means regenerating and republishing that marketplace. Move it onto an official marketplace once one exists.

## Distribution & CI

- **rolldown** bundles the npm package (dependencies kept external).
- Instrumented with the Sentry Node SDK.
- A cross-platform **smoke-test workflow** (`smoke-installer.yml`) runs the built installer non-interactively on macOS, Linux, and Windows: it installs the real Claude Code, Codex, and Grok CLIs from npm (plus a Cursor stub, since Cursor has no headless CLI) and verifies the Sentry plugin actually landed for each.

## Test plan

- `pnpm test` — 52 passing
- `tsc --noEmit`, `pnpm build` (rolldown), and `pnpm format:check` (oxfmt) all clean
- `smoke-installer.yml` green on macOS, Linux, and Windows
