### PR TITLE
feat(installer): stream live command output and theme the UI

### DIFF
--- a/packages/installer/src/__tests__/harnesses.test.ts
+++ b/packages/installer/src/__tests__/harnesses.test.ts
@@ -117,6 +117,16 @@ describe("claude harness", () => {
     );
   });
 
+  it("forwards the output sink to streamed commands", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const sink = {} as NodeJS.WritableStream;
+    await createClaude(system).install(sink);
+    expect(system.run).toHaveBeenCalledWith(
+      "claude plugin install sentry@claude-plugins-official",
+      sink,
+    );
+  });
+
   it("surfaces stderr when install fails", async () => {
     const harness = createClaude(
       fakeSystem({ run: () => ({ ok: false, stderr: "boom", message: "exit 1" }) }),
@@ -410,15 +420,5 @@ describe("cursor harness", () => {
 
     expect(outcome.kind).toBe("done");
     expect(system.run).toHaveBeenCalledWith(`git -C "${target}" pull`);
-  });
-
-  it("includes a restart note in the done outcome", async () => {
-    const system = fakeSystem({ homedir: "/home/user" });
-    const outcome = await createCursor(system).install();
-
-    expect(outcome.kind).toBe("done");
-    if (outcome.kind === "done") {
-      expect(outcome.note).toContain("Restart Cursor");
-    }
   });
 });

--- a/packages/installer/src/harnesses/claude.ts
+++ b/packages/installer/src/harnesses/claude.ts
@@ -1,4 +1,4 @@
-import { realSystem, type SystemDeps } from "../system";
+import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runInstallCommand, runJson } from "./shell";
 
@@ -33,13 +33,14 @@ async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
 // A fresh CLI has no marketplaces registered, so register the official one if it
 // is missing; otherwise refresh its index so the plugin resolves. Required by
 // both install and update.
