### PR TITLE
feat(installer): detect via JSON and clean up conflicting plugins

### DIFF
--- a/packages/installer/src/__tests__/fake-harness.ts
+++ b/packages/installer/src/__tests__/fake-harness.ts
@@ -8,11 +8,16 @@ export interface FakeHarnessOptions {
   installed?: boolean;
   readiness?: InstallReadiness;
   outcome?: InstallOutcome;
+  updateOutcome?: InstallOutcome;
   error?: Error;
+  // When set, the harness exposes a cleanup spy resolving to this description so
+  // tests can assert it runs (and that it runs before install/update). Pass an
+  // empty string to model a cleanup that found nothing.
+  cleaned?: string;
 }
 
 export function fakeHarness(options: FakeHarnessOptions): Harness {
-  return {
+  const harness: Harness = {
     id: options.id,
     name: options.name ?? options.id,
     detect: vi.fn(async () => options.detected ?? false),
@@ -24,5 +29,17 @@ export function fakeHarness(options: FakeHarnessOptions): Harness {
       }
       return options.outcome ?? { kind: "done", command: `${options.id} install` };
     }),
+    update: vi.fn(async () => {
+      if (options.error) {
+        throw options.error;
+      }
+      return options.updateOutcome ?? { kind: "done", command: `${options.id} update` };
+    }),
   };
+
+  if (options.cleaned !== undefined) {
+    harness.cleanup = vi.fn(async () => options.cleaned || null);
+  }
+
+  return harness;
 }

--- a/packages/installer/src/__tests__/harnesses.test.ts
+++ b/packages/installer/src/__tests__/harnesses.test.ts
@@ -10,6 +10,37 @@ import { fakeSystem } from "./fake-system";
 const ok: ShellResult = { ok: true };
 const notFound: ShellResult = { ok: false, message: "not found" };
 
