### PR TITLE
ci(installer): bump installer package.json during craft prepare

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -2,6 +2,9 @@
 minVersion: "2.21.0"
 # Single segment only -- craft splits the branch name on the first "/".
 releaseBranchPrefix: release-installer
+# The default bump targets the root package.json, which is private and
+# unversioned -- bump packages/installer (the published package) instead.
+preReleaseCommand: bash scripts/bump-version.sh
 changelog:
   filePath: packages/installer/CHANGELOG.md
   policy: simple

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+### Bumps the published package version during `craft prepare`.
+###
+### craft invokes this as: bump-version.sh <old-version> <new-version>
+### The published artifact is built from packages/installer, so that is the
+### package.json that must carry the release version -- the repo root is
+### private and unversioned.
+set -euo pipefail
+
+NEW_VERSION="${2}"
+
+cd "$(dirname "$0")/../packages/installer"
+pnpm version "${NEW_VERSION}" --no-git-tag-version --no-git-checks --allow-same-version


### PR DESCRIPTION
The 0.1.1 release publish failed with an npm 403 ("cannot publish over the previously published versions: 0.1.0"). The tarball craft built was `sentry-ai-0.1.0.tgz` — craft's default version bump targets the repo-root `package.json`, which is `private` and has no `version` field, so craft simply *added* `"version": "0.1.1"` to the root and never touched the package that actually gets published. The artifact is built from `packages/installer`, whose `package.json` stayed at `0.1.0`.

This wires a `preReleaseCommand` into `.craft.yml` pointing at `scripts/bump-version.sh`, which bumps `packages/installer/package.json` via `pnpm version --no-git-tag-version --no-git-checks`. `--no-git-checks` is needed because craft's working tree may be dirty when the command runs.

Once this lands, re-running the Release workflow for 0.1.1 will produce a correctly-versioned `sentry-ai-0.1.1.tgz`.