-async function ensureMarketplace(system: SystemDeps): Promise<void> {
+async function ensureMarketplace(system: SystemDeps, output?: OutputSink): Promise<void> {
   const registered = await isMarketplaceRegistered(system);
   await runInstallCommand(
     system,
     registered
       ? `claude plugin marketplace update ${MARKETPLACE}`
       : `claude plugin marketplace add ${MARKETPLACE_SOURCE}`,
+    output,
   );
 }
 
@@ -54,15 +55,15 @@ export function createClaude(system: SystemDeps): Harness {
 
     canInstall: async () => ({ ok: true }),
 
-    install: async (): Promise<InstallOutcome> => {
-      await ensureMarketplace(system);
-      await runInstallCommand(system, INSTALL_COMMAND);
+    install: async (output): Promise<InstallOutcome> => {
+      await ensureMarketplace(system, output);
+      await runInstallCommand(system, INSTALL_COMMAND, output);
       return { kind: "done", command: INSTALL_COMMAND };
     },
 
-    update: async (): Promise<InstallOutcome> => {
-      await ensureMarketplace(system);
-      await runInstallCommand(system, UPDATE_COMMAND);
+    update: async (output): Promise<InstallOutcome> => {
+      await ensureMarketplace(system, output);
+      await runInstallCommand(system, UPDATE_COMMAND, output);
       return { kind: "done", command: UPDATE_COMMAND };
     },
   };

--- a/packages/installer/src/harnesses/codex.ts
+++ b/packages/installer/src/harnesses/codex.ts
@@ -1,4 +1,4 @@
-import { realSystem, type SystemDeps } from "../system";
+import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runInstallCommand, runJson } from "./shell";
 
@@ -50,22 +50,23 @@ async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
 // The Sentry plugin lives in its own marketplace, not a Codex default, so
 // register it if missing; otherwise refresh its snapshot so it resolves.
 // Required by both install and update.
-async function ensureMarketplace(system: SystemDeps): Promise<void> {
+async function ensureMarketplace(system: SystemDeps, output?: OutputSink): Promise<void> {
   const registered = await isMarketplaceRegistered(system);
   await runInstallCommand(
     system,
     registered
       ? `codex plugin marketplace upgrade ${MARKETPLACE}`
       : `codex plugin marketplace add ${MARKETPLACE_SOURCE}`,
+    output,
   );
 }
 
 // Codex has no plugin update command; `add` is idempotent and re-points an
 // already-installed plugin at the refreshed snapshot, so install and update
 // share this single path.
-async function addPlugin(system: SystemDeps): Promise<InstallOutcome> {
-  await ensureMarketplace(system);
-  await runInstallCommand(system, INSTALL_COMMAND);
+async function addPlugin(system: SystemDeps, output?: OutputSink): Promise<InstallOutcome> {
+  await ensureMarketplace(system, output);
+  await runInstallCommand(system, INSTALL_COMMAND, output);
   return { kind: "done", command: INSTALL_COMMAND };
 }
 
@@ -80,18 +81,18 @@ export function createCodex(system: SystemDeps): Harness {
 
     canInstall: async () => ({ ok: true }),
 
-    cleanup: async () => {
+    cleanup: async (output) => {
       if (!(await hasPlugin(system, LEGACY_PLUGIN_ID))) {
         return null;
       }
 
-      await runInstallCommand(system, `codex plugin remove ${LEGACY_PLUGIN_ID}`);
+      await runInstallCommand(system, `codex plugin remove ${LEGACY_PLUGIN_ID}`, output);
       return `Removed conflicting plugin ${LEGACY_PLUGIN_ID}`;
     },
 
-    install: async () => addPlugin(system),
+    install: async (output) => addPlugin(system, output),
 
-    update: async () => addPlugin(system),
+    update: async (output) => addPlugin(system, output),
   };
 }
 

--- a/packages/installer/src/harnesses/cursor.ts
+++ b/packages/installer/src/harnesses/cursor.ts
@@ -1,10 +1,9 @@
 import { join } from "node:path";
-import { realSystem, type SystemDeps } from "../system";
+import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runInstallCommand } from "./shell";
 
 const PLUGIN_REPO = "https://github.com/getsentry/plugin-cursor.git";
-const RESTART_NOTE = 'Restart Cursor or run "Developer: Reload Window" to activate the plugin.';
 
 function pluginDir(system: SystemDeps): string {
   return join(system.homedir, ".cursor", "plugins", "local", "sentry");
@@ -45,17 +44,17 @@ export function createCursor(system: SystemDeps): Harness {
         ? { ok: true }
         : { ok: false, reason: "git is required to clone the Cursor plugin" },
 
-    install: async (): Promise<InstallOutcome> => {
+    install: async (output): Promise<InstallOutcome> => {
       // Quote the target: Windows home paths routinely contain spaces.
       const command = `git clone ${PLUGIN_REPO} "${pluginDir(system)}"`;
-      await runInstallCommand(system, command);
-      return { kind: "done", command, note: RESTART_NOTE };
+      await runInstallCommand(system, command, output);
+      return { kind: "done", command };
     },
 
-    update: async (): Promise<InstallOutcome> => {
+    update: async (output): Promise<InstallOutcome> => {
       const command = `git -C "${pluginDir(system)}" pull`;
-      await runInstallCommand(system, command);
-      return { kind: "done", command, note: RESTART_NOTE };
+      await runInstallCommand(system, command, output);
+      return { kind: "done", command };
     },
   };
 }

--- a/packages/installer/src/harnesses/grok.ts
+++ b/packages/installer/src/harnesses/grok.ts
@@ -1,4 +1,4 @@
-import { realSystem, type SystemDeps } from "../system";
+import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runInstallCommand, runJson } from "./shell";
 
@@ -48,7 +48,7 @@ export function createGrok(system: SystemDeps): Harness {
 
     canInstall: async () => ({ ok: true }),
 
-    cleanup: async () => {
+    cleanup: async (output) => {
       // A sentry plugin installed from a marketplace (e.g. "xAI Official")
       // shadows ours. Uninstall it so our direct-repo install is the one that
       // resolves; ours (no marketplace) is left untouched.
@@ -60,20 +60,20 @@ export function createGrok(system: SystemDeps): Harness {
         return null;
       }
 
-      await runInstallCommand(system, UNINSTALL_COMMAND);
+      await runInstallCommand(system, UNINSTALL_COMMAND, output);
       const via = foreign.marketplace ? ` (installed via ${foreign.marketplace})` : "";
       return `Removed conflicting sentry plugin${via}`;
     },
 
-    install: async (): Promise<InstallOutcome> => {
-      await runInstallCommand(system, INSTALL_COMMAND);
+    install: async (output): Promise<InstallOutcome> => {
+      await runInstallCommand(system, INSTALL_COMMAND, output);
       return { kind: "done", command: INSTALL_COMMAND };
     },
 
     // `grok plugin install` errors on an already-installed repo, so update in
     // place instead of reinstalling.
-    update: async (): Promise<InstallOutcome> => {
-      await runInstallCommand(system, UPDATE_COMMAND);
+    update: async (output): Promise<InstallOutcome> => {
+      await runInstallCommand(system, UPDATE_COMMAND, output);
       return { kind: "done", command: UPDATE_COMMAND };
     },
   };

--- a/packages/installer/src/harnesses/shell.ts
+++ b/packages/installer/src/harnesses/shell.ts
@@ -1,12 +1,19 @@
-import type { SystemDeps } from "../system";
+import type { OutputSink, SystemDeps } from "../system";
 
 export async function detectOnPath(system: SystemDeps, binary: string): Promise<boolean> {
   const locator = system.platform === "win32" ? "where" : "which";
   return (await system.run(`${locator} ${binary}`)).ok;
 }
 
-export async function runInstallCommand(system: SystemDeps, command: string): Promise<void> {
-  const result = await system.run(command);
+// Runs a mutating command, streaming its output to `output` when given. Only the
+// sink is forwarded when present, so non-streaming callers (and tests) still see
+// a single-argument call.
+export async function runInstallCommand(
+  system: SystemDeps,
+  command: string,
+  output?: OutputSink,
+): Promise<void> {
+  const result = output ? await system.run(command, output) : await system.run(command);
 
   if (result.ok) {
     return;

--- a/packages/installer/src/harnesses/types.ts
+++ b/packages/installer/src/harnesses/types.ts
@@ -1,3 +1,5 @@
+import type { OutputSink } from "../system";
+
 /**
  * Result of an install or update attempt.
  */
@@ -46,15 +48,17 @@ export interface Harness {
    * vendor's "official" plugin that would shadow this one). Runs first during
    * install; optional because not every harness has anything to clean up.
    * Returns a short description of what was removed (surfaced in the UI), or null
-   * when there was nothing to clean up.
+   * when there was nothing to clean up. Streams command output to `output`.
    */
-  cleanup?(): Promise<string | null>;
+  cleanup?(output?: OutputSink): Promise<string | null>;
   /**
-   * Install the plugin, assuming it is absent.
+   * Install the plugin, assuming it is absent. Streams command output to
+   * `output` when provided.
    */
-  install(): Promise<InstallOutcome>;
+  install(output?: OutputSink): Promise<InstallOutcome>;
   /**
-   * Update the plugin, assuming it is already present.
+   * Update the plugin, assuming it is already present. Streams command output to
+   * `output` when provided.
    */
-  update(): Promise<InstallOutcome>;
+  update(output?: OutputSink): Promise<InstallOutcome>;
 }

--- a/packages/installer/src/run.ts
+++ b/packages/installer/src/run.ts
@@ -1,3 +1,4 @@
+import type { OutputSink } from "./system";
 import type { Harness } from "./harnesses/types";
 
 export interface Detection {
@@ -30,7 +31,10 @@ export async function detectHarnesses(harnesses: Harness[]): Promise<Detection[]
 // Install (or reinstall) a single harness. A blocked prerequisite short-circuits
 // before install runs; a thrown install is captured as a `failed` result so a
 // concurrent batch can keep going instead of rejecting the whole run.
-export async function installHarness(detection: Detection): Promise<InstallResult> {
+export async function installHarness(
+  detection: Detection,
+  output?: OutputSink,
+): Promise<InstallResult> {
   const readiness = await detection.harness.canInstall();
   if (!readiness.ok) {
     return { kind: "blocked", reason: readiness.reason };
@@ -39,14 +43,14 @@ export async function installHarness(detection: Detection): Promise<InstallResul
   try {
     // Clear out conflicting/legacy Sentry plugins first so ours is the one that
     // resolves, then install or update based on what detection already found.
-    // InstallOutcome (done | manual) is a subset of InstallResult, so a clean
-    // run passes straight through; only blocked/failed and the cleanup note are
-    // added here.
-    const cleaned = (await detection.harness.cleanup?.()) ?? undefined;
+    // Command output streams to `output` as it runs. InstallOutcome (done |
+    // manual) is a subset of InstallResult, so a clean run passes straight
+    // through; only blocked/failed and the cleanup note are added here.
+    const cleaned = (await detection.harness.cleanup?.(output)) ?? undefined;
 
     const outcome = detection.installed
-      ? await detection.harness.update()
-      : await detection.harness.install();
+      ? await detection.harness.update(output)
+      : await detection.harness.install(output);
 
     return cleaned ? { ...outcome, cleaned } : outcome;
   } catch (err) {

--- a/packages/installer/src/system.ts
+++ b/packages/installer/src/system.ts
@@ -1,9 +1,14 @@
-import { exec } from "node:child_process";
+import { exec, spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
+
+// Where a running command's output can be streamed live (e.g. a Listr
+// `task.stdout()`). Plain Node Writable, so the harness layer stays unaware of
+// the renderer.
+export type OutputSink = NodeJS.WritableStream;
 
 export interface ShellResult {
   ok: boolean;
@@ -14,15 +19,43 @@ export interface ShellResult {
 
 export interface SystemDeps {
   // Async so the event loop stays free while a command runs — this is what lets
-  // the spinner animate and concurrent installs actually overlap.
-  run(command: string): Promise<ShellResult>;
+  // the spinner animate and concurrent installs actually overlap. When `output`
+  // is given, stdout/stderr are streamed to it as they arrive (and still
+  // captured in the result); without it, output is simply buffered.
+  run(command: string, output?: OutputSink): Promise<ShellResult>;
   exists(path: string): boolean;
   platform: NodeJS.Platform;
   homedir: string;
 }
 
+// Pipe a command's stdout/stderr straight into `output` and resolve ok/message
+// from the exit code. The live stream already shows the real output (including
+// any error text), so there is no need to buffer it for the result. `end: false`
+// keeps the shared sink open for the next command in the sequence.
+function runStreaming(command: string, output: OutputSink): Promise<ShellResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, { shell: true });
+
+    child.stdout?.pipe(output, { end: false });
+    child.stderr?.pipe(output, { end: false });
+
+    child.on("error", (err) => resolve({ ok: false, message: err.message }));
+    child.on("close", (code) =>
+      resolve(
+        code === 0
+          ? { ok: true }
+          : { ok: false, message: `Command failed with exit code ${code}: ${command}` },
+      ),
+    );
+  });
+}
+
 export const realSystem: SystemDeps = {
-  async run(command) {
+  async run(command, output) {
+    if (output) {
+      return runStreaming(command, output);
+    }
+
     try {
       const { stdout } = await execAsync(command, { encoding: "utf8" });
       return { ok: true, stdout: stdout.trim() };

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -1,6 +1,14 @@
 import { checkbox } from "@inquirer/prompts";
 import { ListrInquirerPromptAdapter } from "@listr2/prompt-adapter-inquirer";
-import { Listr, type ListrTask, type ListrTaskWrapper } from "listr2";
+import {
+  color,
+  createWritable,
+  Listr,
+  ListrDefaultRendererLogLevels,
+  Spinner,
+  type ListrTask,
+  type ListrTaskWrapper,
+} from "listr2";
 import type { Harness } from "./harnesses/types";
 import {
   detectHarnesses,
@@ -57,6 +65,11 @@ interface Ctx {
 // "Claude Code", "Claude Code and Codex", "Claude Code, Codex, and Grok".
 const listFormatter = new Intl.ListFormat("en", { style: "long", type: "conjunction" });
 
+// A diamond that pulses small-to-large for the in-progress spinner.
+class DiamondSpinner extends Spinner {
+  protected readonly spinner = ["◇", "◈", "◆", "◈"];
+}
+
 type TaskWrapper = ListrTaskWrapper<Ctx, any, any>;
 
 // inquirer raises ExitPromptError when the user hits Ctrl-C / Esc at the
@@ -76,6 +89,19 @@ async function promptForAgents(detected: Detection[], task: TaskWrapper): Promis
       value: detection.harness.id,
       checked: true,
     })),
+    // The cursor must stay one column wide: inquirer pads inactive rows with a
+    // single hardcoded space, so a wider cursor would shift the active row's
+    // checkbox out of alignment. Put the gap after the arrow on the checkbox
+    // icons instead, so every row reserves the same two columns before the box.
+    theme: {
+      // Hollow diamond in place of the default "?" prompt prefix.
+      prefix: color.blue("◇"),
+      icon: {
+        cursor: "→",
+        checked: ` ${color.green("◉")}`,
+        unchecked: " ◯",
+      },
+    },
   });
 
   return detected.filter((detection) => selectedIds.includes(detection.harness.id));
@@ -87,24 +113,45 @@ function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
 
   return {
     title: installed ? `${harness.name} (reinstall)` : harness.name,
-    // Keep output (cleanup notes, manual steps, restart hints) visible after the
-    // task settles instead of letting it clear on completion.
-    rendererOptions: { persistentOutput: true },
+    // outputBar shows every streamed line of the running commands; persistentOutput
+    // keeps it (and the trailing notes below) on screen after the task settles.
+    rendererOptions: { persistentOutput: true, outputBar: Infinity },
     task: async (_ctx, task: TaskWrapper) => {
-      const result = await installHarness(detection);
+      // Stream the install/cleanup command output live under this task's row,
+      // grayed (the renderer's color map only tints the icon, so gray the body
+      // through a createWritable transform). Trailing notes go to the raw sink so
+      // their text stays full color and reads as ours, not command noise.
+      const raw = task.stdout();
+      // Gray per line, leaving blank lines genuinely empty — otherwise the gray
+      // escapes make them non-empty and defeat the renderer's removeEmptyLines.
+      const out = createWritable((chunk) =>
+        raw.write(
+          chunk
+            .toString()
+            .split("\n")
+            .map((line: string) => (line ? color.gray(line) : line))
+            .join("\n"),
+        ),
+      );
+      const result = await installHarness(detection, out);
       ctx.results.push(result);
 
+      // Trailing notes (what cleanup removed, manual steps, restart hints) are not
+      // command output, so append them to the raw stream rather than overwriting it.
+      const writeTail = (...lines: (string | undefined)[]) => {
+        const tail = lines.filter(Boolean).join("\n");
+        if (tail) raw.write(`\n${tail}\n`);
+      };
+
       switch (result.kind) {
-        case "done": {
+        case "done":
           task.title = `${harness.name} — ${result.command}`;
-          const output = [result.cleaned, result.note].filter(Boolean).join("\n");
-          if (output) task.output = output;
+          writeTail(result.cleaned, result.note);
           ctx.installed.push(harness.name);
           return;
-        }
         case "manual":
           task.title = `${harness.name} — manual steps required`;
-          task.output = [result.cleaned, result.instructions].filter(Boolean).join("\n");
+          writeTail(result.cleaned, result.instructions);
           ctx.installed.push(harness.name);
           return;
         case "blocked":
@@ -190,6 +237,20 @@ export async function runInstaller(
       concurrent: false,
       exitOnError: true,
       silentRendererCondition: !!process.env.VITEST,
+      rendererOptions: {
+        // Render streamed command output (the OUTPUT log level) in gray so it
+        // reads as secondary to the task titles.
+        color: { [ListrDefaultRendererLogLevels.OUTPUT]: (text) => color.gray(text ?? "") },
+        spinner: new DiamondSpinner(),
+        // Diamond-themed icons in place of listr's defaults.
+        icon: {
+          [ListrDefaultRendererLogLevels.COMPLETED]: "◆",
+          [ListrDefaultRendererLogLevels.OUTPUT]: "◦",
+          [ListrDefaultRendererLogLevels.OUTPUT_WITH_BOTTOMBAR]: "◦",
+          [ListrDefaultRendererLogLevels.SKIPPED_WITH_COLLAPSE]: "◇",
+          [ListrDefaultRendererLogLevels.FAILED]: "✕",
+        },
+      },
     },
   );
 


### PR DESCRIPTION
The installer showed a static spinner while each agent installed, giving no sense of what was actually happening (or why something hung). This streams the real command output live and gives the whole run a Sentry-themed look.

An optional output sink threads from the install task down through `install`/`update`/`cleanup` to the shell runner. The real system spawns the command and pipes its stdout/stderr straight into the task's `task.stdout()` stream, so output appears live under each agent's row. Detection probes (`plugin list --json`, marketplace checks) still buffer and parse as before — only the mutating commands stream. Non-streaming callers still make single-argument `system.run` calls, so existing behavior and tests are unaffected.

Theming, to match the banner: diamond task icons with a small-to-large pulsing diamond spinner (`◇◈◆◈`); streamed output grayed (per line, so blank lines stay genuinely empty and listr's `removeEmptyLines` can drop them) and kept on screen via `persistentOutput` + `outputBar`; an arrow (`→`) prompt cursor with the trailing gap moved onto the checkbox icons so active and inactive rows stay aligned; and a blue hollow-diamond (`◇`) prompt prefix in place of the default `?`. The Cursor restart note is dropped since the closing "Restart … to use Sentry with AI" line already covers it.

Icons, spinner, and the prompt theme only render through listr's TTY renderer, so they show up in an interactive run rather than piped/CI output.