### PR TITLE
fix(installer): surface command stderr when streaming installs

### DIFF
--- a/packages/installer/src/system.ts
+++ b/packages/installer/src/system.ts
@@ -36,15 +36,27 @@ function runStreaming(command: string, output: OutputSink): Promise<ShellResult>
   return new Promise((resolve) => {
     const child = spawn(command, { shell: true });
 
+    // Tee stderr: pipe it to the live view AND buffer it, so a failure can throw
+    // the command's actual error text rather than a generic exit-code message.
+    // Decode as UTF-8 so a multibyte char split across chunks isn't corrupted.
+    let stderr = "";
+    child.stderr?.setEncoding("utf8");
     child.stdout?.pipe(output, { end: false });
     child.stderr?.pipe(output, { end: false });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
 
     child.on("error", (err) => resolve({ ok: false, message: err.message }));
     child.on("close", (code) =>
       resolve(
         code === 0
           ? { ok: true }
-          : { ok: false, message: `Command failed with exit code ${code}: ${command}` },
+          : {
+              ok: false,
+              stderr: stderr.trim(),
+              message: `Command failed with exit code ${code}: ${command}`,
+            },
       ),
     );
   });


### PR DESCRIPTION
When an install streams through an output sink, `runStreaming` piped the command's stderr to the live view but never captured it into the result. A failure then fell through `runInstallCommand`'s `result.stderr || result.message` to the generic "Command failed with exit code N" message. Since the interactive UI always passes a sink, Listr's failure text was almost always that generic message rather than the agent CLI's actual error.

This tees stderr: it keeps piping to the sink for the live view and also buffers it into the `ShellResult`, so the thrown error carries the real text. Verified that a failing command both streams its stderr and returns it in `result.stderr`.