+// JSON fixtures matching each CLI's `plugin list --json` shape.
+const claudeList = (ids: string[]): ShellResult => ({
+  ok: true,
+  stdout: JSON.stringify(ids.map((id) => ({ id }))),
+});
+
+const codexList = (pluginIds: string[]): ShellResult => ({
+  ok: true,
+  stdout: JSON.stringify({ installed: pluginIds.map((pluginId) => ({ pluginId })) }),
+});
+
+const grokList = (
+  plugins: { name: string; source: string; marketplace?: string | null }[],
+): ShellResult => ({
+  ok: true,
+  stdout: JSON.stringify(plugins.map((p) => ({ marketplace: null, ...p }))),
+});
+
+const isList = (cmd: string) => cmd.includes("plugin list --json");
+
+// `marketplace list --json` fixtures: Claude emits a flat array, Codex wraps it.
+const claudeMarketplaces = (names: string[]): ShellResult => ({
+  ok: true,
+  stdout: JSON.stringify(names.map((name) => ({ name }))),
+});
+
+const codexMarketplaces = (names: string[]): ShellResult => ({
+  ok: true,
+  stdout: JSON.stringify({ marketplaces: names.map((name) => ({ name })) }),
+});
+
 describe("claude harness", () => {
   it("detects when the claude binary is on PATH", async () => {
     const harness = createClaude(fakeSystem({ run: () => ok }));
@@ -21,13 +52,20 @@ describe("claude harness", () => {
     expect(await harness.detect()).toBe(false);
   });
 
-  it("reports installed when plugin list includes sentry", async () => {
-    const harness = createClaude(fakeSystem({ run: () => ({ ok: true, stdout: "sentry" }) }));
+  it("reports installed when the listing includes our plugin id", async () => {
+    const harness = createClaude(
+      fakeSystem({ run: () => claudeList(["sentry@claude-plugins-official"]) }),
+    );
     expect(await harness.isInstalled()).toBe(true);
   });
 
-  it("reports not installed when plugin list does not include sentry", async () => {
-    const harness = createClaude(fakeSystem({ run: () => ({ ok: true, stdout: "other-plugin" }) }));
+  it("reports not installed when the listing lacks our plugin id", async () => {
+    const harness = createClaude(fakeSystem({ run: () => claudeList(["other@somewhere"]) }));
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("reports not installed when the listing is not valid json", async () => {
+    const harness = createClaude(fakeSystem({ run: () => ({ ok: true, stdout: "not json" }) }));
     expect(await harness.isInstalled()).toBe(false);
   });
 
@@ -47,9 +85,20 @@ describe("claude harness", () => {
     expect(system.run).toHaveBeenCalledWith("claude plugin install sentry@claude-plugins-official");
   });
 
+  it("updates in place via the update command", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createClaude(system).update();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "claude plugin update sentry@claude-plugins-official",
+    });
+    expect(system.run).toHaveBeenCalledWith("claude plugin update sentry@claude-plugins-official");
+  });
+
   it("adds the official marketplace when it is not registered", async () => {
     const system = fakeSystem({
-      run: (cmd) => (cmd.includes("marketplace list") ? { ok: true, stdout: "" } : ok),
+      run: (cmd) => (cmd.includes("marketplace list") ? claudeMarketplaces([]) : ok),
     });
     await createClaude(system).install();
     expect(system.run).toHaveBeenCalledWith(
@@ -60,25 +109,12 @@ describe("claude harness", () => {
   it("refreshes the marketplace when it is already registered", async () => {
     const system = fakeSystem({
       run: (cmd) =>
-        cmd.includes("marketplace list") ? { ok: true, stdout: "claude-plugins-official" } : ok,
+        cmd.includes("marketplace list") ? claudeMarketplaces(["claude-plugins-official"]) : ok,
     });
-    await createClaude(system).install();
+    await createClaude(system).update();
     expect(system.run).toHaveBeenCalledWith(
       "claude plugin marketplace update claude-plugins-official",
     );
-  });
-
-  it("updates in place when the plugin is already present", async () => {
-    const system = fakeSystem({
-      run: () => ({ ok: true, stdout: "sentry@claude-plugins-official" }),
-    });
-    const outcome = await createClaude(system).install();
-
-    expect(outcome).toMatchObject({
-      kind: "done",
-      command: "claude plugin update sentry@claude-plugins-official",
-    });
-    expect(system.run).toHaveBeenCalledWith("claude plugin update sentry@claude-plugins-official");
   });
 
   it("surfaces stderr when install fails", async () => {
@@ -105,14 +141,36 @@ describe("codex harness", () => {
     expect(await harness.detect()).toBe(false);
   });
 
-  it("reports installed when plugin list includes sentry", async () => {
-    const harness = createCodex(fakeSystem({ run: () => ({ ok: true, stdout: "sentry" }) }));
+  it("reports installed when the listing includes our plugin id", async () => {
+    const harness = createCodex(
+      fakeSystem({ run: () => codexList(["sentry@sentry-plugin-marketplace"]) }),
+    );
     expect(await harness.isInstalled()).toBe(true);
   });
 
-  it("reports not installed when plugin list does not include sentry", async () => {
-    const harness = createCodex(fakeSystem({ run: () => ({ ok: true, stdout: "other-plugin" }) }));
+  it("does not count the legacy openai-curated plugin as ours", async () => {
+    const harness = createCodex(fakeSystem({ run: () => codexList(["sentry@openai-curated"]) }));
     expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("removes the legacy openai-curated plugin when present", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (isList(cmd) ? codexList(["sentry@openai-curated"]) : ok),
+    });
+    const removed = await createCodex(system).cleanup!();
+
+    expect(system.run).toHaveBeenCalledWith("codex plugin remove sentry@openai-curated");
+    expect(removed).toContain("sentry@openai-curated");
+  });
+
+  it("leaves cleanup a no-op when the legacy plugin is absent", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (isList(cmd) ? codexList(["sentry@sentry-plugin-marketplace"]) : ok),
+    });
+    const removed = await createCodex(system).cleanup!();
+
+    expect(removed).toBeNull();
+    expect(system.run).not.toHaveBeenCalledWith("codex plugin remove sentry@openai-curated");
   });
 
   it("installs the plugin from its marketplace", async () => {
@@ -126,9 +184,19 @@ describe("codex harness", () => {
     expect(system.run).toHaveBeenCalledWith("codex plugin add sentry@sentry-plugin-marketplace");
   });
 
+  it("updates via the same idempotent add command", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createCodex(system).update();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "codex plugin add sentry@sentry-plugin-marketplace",
+    });
+  });
+
   it("adds the marketplace when it is not registered", async () => {
     const system = fakeSystem({
-      run: (cmd) => (cmd.includes("marketplace list") ? { ok: true, stdout: "" } : ok),
+      run: (cmd) => (cmd.includes("marketplace list") ? codexMarketplaces([]) : ok),
     });
     await createCodex(system).install();
     expect(system.run).toHaveBeenCalledWith("codex plugin marketplace add getsentry/plugin-codex");
@@ -137,7 +205,7 @@ describe("codex harness", () => {
   it("refreshes the marketplace when it is already registered", async () => {
     const system = fakeSystem({
       run: (cmd) =>
-        cmd.includes("marketplace list") ? { ok: true, stdout: "sentry-plugin-marketplace" } : ok,
+        cmd.includes("marketplace list") ? codexMarketplaces(["sentry-plugin-marketplace"]) : ok,
     });
     await createCodex(system).install();
     expect(system.run).toHaveBeenCalledWith(
@@ -152,6 +220,8 @@ describe("codex harness", () => {
 });
 
 describe("grok harness", () => {
+  const ourRepo = "https://github.com/getsentry/plugin-grok.git";
+
   it("detects via which", async () => {
     const harness = createGrok(fakeSystem({ run: () => ok }));
     expect(await harness.detect()).toBe(true);
@@ -162,25 +232,81 @@ describe("grok harness", () => {
     expect(await harness.detect()).toBe(false);
   });
 
-  it("reports installed when plugin list includes sentry", async () => {
-    const harness = createGrok(fakeSystem({ run: () => ({ ok: true, stdout: "sentry" }) }));
+  it("reports installed when sentry is present from our repo with no marketplace", async () => {
+    const harness = createGrok(
+      fakeSystem({ run: () => grokList([{ name: "sentry", source: ourRepo }]) }),
+    );
     expect(await harness.isInstalled()).toBe(true);
   });
 
-  it("reports not installed when plugin list does not include sentry", async () => {
-    const harness = createGrok(fakeSystem({ run: () => ({ ok: true, stdout: "other-plugin" }) }));
+  it("does not count a marketplace-installed sentry as ours", async () => {
+    const harness = createGrok(
+      fakeSystem({
+        run: () => grokList([{ name: "sentry", source: ourRepo, marketplace: "xAI Official" }]),
+      }),
+    );
     expect(await harness.isInstalled()).toBe(false);
   });
 
-  it("installs with the --trust flag when not yet present", async () => {
+  it("reports not installed when sentry comes from a different source", async () => {
+    const harness = createGrok(
+      fakeSystem({
+        run: () => grokList([{ name: "sentry", source: "https://github.com/someone/other.git" }]),
+      }),
+    );
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("reports not installed when no sentry plugin is present", async () => {
+    const harness = createGrok(fakeSystem({ run: () => grokList([]) }));
+    expect(await harness.isInstalled()).toBe(false);
+  });
+
+  it("uninstalls a marketplace-installed sentry during cleanup", async () => {
+    const system = fakeSystem({
+      run: (cmd) =>
+        isList(cmd)
+          ? grokList([{ name: "sentry", source: ourRepo, marketplace: "xAI Official" }])
+          : ok,
+    });
+    const removed = await createGrok(system).cleanup!();
+
+    expect(system.run).toHaveBeenCalledWith("grok plugin uninstall sentry");
+    expect(removed).toContain("xAI Official");
+  });
+
+  it("leaves our own install untouched during cleanup", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (isList(cmd) ? grokList([{ name: "sentry", source: ourRepo }]) : ok),
+    });
+    const removed = await createGrok(system).cleanup!();
+
+    expect(removed).toBeNull();
+    expect(system.run).not.toHaveBeenCalledWith("grok plugin uninstall sentry");
+  });
+
+  it("does nothing during cleanup when no sentry plugin is present", async () => {
+    const system = fakeSystem({ run: (cmd) => (isList(cmd) ? grokList([]) : ok) });
+    const removed = await createGrok(system).cleanup!();
+
+    expect(removed).toBeNull();
+    expect(system.run).not.toHaveBeenCalledWith("grok plugin uninstall sentry");
+  });
+
+  it("installs with the --trust flag", async () => {
     const system = fakeSystem({ run: () => ok });
-    await createGrok(system).install();
+    const outcome = await createGrok(system).install();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "grok plugin install getsentry/plugin-grok --trust",
+    });
     expect(system.run).toHaveBeenCalledWith("grok plugin install getsentry/plugin-grok --trust");
   });
 
-  it("updates in place when the plugin is already present", async () => {
-    const system = fakeSystem({ run: () => ({ ok: true, stdout: "plugin-grok-x: sentry" }) });
-    const outcome = await createGrok(system).install();
+  it("updates in place via the update command", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createGrok(system).update();
 
     expect(outcome).toMatchObject({ kind: "done", command: "grok plugin update sentry" });
     expect(system.run).toHaveBeenCalledWith("grok plugin update sentry");
@@ -267,7 +393,7 @@ describe("cursor harness", () => {
     }
   });
 
-  it("clones the plugin repo when the target directory does not exist", async () => {
+  it("clones the plugin repo on install", async () => {
     const system = fakeSystem({ homedir: "/home/user" });
     const outcome = await createCursor(system).install();
 
@@ -277,10 +403,10 @@ describe("cursor harness", () => {
     );
   });
 
-  it("pulls when the target directory already exists", async () => {
+  it("pulls the existing checkout on update", async () => {
     const target = "/home/user/.cursor/plugins/local/sentry";
     const system = fakeSystem({ homedir: "/home/user", existing: [target] });
-    const outcome = await createCursor(system).install();
+    const outcome = await createCursor(system).update();
 
     expect(outcome.kind).toBe("done");
     expect(system.run).toHaveBeenCalledWith(`git -C "${target}" pull`);

--- a/packages/installer/src/__tests__/run.test.ts
+++ b/packages/installer/src/__tests__/run.test.ts
@@ -37,6 +37,36 @@ describe("installHarness", () => {
     expect(claude.install).toHaveBeenCalledOnce();
   });
 
+  it("updates instead of installing when the plugin is already present", async () => {
+    const claude = fakeHarness({ id: "claude", installed: true });
+
+    const result = await installHarness({ harness: claude, detected: true, installed: true });
+
+    expect(result).toEqual({ kind: "done", command: "claude update", note: undefined });
+    expect(claude.update).toHaveBeenCalledOnce();
+    expect(claude.install).not.toHaveBeenCalled();
+  });
+
+  it("runs cleanup before installing and surfaces what it removed", async () => {
+    const codex = fakeHarness({ id: "codex", cleaned: "Removed sentry@openai-curated" });
+
+    const result = await installHarness({ harness: codex, detected: true, installed: false });
+
+    expect(result).toMatchObject({ kind: "done", cleaned: "Removed sentry@openai-curated" });
+    expect(codex.cleanup).toHaveBeenCalledOnce();
+    const cleanupOrder = (codex.cleanup as any).mock.invocationCallOrder[0];
+    const installOrder = (codex.install as any).mock.invocationCallOrder[0];
+    expect(cleanupOrder).toBeLessThan(installOrder);
+  });
+
+  it("omits cleaned when cleanup found nothing to remove", async () => {
+    const codex = fakeHarness({ id: "codex", cleaned: "" });
+
+    const result = await installHarness({ harness: codex, detected: true, installed: false });
+
+    expect(result).toEqual({ kind: "done", command: "codex install" });
+  });
+
   it("passes the note through on a done outcome", async () => {
     const cursor = fakeHarness({
       id: "cursor",

--- a/packages/installer/src/__tests__/ui.test.ts
+++ b/packages/installer/src/__tests__/ui.test.ts
@@ -18,6 +18,20 @@ describe("runInstaller (non-interactive)", () => {
     expect(codex.install).not.toHaveBeenCalled();
   });
 
+  it("runs cleanup before installing a detected agent", async () => {
+    const codex = fakeHarness({
+      id: "codex",
+      detected: true,
+      cleaned: "Removed conflicting plugin sentry@openai-curated",
+    });
+
+    const ok = await runInstaller([codex], { interactive: false });
+
+    expect(ok).toBe(true);
+    expect(codex.cleanup).toHaveBeenCalledOnce();
+    expect(codex.install).toHaveBeenCalledOnce();
+  });
+
   it("returns false when an install fails but still installs the others", async () => {
     const claude = fakeHarness({ id: "claude", detected: true, error: new Error("boom") });
     const codex = fakeHarness({ id: "codex", detected: true });

--- a/packages/installer/src/harnesses/claude.ts
+++ b/packages/installer/src/harnesses/claude.ts
@@ -1,11 +1,47 @@
 import { realSystem, type SystemDeps } from "../system";
-import type { Harness } from "./types";
-import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
+import type { Harness, InstallOutcome } from "./types";
+import { detectOnPath, runInstallCommand, runJson } from "./shell";
 
 const MARKETPLACE = "claude-plugins-official";
 const MARKETPLACE_SOURCE = "anthropics/claude-plugins-official";
-const INSTALL_COMMAND = `claude plugin install sentry@${MARKETPLACE}`;
-const UPDATE_COMMAND = `claude plugin update sentry@${MARKETPLACE}`;
+const PLUGIN_ID = `sentry@${MARKETPLACE}`;
+const INSTALL_COMMAND = `claude plugin install ${PLUGIN_ID}`;
+const UPDATE_COMMAND = `claude plugin update ${PLUGIN_ID}`;
+
+// `claude plugin list --json` emits an array of installed plugins. We only care
+// about the marketplace-qualified id of each entry.
+interface ClaudePlugin {
+  id?: string;
+}
+
+// `claude plugin marketplace list --json` emits an array of registered
+// marketplaces, each with a `name`.
+interface ClaudeMarketplace {
+  name?: string;
+}
+
+async function isSentryInstalled(system: SystemDeps): Promise<boolean> {
+  const plugins = await runJson<ClaudePlugin[]>(system, "claude plugin list --json");
+  return Array.isArray(plugins) && plugins.some((plugin) => plugin.id === PLUGIN_ID);
+}
+
+async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
+  const list = await runJson<ClaudeMarketplace[]>(system, "claude plugin marketplace list --json");
+  return Array.isArray(list) && list.some((entry) => entry.name === MARKETPLACE);
+}
+
+// A fresh CLI has no marketplaces registered, so register the official one if it
+// is missing; otherwise refresh its index so the plugin resolves. Required by
+// both install and update.
+async function ensureMarketplace(system: SystemDeps): Promise<void> {
+  const registered = await isMarketplaceRegistered(system);
+  await runInstallCommand(
+    system,
+    registered
+      ? `claude plugin marketplace update ${MARKETPLACE}`
+      : `claude plugin marketplace add ${MARKETPLACE_SOURCE}`,
+  );
+}
 
 export function createClaude(system: SystemDeps): Harness {
   return {
@@ -14,31 +50,20 @@ export function createClaude(system: SystemDeps): Harness {
 
     detect: async () => detectOnPath(system, "claude"),
 
-    isInstalled: async () => outputIncludes(system, "claude plugin list", "sentry"),
+    isInstalled: async () => isSentryInstalled(system),
 
     canInstall: async () => ({ ok: true }),
 
-    install: async () => {
-      // A fresh CLI has no marketplaces registered, so register the official one
-      // if it is missing; otherwise refresh its index so the plugin resolves.
-      const registered = await outputIncludes(
-        system,
-        "claude plugin marketplace list",
-        MARKETPLACE,
-      );
-      await runInstallCommand(
-        system,
-        registered
-          ? `claude plugin marketplace update ${MARKETPLACE}`
-          : `claude plugin marketplace add ${MARKETPLACE_SOURCE}`,
-      );
+    install: async (): Promise<InstallOutcome> => {
+      await ensureMarketplace(system);
+      await runInstallCommand(system, INSTALL_COMMAND);
+      return { kind: "done", command: INSTALL_COMMAND };
+    },
 
-      const command = (await outputIncludes(system, "claude plugin list", "sentry"))
-        ? UPDATE_COMMAND
-        : INSTALL_COMMAND;
-
-      await runInstallCommand(system, command);
-      return { kind: "done", command };
+    update: async (): Promise<InstallOutcome> => {
+      await ensureMarketplace(system);
+      await runInstallCommand(system, UPDATE_COMMAND);
+      return { kind: "done", command: UPDATE_COMMAND };
     },
   };
 }

--- a/packages/installer/src/harnesses/codex.ts
+++ b/packages/installer/src/harnesses/codex.ts
@@ -1,6 +1,6 @@
 import { realSystem, type SystemDeps } from "../system";
-import type { Harness } from "./types";
-import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
+import type { Harness, InstallOutcome } from "./types";
+import { detectOnPath, runInstallCommand, runJson } from "./shell";
 
 // TODO: Codex is the only agent we install from our OWN marketplace
 // (getsentry/plugin-codex) rather than the agent vendor's official marketplace
@@ -10,7 +10,64 @@ import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
 // marketplace once one is available so updates flow without re-vendoring.
 const MARKETPLACE = "sentry-plugin-marketplace";
 const MARKETPLACE_SOURCE = "getsentry/plugin-codex";
-const INSTALL_COMMAND = `codex plugin add sentry@${MARKETPLACE}`;
+const PLUGIN_ID = `sentry@${MARKETPLACE}`;
+const INSTALL_COMMAND = `codex plugin add ${PLUGIN_ID}`;
+
+// Codex ships an "official" Sentry plugin from its own curated marketplace. It
+// shadows ours, so remove it before installing. Drop this once we publish to
+// that marketplace and our plugin becomes the official one.
+const LEGACY_PLUGIN_ID = "sentry@openai-curated";
+
+// `codex plugin list --json` wraps installed plugins under `installed`, each
+// keyed by a marketplace-qualified pluginId.
+interface CodexPlugin {
+  pluginId?: string;
+}
+interface CodexPluginList {
+  installed?: CodexPlugin[];
+}
+
+// `codex plugin marketplace list --json` wraps registered marketplaces under
+// `marketplaces`, each with a `name`.
+interface CodexMarketplaceList {
+  marketplaces?: { name?: string }[];
+}
+
+async function installedPlugins(system: SystemDeps): Promise<CodexPlugin[]> {
+  const data = await runJson<CodexPluginList>(system, "codex plugin list --json");
+  return data?.installed ?? [];
+}
+
+async function hasPlugin(system: SystemDeps, pluginId: string): Promise<boolean> {
+  return (await installedPlugins(system)).some((plugin) => plugin.pluginId === pluginId);
+}
+
+async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
+  const data = await runJson<CodexMarketplaceList>(system, "codex plugin marketplace list --json");
+  return (data?.marketplaces ?? []).some((entry) => entry.name === MARKETPLACE);
+}
+
+// The Sentry plugin lives in its own marketplace, not a Codex default, so
+// register it if missing; otherwise refresh its snapshot so it resolves.
+// Required by both install and update.
+async function ensureMarketplace(system: SystemDeps): Promise<void> {
+  const registered = await isMarketplaceRegistered(system);
+  await runInstallCommand(
+    system,
+    registered
+      ? `codex plugin marketplace upgrade ${MARKETPLACE}`
+      : `codex plugin marketplace add ${MARKETPLACE_SOURCE}`,
+  );
+}
+
+// Codex has no plugin update command; `add` is idempotent and re-points an
+// already-installed plugin at the refreshed snapshot, so install and update
+// share this single path.
+async function addPlugin(system: SystemDeps): Promise<InstallOutcome> {
+  await ensureMarketplace(system);
+  await runInstallCommand(system, INSTALL_COMMAND);
+  return { kind: "done", command: INSTALL_COMMAND };
+}
 
 export function createCodex(system: SystemDeps): Harness {
   return {
@@ -19,26 +76,22 @@ export function createCodex(system: SystemDeps): Harness {
 
     detect: async () => detectOnPath(system, "codex"),
 
-    isInstalled: async () => outputIncludes(system, "codex plugin list", "sentry"),
+    isInstalled: async () => hasPlugin(system, PLUGIN_ID),
 
     canInstall: async () => ({ ok: true }),
 
-    install: async () => {
-      // The Sentry plugin lives in its own marketplace, not a Codex default, so
-      // register it if missing; otherwise refresh its snapshot so it resolves.
-      const registered = await outputIncludes(system, "codex plugin marketplace list", MARKETPLACE);
-      await runInstallCommand(
-        system,
-        registered
-          ? `codex plugin marketplace upgrade ${MARKETPLACE}`
-          : `codex plugin marketplace add ${MARKETPLACE_SOURCE}`,
-      );
+    cleanup: async () => {
+      if (!(await hasPlugin(system, LEGACY_PLUGIN_ID))) {
+        return null;
+      }
 
-      // Codex has no plugin update command; `add` is idempotent and re-points an
-      // already-installed plugin at the refreshed snapshot.
-      await runInstallCommand(system, INSTALL_COMMAND);
-      return { kind: "done", command: INSTALL_COMMAND };
+      await runInstallCommand(system, `codex plugin remove ${LEGACY_PLUGIN_ID}`);
+      return `Removed conflicting plugin ${LEGACY_PLUGIN_ID}`;
     },
+
+    install: async () => addPlugin(system),
+
+    update: async () => addPlugin(system),
   };
 }
 

--- a/packages/installer/src/harnesses/cursor.ts
+++ b/packages/installer/src/harnesses/cursor.ts
@@ -46,13 +46,14 @@ export function createCursor(system: SystemDeps): Harness {
         : { ok: false, reason: "git is required to clone the Cursor plugin" },
 
     install: async (): Promise<InstallOutcome> => {
-      const target = pluginDir(system);
-
       // Quote the target: Windows home paths routinely contain spaces.
-      const command = system.exists(target)
-        ? `git -C "${target}" pull`
-        : `git clone ${PLUGIN_REPO} "${target}"`;
+      const command = `git clone ${PLUGIN_REPO} "${pluginDir(system)}"`;
+      await runInstallCommand(system, command);
+      return { kind: "done", command, note: RESTART_NOTE };
+    },
 
+    update: async (): Promise<InstallOutcome> => {
+      const command = `git -C "${pluginDir(system)}" pull`;
       await runInstallCommand(system, command);
       return { kind: "done", command, note: RESTART_NOTE };
     },

--- a/packages/installer/src/harnesses/grok.ts
+++ b/packages/installer/src/harnesses/grok.ts
@@ -1,16 +1,41 @@
 import { realSystem, type SystemDeps } from "../system";
-import type { Harness } from "./types";
-import { detectOnPath, outputIncludes, runInstallCommand } from "./shell";
+import type { Harness, InstallOutcome } from "./types";
+import { detectOnPath, runInstallCommand, runJson } from "./shell";
 
 // Grok has no headless install-by-name; its marketplace install is TUI-only. So
 // we install from the plugin repo directly — the exact source grok's built-in
-// "xai-official" marketplace catalogs for sentry. Hence a MARKETPLACE_SOURCE (the
+// "xAI Official" marketplace catalogs for sentry. Hence a MARKETPLACE_SOURCE (the
 // repo) but no MARKETPLACE registration step.
-// TODO: install sentry by name from the official "xai-official" marketplace once
+// TODO: install sentry by name from the official "xAI Official" marketplace once
 // grok exposes a headless command for it (today that is TUI-only).
 const MARKETPLACE_SOURCE = "getsentry/plugin-grok";
 const INSTALL_COMMAND = `grok plugin install ${MARKETPLACE_SOURCE} --trust`;
 const UPDATE_COMMAND = "grok plugin update sentry";
+const UNINSTALL_COMMAND = "grok plugin uninstall sentry";
+
+// `grok plugin list --json` emits an array of plugins. The two ways sentry can
+// be installed both report our repo as `source`, so `marketplace` is what tells
+// them apart: a direct repo install (ours) has `marketplace: null`, while a
+// marketplace install (e.g. "xAI Official") names that marketplace.
+interface GrokPlugin {
+  name?: string;
+  source?: string;
+  marketplace?: string | null;
+}
+
+async function listPlugins(system: SystemDeps): Promise<GrokPlugin[]> {
+  const plugins = await runJson<GrokPlugin[]>(system, "grok plugin list --json");
+  return Array.isArray(plugins) ? plugins : [];
+}
+
+// Ours: the sentry plugin installed directly from our repo, with no marketplace.
+function isOurs(plugin: GrokPlugin): boolean {
+  return (
+    plugin.name === "sentry" &&
+    !plugin.marketplace &&
+    (plugin.source ?? "").includes(MARKETPLACE_SOURCE)
+  );
+}
 
 export function createGrok(system: SystemDeps): Harness {
   return {
@@ -19,19 +44,37 @@ export function createGrok(system: SystemDeps): Harness {
 
     detect: async () => detectOnPath(system, "grok"),
 
-    isInstalled: async () => outputIncludes(system, "grok plugin list", "sentry"),
+    isInstalled: async () => (await listPlugins(system)).some(isOurs),
 
     canInstall: async () => ({ ok: true }),
 
-    install: async () => {
-      // `grok plugin install` errors on an already-installed repo, so update
-      // in place when the plugin is already present.
-      const command = (await outputIncludes(system, "grok plugin list", "sentry"))
-        ? UPDATE_COMMAND
-        : INSTALL_COMMAND;
+    cleanup: async () => {
+      // A sentry plugin installed from a marketplace (e.g. "xAI Official")
+      // shadows ours. Uninstall it so our direct-repo install is the one that
+      // resolves; ours (no marketplace) is left untouched.
+      const foreign = (await listPlugins(system)).find(
+        (plugin) => plugin.name === "sentry" && !isOurs(plugin),
+      );
 
-      await runInstallCommand(system, command);
-      return { kind: "done", command };
+      if (!foreign) {
+        return null;
+      }
+
+      await runInstallCommand(system, UNINSTALL_COMMAND);
+      const via = foreign.marketplace ? ` (installed via ${foreign.marketplace})` : "";
+      return `Removed conflicting sentry plugin${via}`;
+    },
+
+    install: async (): Promise<InstallOutcome> => {
+      await runInstallCommand(system, INSTALL_COMMAND);
+      return { kind: "done", command: INSTALL_COMMAND };
+    },
+
+    // `grok plugin install` errors on an already-installed repo, so update in
+    // place instead of reinstalling.
+    update: async (): Promise<InstallOutcome> => {
+      await runInstallCommand(system, UPDATE_COMMAND);
+      return { kind: "done", command: UPDATE_COMMAND };
     },
   };
 }

--- a/packages/installer/src/harnesses/shell.ts
+++ b/packages/installer/src/harnesses/shell.ts
@@ -15,13 +15,19 @@ export async function runInstallCommand(system: SystemDeps, command: string): Pr
   throw new Error(result.stderr || result.message || `Command failed: ${command}`);
 }
 
-// True when `command` succeeds and its output contains `needle` (case-insensitive).
-// Used to probe plugin/marketplace listings for an already-present entry.
-export async function outputIncludes(
-  system: SystemDeps,
-  command: string,
-  needle: string,
-): Promise<boolean> {
+// Run a command expected to emit JSON and return the parsed value. Returns null
+// when the command fails or its output is not valid JSON, so a missing or broken
+// listing reads as "nothing installed" rather than crashing the installer.
+export async function runJson<T>(system: SystemDeps, command: string): Promise<T | null> {
   const result = await system.run(command);
-  return result.ok && (result.stdout?.toLowerCase().includes(needle) ?? false);
+
+  if (!result.ok || !result.stdout) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(result.stdout) as T;
+  } catch {
+    return null;
+  }
 }

--- a/packages/installer/src/harnesses/types.ts
+++ b/packages/installer/src/harnesses/types.ts
@@ -1,14 +1,60 @@
+/**
+ * Result of an install or update attempt.
+ */
 export type InstallOutcome =
+  /**
+   * The operation completed automatically. `command` is the command that was
+   * run, with an optional `note` for any follow-up the user should know about.
+   */
   | { kind: "done"; command: string; note?: string }
+  /**
+   * The operation could not be automated; `instructions` tell the user how to
+   * finish it manually.
+   */
   | { kind: "manual"; instructions: string };
 
+/**
+ * Whether installation can proceed, carrying a `reason` when it cannot.
+ */
 export type InstallReadiness = { ok: true } | { ok: false; reason: string };
 
 export interface Harness {
+  /**
+   * Stable machine-readable identifier for the harness (e.g. "claude").
+   */
   readonly id: string;
+  /**
+   * Human-readable name shown in the UI (e.g. "Claude Code").
+   */
   readonly name: string;
+  /**
+   * Whether this harness is present on the system and worth offering to the
+   * user as an install target.
+   */
   detect(): Promise<boolean>;
+  /**
+   * Whether the Sentry plugin is already installed for this harness.
+   */
   isInstalled(): Promise<boolean>;
+  /**
+   * Whether installation can proceed, with a reason when it cannot (e.g. a
+   * missing CLI or unsupported version).
+   */
   canInstall(): Promise<InstallReadiness>;
+  /**
+   * Remove conflicting or legacy Sentry plugins before installing ours (e.g. a
+   * vendor's "official" plugin that would shadow this one). Runs first during
+   * install; optional because not every harness has anything to clean up.
+   * Returns a short description of what was removed (surfaced in the UI), or null
+   * when there was nothing to clean up.
+   */
+  cleanup?(): Promise<string | null>;
+  /**
+   * Install the plugin, assuming it is absent.
+   */
   install(): Promise<InstallOutcome>;
+  /**
+   * Update the plugin, assuming it is already present.
+   */
+  update(): Promise<InstallOutcome>;
 }

--- a/packages/installer/src/run.ts
+++ b/packages/installer/src/run.ts
@@ -10,8 +10,8 @@ export interface Detection {
 // `blocked`/`failed` are failures the caller surfaces and counts toward a
 // non-zero exit. installHarness never throws — every path maps to one of these.
 export type InstallResult =
-  | { kind: "done"; command: string; note?: string }
-  | { kind: "manual"; instructions: string }
+  | { kind: "done"; command: string; note?: string; cleaned?: string }
+  | { kind: "manual"; instructions: string; cleaned?: string }
   | { kind: "blocked"; reason: string }
   | { kind: "failed"; message: string };
 
@@ -37,9 +37,18 @@ export async function installHarness(detection: Detection): Promise<InstallResul
   }
 
   try {
+    // Clear out conflicting/legacy Sentry plugins first so ours is the one that
+    // resolves, then install or update based on what detection already found.
     // InstallOutcome (done | manual) is a subset of InstallResult, so a clean
-    // install passes straight through; only blocked/failed are added here.
-    return await detection.harness.install();
+    // run passes straight through; only blocked/failed and the cleanup note are
+    // added here.
+    const cleaned = (await detection.harness.cleanup?.()) ?? undefined;
+
+    const outcome = detection.installed
+      ? await detection.harness.update()
+      : await detection.harness.install();
+
+    return cleaned ? { ...outcome, cleaned } : outcome;
   } catch (err) {
     return { kind: "failed", message: err instanceof Error ? err.message : String(err) };
   }

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -81,18 +81,23 @@ function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
 
   return {
     title: installed ? `${harness.name} (reinstall)` : harness.name,
+    // Keep output (cleanup notes, manual steps, restart hints) visible after the
+    // task settles instead of letting it clear on completion.
+    rendererOptions: { persistentOutput: true },
     task: async (_ctx, task: TaskWrapper) => {
       const result = await installHarness(detection);
       ctx.results.push(result);
 
       switch (result.kind) {
-        case "done":
+        case "done": {
           task.title = `${harness.name} — ${result.command}`;
-          if (result.note) task.output = result.note;
+          const output = [result.cleaned, result.note].filter(Boolean).join("\n");
+          if (output) task.output = output;
           return;
+        }
         case "manual":
           task.title = `${harness.name} — manual steps required`;
-          task.output = result.instructions;
+          task.output = [result.cleaned, result.instructions].filter(Boolean).join("\n");
           return;
         case "blocked":
           task.skip(`${harness.name} — ${result.reason}`);


### PR DESCRIPTION
The installer probed for an already-installed Sentry plugin by grepping plain `plugin list` output for the substring `sentry`. That can't distinguish our plugin from another sentry plugin, and gives us no way to act on conflicting installs. This reworks detection and adds a cleanup step so ours is reliably the plugin that resolves.

Every harness now parses the `--json` variant of its listings rather than substring-matching. `plugin list --json` drives installed-detection — Claude and Codex match a marketplace-qualified id (`sentry@claude-plugins-official`, `sentry@sentry-plugin-marketplace`); Grok matches our repo source *with no marketplace*, since the xAI Official marketplace catalogs our repo as its source and `source` alone can't tell a direct repo install from a marketplace one (the `marketplace` field is the discriminator, null for ours). The marketplace-registered check uses `plugin marketplace list --json` the same way, which let the brittle `outputIncludes` substring helper be removed.

A new optional `cleanup` step runs before install to remove a conflicting or legacy Sentry plugin that would otherwise shadow ours. Codex removes the curated `sentry@openai-curated`; Grok uninstalls a marketplace-installed sentry so our direct-repo install takes over. `cleanup` returns a short description of what it removed, and the installer surfaces that as persistent task output so the removal is visible rather than silent (this also fixes the pre-existing Cursor restart note, which was being cleared on completion).

The single `install` method is split into explicit `install` and `update` so the orchestrator picks based on what detection already found instead of each harness re-probing its own listing. Finally, the closing line now names the agents that actually received the plugin ("Restart Claude Code and Codex to use Sentry with AI") instead of the vague "Restart your AI tools".
