### PR TITLE
release: add 0.1.2 changelog entry

### DIFF
--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.2
+
+- Add `--no-telemetry` flag and `DO_NOT_TRACK=1` env var support to opt out
+  of crash reporting telemetry.
+- Give the install banner brand voice.
+
 ## 0.1.1
 
 - Detect installed agents via their JSON config and clean up conflicting


### PR DESCRIPTION
Adds the missing changelog entry for 0.1.2 so craft can prepare the release.

Changes since 0.1.1:
- `--no-telemetry` / `DO_NOT_TRACK=1` opt-out (#197)
- Themed install banner with brand voice (#193)