### PR TITLE
feat(installer): name installed agents in the restart hint

### DIFF
--- a/packages/installer/src/__tests__/ui.test.ts
+++ b/packages/installer/src/__tests__/ui.test.ts
@@ -32,6 +32,27 @@ describe("runInstaller (non-interactive)", () => {
     expect(codex.install).toHaveBeenCalledOnce();
   });
 
+  it("closes by naming the agents to restart", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const claude = fakeHarness({ id: "claude", name: "Claude Code", detected: true });
+    const grok = fakeHarness({ id: "grok", name: "Grok", detected: true });
+
+    await runInstaller([claude, grok], { interactive: false });
+
+    expect(log).toHaveBeenCalledWith("\nRestart Claude Code and Grok to use Sentry with AI.");
+    log.mockRestore();
+  });
+
+  it("omits the restart hint when nothing was installed", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const claude = fakeHarness({ id: "claude", detected: false });
+
+    await runInstaller([claude], { interactive: false });
+
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Restart"));
+    log.mockRestore();
+  });
+
   it("returns false when an install fails but still installs the others", async () => {
     const claude = fakeHarness({ id: "claude", detected: true, error: new Error("boom") });
     const codex = fakeHarness({ id: "codex", detected: true });

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -48,8 +48,14 @@ interface Ctx {
   detections: Detection[];
   selected: Detection[];
   results: InstallResult[];
+  // Names of agents that actually received the plugin, for the closing restart
+  // hint. Blocked/failed agents are excluded — nothing to restart for those.
+  installed: string[];
   cancelled: boolean;
 }
+
+// "Claude Code", "Claude Code and Codex", "Claude Code, Codex, and Grok".
+const listFormatter = new Intl.ListFormat("en", { style: "long", type: "conjunction" });
 
 type TaskWrapper = ListrTaskWrapper<Ctx, any, any>;
 
@@ -93,11 +99,13 @@ function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
           task.title = `${harness.name} — ${result.command}`;
           const output = [result.cleaned, result.note].filter(Boolean).join("\n");
           if (output) task.output = output;
+          ctx.installed.push(harness.name);
           return;
         }
         case "manual":
           task.title = `${harness.name} — manual steps required`;
           task.output = [result.cleaned, result.instructions].filter(Boolean).join("\n");
+          ctx.installed.push(harness.name);
           return;
         case "blocked":
           task.skip(`${harness.name} — ${result.reason}`);
@@ -178,7 +186,13 @@ export async function runInstaller(
     },
   );
 
-  const ctx: Ctx = { detections: [], selected: [], results: [], cancelled: false };
+  const ctx: Ctx = {
+    detections: [],
+    selected: [],
+    results: [],
+    installed: [],
+    cancelled: false,
+  };
 
   try {
     await tasks.run(ctx);
@@ -195,8 +209,8 @@ export async function runInstaller(
     return false;
   }
 
-  if (ctx.results.length > 0) {
-    console.log("\nRestart your AI tools to load the Sentry plugin.");
+  if (ctx.installed.length > 0) {
+    console.log(`\nRestart ${listFormatter.format(ctx.installed)} to use Sentry with AI.`);
   }
 
   return ctx.results.every(installSucceeded);


### PR DESCRIPTION
The closing line said "Restart your AI tools to load the Sentry plugin",
which is vague when only some of the detected agents were installed.
List the agents that actually received the plugin instead, e.g. "Restart
Claude Code and Codex to use Sentry with AI". Blocked or failed agents
are excluded since there is nothing to restart for them.