### PR TITLE
ci(installer): publish @sentry/ai to npm via craft

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,0 +1,17 @@
+# Releases packages/installer to npm as @sentry/ai via craft.
+minVersion: "2.21.0"
+# Single segment only -- craft splits the branch name on the first "/".
+releaseBranchPrefix: release-installer
+changelog:
+  filePath: packages/installer/CHANGELOG.md
+  policy: simple
+
+# No github target, so no git tags or GitHub releases.
+targets:
+  - name: npm
+    id: "@sentry/ai"
+    access: public
+    includeNames: /^sentry-ai-\d.*\.tgz$/
+
+requireNames:
+  - /^sentry-ai-\d.*\.tgz$/

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,41 @@
+# Packs the installer tarball on release branches. Artifact name must be the
+# commit SHA -- that's what craft downloads at publish time.
+name: Release Build
+
+on:
+  push:
+    branches:
+      - release-installer/**
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - uses: pnpm/action-setup@a15d269cd4658e1107c09f1fabf4cbd7bd1f308a # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm --filter @sentry/ai build
+
+      - name: Pack tarball
+        working-directory: packages/installer
+        run: pnpm pack --pack-destination "${{ github.workspace }}"
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ github.sha }}
+          path: "*.tgz"
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# Runs `craft prepare`. Needs the App token, not GITHUB_TOKEN -- a branch pushed
+# with GITHUB_TOKEN wouldn't trigger release-build.yml.
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version to release (or "auto")
+        required: false
+      force:
+        description: Force a release even when there are release-blockers (optional)
+        required: false
+      merge_target:
+        description: Target branch to merge into. Uses the default branch as a fallback (optional)
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    name: "Release a new version"
+    steps:
+      - name: Get auth token
+        id: token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          token: ${{ steps.token.outputs.token }}
+          fetch-depth: 0
+
+      - name: Prepare release
+        uses: getsentry/craft@acdb88019720182caf57293360d7cdc8db9e75ac # v2.26.10
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        with:
+          version: ${{ github.event.inputs.version }}
+          force: ${{ github.event.inputs.force }}
+          merge_target: ${{ github.event.inputs.merge_target }}

--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.1.0
+
+Initial release of `@sentry/ai`, a single `npx` entrypoint for installing the
+Sentry plugin into supported AI coding assistants (Claude Code, Codex, Cursor,
+and Grok). Detects which agents are present, installs or updates the plugin for
+each, and reports per-agent results.

--- a/packages/installer/LICENSE
+++ b/packages/installer/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Sentry (https://sentry.io) and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -10,6 +10,13 @@
   "homepage": "https://github.com/getsentry/sentry-for-ai#readme",
   "author": "Sentry",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
   "engines": {
     "node": ">=18.0.0"
   },


### PR DESCRIPTION
Sets up the Craft release pipeline so `packages/installer` can ship to npm as `@sentry/ai`. This repo prepares the release and builds the artifact; the actual publish runs from getsentry/publish after a team lead approves the release issue.

## What

- `.craft.yml` — a single npm target (public scoped access) with a tarball-name guard. No `github` target, so a release produces no git tags and no GitHub releases.
- `releaseBranchPrefix: release-installer` — the (transient) release branch reads as `release-installer/<version>`, scoping it to the package rather than the repo. craft deletes it after publish.
- `changelog: { filePath: packages/installer/CHANGELOG.md, policy: simple }` — the changelog lives with the package and is curated by hand, matching sentry-javascript. `auto` would sweep this repo's skill-drift and plugin churn into the installer's changelog.
- `release.yml` — runs `craft prepare` via the Sentry release bot GitHub App token. It deliberately uses an App token rather than `GITHUB_TOKEN`: a release branch pushed with `GITHUB_TOKEN` would not trigger `release-build.yml`, so the artifact would never get built.
- `release-build.yml` — on `release-installer/**`, builds the installer, runs `pnpm pack`, and uploads the tarball as a single artifact named after the commit SHA (what Craft's default GitHub artifact provider downloads at publish time).
- `packages/installer/package.json` — `files: ["dist", "CHANGELOG.md"]` so the gitignored build and the changelog ship in the tarball, and `publishConfig.access: public`. Adds an explicit `LICENSE` so the package is self-contained rather than relying on pnpm copying the root one.
- `packages/installer/CHANGELOG.md` — pre-seeded `0.1.0` entry.

## What a release leaves in this repo

Nothing permanent. No tags, no GitHub release, no lingering branch — only npm gets a new version. The `release-installer/<version>` branch exists for the duration of the release and is deleted on publish.

## Before the first release can run

- The `SENTRY_RELEASE_BOT_CLIENT_ID` variable is org-wide (`visibility: all`) and already available; confirm with the github-releng team that the `SENTRY_RELEASE_BOT_PRIVATE_KEY` org secret is visible to this repo.
- Confirm the getsentry/publish npm token can create a new `@sentry`-scoped package and that `@sentry/ai` is unclaimed.
