### PR TITLE
feat(installer): keep per-agent install output on screen

### DIFF
--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -169,9 +169,16 @@ export async function runInstaller(
 
           // exitOnError: false so one agent failing does not abort the rest;
           // each subtask records its own result and the batch still settles.
+          // collapseSubtasks: false keeps the per-agent rows (and their command
+          // and cleanup output) on screen after the group finishes instead of
+          // folding them back into the parent line.
           return task.newListr(
             selected.map((detection) => installTask(ctx, detection)),
-            { concurrent: true, exitOnError: false },
+            {
+              concurrent: true,
+              exitOnError: false,
+              rendererOptions: { collapseSubtasks: false },
+            },
           );
         },
       },


### PR DESCRIPTION
The install subtasks run under a parent "Installing plugins" task, which
collapses its children once it completes — folding away each agent's
resolved command and cleanup note. Set collapseSubtasks: false so the
per-agent rows and their output stay visible after the group finishes.