### PR TITLE
feat(mcp): tag Sentry MCP server URL with utm_source

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "sentry": {
       "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
+      "url": "https://mcp.sentry.dev/mcp?utm_source=plugin"
     }
   }
 }


### PR DESCRIPTION
Adds `?utm_source=plugin` to the Sentry MCP server URL in the root `mcp.json` so traffic that reaches the MCP server via the AI plugin can be attributed back to it. The Cursor, Codex, and Grok builds copy this file through verbatim, so the tag flows to all three distributions.