### PR TITLE
feat(installer): add --no-telemetry flag and DO_NOT_TRACK support

### DIFF
--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineCommand, runMain } from "citty";
 import { harnesses } from "./harnesses";
-import { initTelemetry } from "./instrument";
+import { captureAndFlush, initTelemetry } from "./instrument";
 import { runInstaller } from "./ui";
 
 // Initialize telemetry before citty parses arguments so that any startup errors
@@ -50,8 +50,15 @@ const install = defineCommand({
   },
   async run({ args }) {
     const interactive = args.interactive && !args.yes;
-    const ok = await runInstaller(harnesses, { interactive });
-    process.exit(ok ? 0 : 1);
+    try {
+      const ok = await runInstaller(harnesses, { interactive });
+      process.exit(ok ? 0 : 1);
+    } catch (err) {
+      // Unexpected error outside the Listr runner: capture and flush before exit
+      // so crashes during the command execution path are not silently dropped.
+      await captureAndFlush(err);
+      throw err;
+    }
   },
 });
 

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -1,9 +1,19 @@
-import "./instrument";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineCommand, runMain } from "citty";
 import { harnesses } from "./harnesses";
+import { initTelemetry } from "./instrument";
 import { runInstaller } from "./ui";
+
+// Initialize telemetry before citty parses arguments so that any startup errors
+// are captured. We pre-scan raw argv for --no-telemetry ourselves here because
+// citty has not run yet. DO_NOT_TRACK=1 (https://consoledonottrack.com) also
+// disables telemetry.
+const telemetryEnabled =
+  process.env.DO_NOT_TRACK !== "1" &&
+  !process.argv.slice(2).includes("--no-telemetry");
+
+initTelemetry(telemetryEnabled);
 
 const { version, description } = JSON.parse(
   readFileSync(join(__dirname, "../package.json"), "utf8"),
@@ -28,6 +38,12 @@ const install = defineCommand({
       alias: "y",
       description: "Alias for --no-interactive",
       default: false,
+    },
+    telemetry: {
+      type: "boolean",
+      description:
+        "Send crash reports to Sentry (default: on). Pass --no-telemetry or set DO_NOT_TRACK=1 to disable.",
+      default: true,
     },
   },
   async run({ args }) {

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -9,8 +9,10 @@ import { runInstaller } from "./ui";
 // are captured. We pre-scan raw argv for --no-telemetry ourselves here because
 // citty has not run yet. DO_NOT_TRACK=1 (https://consoledonottrack.com) also
 // disables telemetry.
+const DO_NOT_TRACK_VALUES = new Set(["1", "true", "yes"]);
+
 const telemetryEnabled =
-  process.env.DO_NOT_TRACK !== "1" &&
+  !DO_NOT_TRACK_VALUES.has((process.env.DO_NOT_TRACK ?? "").toLowerCase()) &&
   !process.argv.slice(2).includes("--no-telemetry");
 
 initTelemetry(telemetryEnabled);

--- a/packages/installer/src/instrument.ts
+++ b/packages/installer/src/instrument.ts
@@ -1,14 +1,22 @@
 import * as Sentry from "@sentry/node";
 
-Sentry.init({
-  dsn:
-    process.env.SENTRY_DSN ??
-    "https://229b213cf5670aeb117d4de56ba6814e@o1.ingest.us.sentry.io/4511570959335425",
+// Call once at startup. When `enabled` is false (--no-telemetry or
+// DO_NOT_TRACK=1) this is a no-op and the Sentry SDK is never loaded.
+export function initTelemetry(enabled: boolean): void {
+  if (!enabled) {
+    return;
+  }
 
-  tracesSampleRate: 1.0,
-});
+  Sentry.init({
+    dsn:
+      process.env.SENTRY_DSN ??
+      "https://229b213cf5670aeb117d4de56ba6814e@o1.ingest.us.sentry.io/4511570959335425",
 
-process.on("SIGTERM", async () => {
-  await Sentry.close(2000);
-  process.exit(0);
-});
+    tracesSampleRate: 1.0,
+  });
+
+  process.on("SIGTERM", async () => {
+    await Sentry.close(2000);
+    process.exit(0);
+  });
+}

--- a/packages/installer/src/instrument.ts
+++ b/packages/installer/src/instrument.ts
@@ -1,22 +1,54 @@
-import * as Sentry from "@sentry/node";
+import type * as SentryNode from "@sentry/node";
 
-// Call once at startup. When `enabled` is false (--no-telemetry or
-// DO_NOT_TRACK=1) this is a no-op and the Sentry SDK is never loaded.
+type SentryInstance = typeof SentryNode | undefined;
+
+// Resolves to the live Sentry module once initialized, or undefined when
+// telemetry is disabled or the SDK fails to load. Exported so the command
+// handler can explicitly capture and flush before exit rather than relying
+// solely on global uncaughtException handlers.
+let sentryReady: Promise<SentryInstance> = Promise.resolve(undefined);
+
+// Kick off @sentry/node initialization in the background so its ~200ms OTel
+// startup runs concurrently with CLI setup instead of blocking the banner.
+// Important errors from the command execution path should go through
+// captureAndFlush rather than relying only on the global handlers installed
+// after this promise resolves.
 export function initTelemetry(enabled: boolean): void {
   if (!enabled) {
     return;
   }
 
-  Sentry.init({
-    dsn:
-      process.env.SENTRY_DSN ??
-      "https://229b213cf5670aeb117d4de56ba6814e@o1.ingest.us.sentry.io/4511570959335425",
+  sentryReady = import("@sentry/node")
+    .then((Sentry) => {
+      Sentry.init({
+        dsn:
+          process.env.SENTRY_DSN ??
+          "https://229b213cf5670aeb117d4de56ba6814e@o1.ingest.us.sentry.io/4511570959335425",
 
-    tracesSampleRate: 1.0,
-  });
+        tracesSampleRate: 1.0,
+      });
 
-  process.on("SIGTERM", async () => {
-    await Sentry.close(2000);
-    process.exit(0);
-  });
+      process.on("SIGTERM", async () => {
+        await Sentry.close(2000);
+        process.exit(0);
+      });
+
+      return Sentry as SentryInstance;
+    })
+    .catch(() => undefined);
+}
+
+// Capture an exception and flush pending events. Waits up to 2s for Sentry to
+// finish initializing (handling the window where init is still in flight);
+// silently no-ops when telemetry is disabled or the SDK failed to load.
+export async function captureAndFlush(err: unknown): Promise<void> {
+  const Sentry = await Promise.race([
+    sentryReady,
+    new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 2000)),
+  ]);
+
+  if (Sentry) {
+    Sentry.captureException(err);
+    await Sentry.flush(1000);
+  }
 }


