### PR TITLE
fix(claude): Add utm_source=plugin to inline MCP server URL

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -11,7 +11,7 @@
   "mcpServers": {
     "sentry": {
       "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
+      "url": "https://mcp.sentry.dev/mcp?utm_source=plugin"
     }
   }
 }

--- a/plugin-src/claude/plugin.json
+++ b/plugin-src/claude/plugin.json
@@ -12,7 +12,7 @@
   "mcpServers": {
     "sentry": {
       "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
+      "url": "https://mcp.sentry.dev/mcp?utm_source=plugin"
     }
   }
 }


### PR DESCRIPTION
Claude's `plugin.json` was declaring the MCP server without `?utm_source=plugin`, so all Claude-originated traffic was invisible in the `app.utm_source:plugin` Sentry pivot.

Cursor, Codex, and Grok already include the param in their distributed configs. This brings Claude in line.

Two files changed:
- `plugin-src/claude/plugin.json` — source manifest
- `.claude-plugin/plugin.json` — built artifact

Note: `getsentry/plugin-claude` also needs the same one-line fix. Branch `fix/mcp-utm-source` is pushed there but a PR couldn't be opened automatically (permission error). Whoever has write access to that repo can open it.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0ALBU24PC4%3A1781739731.360829%22)