### PR TITLE
ci(installer): bump release version with npm instead of pnpm

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -5,9 +5,13 @@
 ### The published artifact is built from packages/installer, so that is the
 ### package.json that must carry the release version -- the repo root is
 ### private and unversioned.
+###
+### Uses `npm pkg set` rather than pnpm: craft's container ships npm but not
+### pnpm, and this is a plain package.json edit -- no install, lockfile, or
+### git checks involved.
 set -euo pipefail
 
 NEW_VERSION="${2}"
 
 cd "$(dirname "$0")/../packages/installer"
-pnpm version "${NEW_VERSION}" --no-git-tag-version --no-git-checks --allow-same-version
+npm pkg set version="${NEW_VERSION}"


### PR DESCRIPTION
Follow-up to #192. The `preReleaseCommand` failed in craft's container with `pnpm: command not found` — the craft image ships `node`/`npm` but not `pnpm`, and the Release workflow doesn't set pnpm up.

Switch the bump to `npm pkg set version`, which is present in the container and is a plain `package.json` edit: no install, no lockfile changes, no git working-tree checks. This is the approach pnpm itself recommends when `pnpm pkg` is unavailable.