### PR DESCRIPTION
## What

Adds an opt-out for installer telemetry via `--no-telemetry` and the `DO_NOT_TRACK=1` env var.

Before this change `instrument.ts` was a side-effectful import that initialized the Sentry SDK unconditionally on every run with no way to disable it. Now:

- `initTelemetry(enabled)` is an explicit exported function instead of a bare module side effect
- `index.ts` pre-scans raw `process.argv` for `--no-telemetry` (before citty parses) and checks `DO_NOT_TRACK` — same pattern as `--no-interactive` already uses for boolean negation
- The `telemetry` boolean arg is declared in the `install` command so it shows up in `--help`
- When disabled, the Sentry SDK is never initialized — not just silenced

## Why

The installer had no disclosure and no opt-out for telemetry. `DO_NOT_TRACK=1` is a [widely-honored convention](https://consoledonottrack.com) that developers reasonably expect CLI tools to respect.

## Verified

All 67 existing tests pass (`pnpm --filter @sentry/ai test`). No new test surface needed — the telemetry init is already excluded in the test environment via `VITEST`.

---
[View Session in Sentry](https://sentry.sentry.io/traces/?project=4510944073809921&query=gen_ai.conversation.id%3A%22slack%3AC0ALBU24PC4%3A1781741854.295209%22)