### PR TITLE
feat(installer): add a remove subcommand to uninstall the plugin

### DIFF
--- a/packages/installer/README.md
+++ b/packages/installer/README.md
@@ -41,6 +41,15 @@ For each detected assistant, the installer runs that tool's native plugin comman
 
 Each per-agent plugin is built and published from the [`sentry-for-ai`](https://github.com/getsentry/sentry-for-ai) repository, which is the source of truth for all skills and commands.
 
+## Removing the plugin
+
+```bash
+npx @sentry/ai remove                  # interactive — pick which agents to remove from
+npx @sentry/ai remove --no-interactive # remove from every agent that has it
+```
+
+`uninstall` is an alias for `remove`. This only offers agents that currently have the plugin, and removes the Sentry plugin itself — each tool's plugin marketplace is left registered. Restart your AI tools afterward to drop the plugin.
+
 ## Requirements
 
 - Node.js 18 or newer

--- a/packages/installer/src/__tests__/fake-harness.ts
+++ b/packages/installer/src/__tests__/fake-harness.ts
@@ -9,6 +9,7 @@ export interface FakeHarnessOptions {
   readiness?: InstallReadiness;
   outcome?: InstallOutcome;
   updateOutcome?: InstallOutcome;
+  removeOutcome?: InstallOutcome;
   error?: Error;
   // When set, the harness exposes a cleanup spy resolving to this description so
   // tests can assert it runs (and that it runs before install/update). Pass an
@@ -34,6 +35,12 @@ export function fakeHarness(options: FakeHarnessOptions): Harness {
         throw options.error;
       }
       return options.updateOutcome ?? { kind: "done", command: `${options.id} update` };
+    }),
+    remove: vi.fn(async () => {
+      if (options.error) {
+        throw options.error;
+      }
+      return options.removeOutcome ?? { kind: "done", command: `${options.id} remove` };
     }),
   };
 

--- a/packages/installer/src/__tests__/harnesses.test.ts
+++ b/packages/installer/src/__tests__/harnesses.test.ts
@@ -127,6 +127,20 @@ describe("claude harness", () => {
     );
   });
 
+  it("removes via the uninstall command, leaving the marketplace registered", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createClaude(system).remove();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "claude plugin uninstall sentry@claude-plugins-official",
+    });
+    expect(system.run).toHaveBeenCalledWith(
+      "claude plugin uninstall sentry@claude-plugins-official",
+    );
+    expect(system.run).not.toHaveBeenCalledWith(expect.stringContaining("marketplace remove"));
+  });
+
   it("surfaces stderr when install fails", async () => {
     const harness = createClaude(
       fakeSystem({ run: () => ({ ok: false, stderr: "boom", message: "exit 1" }) }),
@@ -221,6 +235,17 @@ describe("codex harness", () => {
     expect(system.run).toHaveBeenCalledWith(
       "codex plugin marketplace upgrade sentry-plugin-marketplace",
     );
+  });
+
+  it("removes our plugin via plugin remove", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createCodex(system).remove();
+
+    expect(outcome).toMatchObject({
+      kind: "done",
+      command: "codex plugin remove sentry@sentry-plugin-marketplace",
+    });
+    expect(system.run).toHaveBeenCalledWith("codex plugin remove sentry@sentry-plugin-marketplace");
   });
 
   it("throws when the install fails", async () => {
@@ -322,6 +347,14 @@ describe("grok harness", () => {
     expect(system.run).toHaveBeenCalledWith("grok plugin update sentry");
   });
 
+  it("removes via the uninstall command", async () => {
+    const system = fakeSystem({ run: () => ok });
+    const outcome = await createGrok(system).remove();
+
+    expect(outcome).toMatchObject({ kind: "done", command: "grok plugin uninstall sentry" });
+    expect(system.run).toHaveBeenCalledWith("grok plugin uninstall sentry");
+  });
+
   it("throws when the install fails", async () => {
     const harness = createGrok(fakeSystem({ run: () => ({ ok: false, stderr: "nope" }) }));
     await expect(harness.install()).rejects.toThrow("nope");
@@ -420,5 +453,23 @@ describe("cursor harness", () => {
 
     expect(outcome.kind).toBe("done");
     expect(system.run).toHaveBeenCalledWith(`git -C "${target}" pull`);
+  });
+
+  it("deletes the plugin directory on remove", async () => {
+    const target = "/home/user/.cursor/plugins/local/sentry";
+    const system = fakeSystem({ homedir: "/home/user", existing: [target] });
+    const outcome = await createCursor(system).remove();
+
+    expect(outcome.kind).toBe("done");
+    expect(system.run).toHaveBeenCalledWith(`rm -rf "${target}"`);
+  });
+
+  it("uses the native recursive remove on Windows", async () => {
+    const homedir = "C:\\Users\\user";
+    const target = join(homedir, ".cursor", "plugins", "local", "sentry");
+    const system = fakeSystem({ homedir, platform: "win32" });
+    await createCursor(system).remove();
+
+    expect(system.run).toHaveBeenCalledWith(`rmdir /s /q "${target}"`);
   });
 });

--- a/packages/installer/src/__tests__/run.test.ts
+++ b/packages/installer/src/__tests__/run.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { detectHarnesses, installHarness, installSucceeded } from "../run";
+import { detectHarnesses, installHarness, installSucceeded, removeHarness } from "../run";
 import { fakeHarness } from "./fake-harness";
 
 describe("detectHarnesses", () => {
@@ -111,6 +111,36 @@ describe("installHarness", () => {
     const result = await installHarness({ harness: claude, detected: true, installed: false });
 
     expect(result).toEqual({ kind: "failed", message: "boom" });
+  });
+});
+
+describe("removeHarness", () => {
+  it("returns the harness remove outcome", async () => {
+    const claude = fakeHarness({ id: "claude", installed: true });
+
+    const result = await removeHarness({ harness: claude, detected: true, installed: true });
+
+    expect(result).toEqual({ kind: "done", command: "claude remove" });
+    expect(claude.remove).toHaveBeenCalledOnce();
+    expect(claude.install).not.toHaveBeenCalled();
+  });
+
+  it("captures a thrown remove as a failed result", async () => {
+    const claude = fakeHarness({ id: "claude", installed: true, error: new Error("boom") });
+
+    const result = await removeHarness({ harness: claude, detected: true, installed: true });
+
+    expect(result).toEqual({ kind: "failed", message: "boom" });
+  });
+
+  it("does not run cleanup or a readiness gate before removing", async () => {
+    const codex = fakeHarness({ id: "codex", installed: true, cleaned: "should not run" });
+
+    await removeHarness({ harness: codex, detected: true, installed: true });
+
+    expect(codex.cleanup).not.toHaveBeenCalled();
+    expect(codex.canInstall).not.toHaveBeenCalled();
+    expect(codex.remove).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/installer/src/__tests__/ui.test.ts
+++ b/packages/installer/src/__tests__/ui.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { runInstaller } from "../ui";
+import { runInstaller, runRemover } from "../ui";
 import { fakeHarness } from "./fake-harness";
 
 // These cover the non-interactive path, which skips the prompt and installs
@@ -109,5 +109,64 @@ describe("runInstaller (non-interactive)", () => {
 
     expect(ok).toBe(true);
     expect(peak).toBeGreaterThan(1);
+  });
+});
+
+describe("runRemover (non-interactive)", () => {
+  it("removes only detected agents that have the plugin installed", async () => {
+    const claude = fakeHarness({ id: "claude", detected: true, installed: true });
+    const codex = fakeHarness({ id: "codex", detected: true, installed: false });
+    const grok = fakeHarness({ id: "grok", detected: false });
+
+    const ok = await runRemover([claude, codex, grok], { interactive: false });
+
+    expect(ok).toBe(true);
+    expect(claude.remove).toHaveBeenCalledOnce();
+    expect(codex.remove).not.toHaveBeenCalled();
+    expect(grok.remove).not.toHaveBeenCalled();
+  });
+
+  it("closes with the neuralyzer line naming the agents to restart", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const claude = fakeHarness({
+      id: "claude",
+      name: "Claude Code",
+      detected: true,
+      installed: true,
+    });
+    const grok = fakeHarness({ id: "grok", name: "Grok", detected: true, installed: true });
+
+    await runRemover([claude, grok], { interactive: false });
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("Restart Claude Code and Grok. "));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("They won't remember a thing."));
+    log.mockRestore();
+  });
+
+  it("omits the restart hint when nothing was installed to remove", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const claude = fakeHarness({ id: "claude", detected: true, installed: false });
+
+    const ok = await runRemover([claude], { interactive: false });
+
+    expect(ok).toBe(true);
+    expect(claude.remove).not.toHaveBeenCalled();
+    expect(log).not.toHaveBeenCalledWith(expect.stringContaining("Restart"));
+    log.mockRestore();
+  });
+
+  it("returns false when a remove fails but still removes the others", async () => {
+    const claude = fakeHarness({
+      id: "claude",
+      detected: true,
+      installed: true,
+      error: new Error("boom"),
+    });
+    const codex = fakeHarness({ id: "codex", detected: true, installed: true });
+
+    const ok = await runRemover([claude, codex], { interactive: false });
+
+    expect(ok).toBe(false);
+    expect(codex.remove).toHaveBeenCalledOnce();
   });
 });

--- a/packages/installer/src/harnesses/claude.ts
+++ b/packages/installer/src/harnesses/claude.ts
@@ -1,12 +1,13 @@
 import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
-import { detectOnPath, runInstallCommand, runJson } from "./shell";
+import { detectOnPath, runCommand, runJson } from "./shell";
 
 const MARKETPLACE = "claude-plugins-official";
 const MARKETPLACE_SOURCE = "anthropics/claude-plugins-official";
 const PLUGIN_ID = `sentry@${MARKETPLACE}`;
 const INSTALL_COMMAND = `claude plugin install ${PLUGIN_ID}`;
 const UPDATE_COMMAND = `claude plugin update ${PLUGIN_ID}`;
+const UNINSTALL_COMMAND = `claude plugin uninstall ${PLUGIN_ID}`;
 
 // `claude plugin list --json` emits an array of installed plugins. We only care
 // about the marketplace-qualified id of each entry.
@@ -35,7 +36,7 @@ async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
 // both install and update.
 async function ensureMarketplace(system: SystemDeps, output?: OutputSink): Promise<void> {
   const registered = await isMarketplaceRegistered(system);
-  await runInstallCommand(
+  await runCommand(
     system,
     registered
       ? `claude plugin marketplace update ${MARKETPLACE}`
@@ -57,14 +58,19 @@ export function createClaude(system: SystemDeps): Harness {
 
     install: async (output): Promise<InstallOutcome> => {
       await ensureMarketplace(system, output);
-      await runInstallCommand(system, INSTALL_COMMAND, output);
+      await runCommand(system, INSTALL_COMMAND, output);
       return { kind: "done", command: INSTALL_COMMAND };
     },
 
     update: async (output): Promise<InstallOutcome> => {
       await ensureMarketplace(system, output);
-      await runInstallCommand(system, UPDATE_COMMAND, output);
+      await runCommand(system, UPDATE_COMMAND, output);
       return { kind: "done", command: UPDATE_COMMAND };
+    },
+
+    remove: async (output): Promise<InstallOutcome> => {
+      await runCommand(system, UNINSTALL_COMMAND, output);
+      return { kind: "done", command: UNINSTALL_COMMAND };
     },
   };
 }

--- a/packages/installer/src/harnesses/codex.ts
+++ b/packages/installer/src/harnesses/codex.ts
@@ -1,6 +1,6 @@
 import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
-import { detectOnPath, runInstallCommand, runJson } from "./shell";
+import { detectOnPath, runCommand, runJson } from "./shell";
 
 // TODO: Codex is the only agent we install from our OWN marketplace
 // (getsentry/plugin-codex) rather than the agent vendor's official marketplace
@@ -12,6 +12,7 @@ const MARKETPLACE = "sentry-plugin-marketplace";
 const MARKETPLACE_SOURCE = "getsentry/plugin-codex";
 const PLUGIN_ID = `sentry@${MARKETPLACE}`;
 const INSTALL_COMMAND = `codex plugin add ${PLUGIN_ID}`;
+const UNINSTALL_COMMAND = `codex plugin remove ${PLUGIN_ID}`;
 
 // Codex ships an "official" Sentry plugin from its own curated marketplace. It
 // shadows ours, so remove it before installing. Drop this once we publish to
@@ -52,7 +53,7 @@ async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
 // Required by both install and update.
 async function ensureMarketplace(system: SystemDeps, output?: OutputSink): Promise<void> {
   const registered = await isMarketplaceRegistered(system);
-  await runInstallCommand(
+  await runCommand(
     system,
     registered
       ? `codex plugin marketplace upgrade ${MARKETPLACE}`
@@ -66,7 +67,7 @@ async function ensureMarketplace(system: SystemDeps, output?: OutputSink): Promi
 // share this single path.
 async function addPlugin(system: SystemDeps, output?: OutputSink): Promise<InstallOutcome> {
   await ensureMarketplace(system, output);
-  await runInstallCommand(system, INSTALL_COMMAND, output);
+  await runCommand(system, INSTALL_COMMAND, output);
   return { kind: "done", command: INSTALL_COMMAND };
 }
 
@@ -86,13 +87,18 @@ export function createCodex(system: SystemDeps): Harness {
         return null;
       }
 
-      await runInstallCommand(system, `codex plugin remove ${LEGACY_PLUGIN_ID}`, output);
+      await runCommand(system, `codex plugin remove ${LEGACY_PLUGIN_ID}`, output);
       return `Removed conflicting plugin ${LEGACY_PLUGIN_ID}`;
     },
 
     install: async (output) => addPlugin(system, output),
 
     update: async (output) => addPlugin(system, output),
+
+    remove: async (output): Promise<InstallOutcome> => {
+      await runCommand(system, UNINSTALL_COMMAND, output);
+      return { kind: "done", command: UNINSTALL_COMMAND };
+    },
   };
 }
 

--- a/packages/installer/src/harnesses/cursor.ts
+++ b/packages/installer/src/harnesses/cursor.ts
@@ -1,7 +1,7 @@
 import { join } from "node:path";
 import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
-import { detectOnPath, runInstallCommand } from "./shell";
+import { detectOnPath, runCommand } from "./shell";
 
 const PLUGIN_REPO = "https://github.com/getsentry/plugin-cursor.git";
 
@@ -47,13 +47,22 @@ export function createCursor(system: SystemDeps): Harness {
     install: async (output): Promise<InstallOutcome> => {
       // Quote the target: Windows home paths routinely contain spaces.
       const command = `git clone ${PLUGIN_REPO} "${pluginDir(system)}"`;
-      await runInstallCommand(system, command, output);
+      await runCommand(system, command, output);
       return { kind: "done", command };
     },
 
     update: async (output): Promise<InstallOutcome> => {
       const command = `git -C "${pluginDir(system)}" pull`;
-      await runInstallCommand(system, command, output);
+      await runCommand(system, command, output);
+      return { kind: "done", command };
+    },
+
+    remove: async (output): Promise<InstallOutcome> => {
+      // The plugin is just a checkout, so removal is a recursive directory
+      // delete. Windows has no `rm`, so use its native recursive remove.
+      const dir = pluginDir(system);
+      const command = system.platform === "win32" ? `rmdir /s /q "${dir}"` : `rm -rf "${dir}"`;
+      await runCommand(system, command, output);
       return { kind: "done", command };
     },
   };

--- a/packages/installer/src/harnesses/grok.ts
+++ b/packages/installer/src/harnesses/grok.ts
@@ -1,6 +1,6 @@
 import { realSystem, type OutputSink, type SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
-import { detectOnPath, runInstallCommand, runJson } from "./shell";
+import { detectOnPath, runCommand, runJson } from "./shell";
 
 // Grok has no headless install-by-name; its marketplace install is TUI-only. So
 // we install from the plugin repo directly — the exact source grok's built-in
@@ -60,21 +60,26 @@ export function createGrok(system: SystemDeps): Harness {
         return null;
       }
 
-      await runInstallCommand(system, UNINSTALL_COMMAND, output);
+      await runCommand(system, UNINSTALL_COMMAND, output);
       const via = foreign.marketplace ? ` (installed via ${foreign.marketplace})` : "";
       return `Removed conflicting sentry plugin${via}`;
     },
 
     install: async (output): Promise<InstallOutcome> => {
-      await runInstallCommand(system, INSTALL_COMMAND, output);
+      await runCommand(system, INSTALL_COMMAND, output);
       return { kind: "done", command: INSTALL_COMMAND };
     },
 
     // `grok plugin install` errors on an already-installed repo, so update in
     // place instead of reinstalling.
     update: async (output): Promise<InstallOutcome> => {
-      await runInstallCommand(system, UPDATE_COMMAND, output);
+      await runCommand(system, UPDATE_COMMAND, output);
       return { kind: "done", command: UPDATE_COMMAND };
+    },
+
+    remove: async (output): Promise<InstallOutcome> => {
+      await runCommand(system, UNINSTALL_COMMAND, output);
+      return { kind: "done", command: UNINSTALL_COMMAND };
     },
   };
 }

--- a/packages/installer/src/harnesses/shell.ts
+++ b/packages/installer/src/harnesses/shell.ts
@@ -5,10 +5,11 @@ export async function detectOnPath(system: SystemDeps, binary: string): Promise<
   return (await system.run(`${locator} ${binary}`)).ok;
 }
 
-// Runs a mutating command, streaming its output to `output` when given. Only the
-// sink is forwarded when present, so non-streaming callers (and tests) still see
-// a single-argument call.
-export async function runInstallCommand(
+// Runs a mutating command (install, update, remove, cleanup), throwing on a
+// non-zero exit so callers can treat failure as an exception. Streams its output
+// to `output` when given. Only the sink is forwarded when present, so
+// non-streaming callers (and tests) still see a single-argument call.
+export async function runCommand(
   system: SystemDeps,
   command: string,
   output?: OutputSink,

--- a/packages/installer/src/harnesses/types.ts
+++ b/packages/installer/src/harnesses/types.ts
@@ -1,7 +1,7 @@
 import type { OutputSink } from "../system";
 
 /**
- * Result of an install or update attempt.
+ * Result of an install, update, or remove attempt.
  */
 export type InstallOutcome =
   /**
@@ -61,4 +61,11 @@ export interface Harness {
    * `output` when provided.
    */
   update(output?: OutputSink): Promise<InstallOutcome>;
+  /**
+   * Remove the plugin, assuming it is present. Streams command output to
+   * `output` when provided. Only our own plugin is taken out — any marketplace
+   * we registered is left in place (it may be a shared/official one), and
+   * `cleanup` does not run for removal.
+   */
+  remove(output?: OutputSink): Promise<InstallOutcome>;
 }

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { defineCommand, runMain } from "citty";
 import { harnesses } from "./harnesses";
 import { captureAndFlush, initTelemetry } from "./instrument";
-import { runInstaller } from "./ui";
+import { runInstaller, runRemover } from "./ui";
 
 // Initialize telemetry before citty parses arguments so that any startup errors
 // are captured. We pre-scan raw argv for --no-telemetry ourselves here because
@@ -21,33 +21,36 @@ const { version, description } = JSON.parse(
   readFileSync(join(__dirname, "../package.json"), "utf8"),
 ) as { version: string; description: string };
 
+// Both subcommands take the same agent-selection flags.
+const agentSelectionArgs = {
+  // citty turns `--no-interactive` into `interactive: false` via its built-in
+  // boolean negation, so the flag is modeled as `interactive` (default true)
+  // rather than a separate `no-interactive` arg.
+  interactive: {
+    type: "boolean",
+    description: "Prompt to select agents; pass --no-interactive to act on every detected agent",
+    default: true,
+  },
+  yes: {
+    type: "boolean",
+    alias: "y",
+    description: "Alias for --no-interactive",
+    default: false,
+  },
+  telemetry: {
+    type: "boolean",
+    description:
+      "Send crash reports to Sentry (default: on). Pass --no-telemetry or set DO_NOT_TRACK=1 to disable.",
+    default: true,
+  },
+} as const;
+
 const install = defineCommand({
   meta: {
     name: "install",
     description: "Install the Sentry plugin into your detected AI coding assistants",
   },
-  args: {
-    // citty turns `--no-interactive` into `interactive: false` via its built-in
-    // boolean negation, so the flag is modeled as `interactive` (default true)
-    // rather than a separate `no-interactive` arg.
-    interactive: {
-      type: "boolean",
-      description: "Prompt to select agents; pass --no-interactive to install every detected agent",
-      default: true,
-    },
-    yes: {
-      type: "boolean",
-      alias: "y",
-      description: "Alias for --no-interactive",
-      default: false,
-    },
-    telemetry: {
-      type: "boolean",
-      description:
-        "Send crash reports to Sentry (default: on). Pass --no-telemetry or set DO_NOT_TRACK=1 to disable.",
-      default: true,
-    },
-  },
+  args: agentSelectionArgs,
   async run({ args }) {
     const interactive = args.interactive && !args.yes;
     try {
@@ -62,6 +65,24 @@ const install = defineCommand({
   },
 });
 
+const remove = defineCommand({
+  meta: {
+    name: "remove",
+    description: "Remove the Sentry plugin from your detected AI coding assistants",
+  },
+  args: agentSelectionArgs,
+  async run({ args }) {
+    const interactive = args.interactive && !args.yes;
+    try {
+      const ok = await runRemover(harnesses, { interactive });
+      process.exit(ok ? 0 : 1);
+    } catch (err) {
+      await captureAndFlush(err);
+      throw err;
+    }
+  },
+});
+
 const main = defineCommand({
   meta: {
     name: "sentry-ai",
@@ -70,10 +91,14 @@ const main = defineCommand({
   },
   subCommands: {
     install,
+    remove,
+    // `uninstall` is an alias for `remove`; citty resolves subcommands by key,
+    // so registering the same command under both names exposes both.
+    uninstall: remove,
   },
 });
 
-const SUBCOMMANDS = new Set(["install"]);
+const SUBCOMMANDS = new Set(["install", "remove", "uninstall"]);
 const PASSTHROUGH = new Set(["--help", "-h", "--version"]);
 
 // citty has no concept of a default subcommand, so `npx @sentry/ai` with no

--- a/packages/installer/src/run.ts
+++ b/packages/installer/src/run.ts
@@ -58,6 +58,21 @@ export async function installHarness(
   }
 }
 
+// Remove a single harness's plugin. The caller filters to harnesses that have it
+// installed, so there is no readiness gate and no cleanup — we only take out our
+// own plugin. A thrown remove is captured as a `failed` result so a concurrent
+// batch keeps going instead of rejecting the whole run.
+export async function removeHarness(
+  detection: Detection,
+  output?: OutputSink,
+): Promise<InstallResult> {
+  try {
+    return await detection.harness.remove(output);
+  } catch (err) {
+    return { kind: "failed", message: err instanceof Error ? err.message : String(err) };
+  }
+}
+
 export function installSucceeded(result: InstallResult): boolean {
   return result.kind === "done" || result.kind === "manual";
 }

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -16,9 +16,11 @@ import {
   detectHarnesses,
   installHarness,
   installSucceeded,
+  removeHarness,
   type Detection,
   type InstallResult,
 } from "./run";
+import type { OutputSink } from "./system";
 
 const BANNER_LINES = [
   "█▀ █▀▀ █▄░█ ▀█▀ █▀█ █▄█   █▀▀ █▀█ █▀█   ▄▀█ █",
@@ -70,6 +72,14 @@ function introTitle(colored: boolean, phase?: number): string {
   return `${prefix}${word}${suffix}`;
 }
 
+// The remove flow's tagline. A flat Men-in-Black riff that stays static — there
+// is nothing to teach, so the line does not shimmer (the `phase` is ignored).
+const NEURALYZE_TITLE = "Neuralyzing your agents of Sentry.";
+
+function neuralyzeTitle(_colored: boolean): string {
+  return color.dim(NEURALYZE_TITLE);
+}
+
 export interface RunOptions {
   // When false, skip the selector and install every detected agent (CI smoke
   // tests, unattended runs). The selection task is disabled in this mode.
@@ -80,10 +90,58 @@ interface Ctx {
   detections: Detection[];
   selected: Detection[];
   results: InstallResult[];
-  // Names of agents that actually received the plugin, for the closing restart
-  // hint. Blocked/failed agents are excluded — nothing to restart for those.
-  installed: string[];
+  // Names of agents the flow actually acted on (installed or removed), for the
+  // closing restart hint. Blocked/failed agents are excluded — nothing to
+  // restart for those.
+  affected: string[];
   cancelled: boolean;
+}
+
+/**
+ * The parts of the flow that differ between install and remove. Detection and
+ * selection are shared; everything below tailors the tagline, the prompt, the
+ * per-agent action, and the closing line to one direction.
+ */
+interface FlowMode {
+  /**
+   * Tagline painted above the task list. `phase` drives the shimmer; a static
+   * mode (remove) ignores it and always renders at rest.
+   */
+  header(colored: boolean, phase?: number): string;
+  /**
+   * Whether the tagline shimmers while work is in flight.
+   */
+  animate: boolean;
+  /**
+   * Which detections this flow can act on. Install targets every detected agent;
+   * remove targets only those that actually have our plugin.
+   */
+  eligible(detection: Detection): boolean;
+  /**
+   * Message shown above the agent checkbox.
+   */
+  selectMessage: string;
+  /**
+   * Per-agent label in the checkbox and the task list.
+   */
+  label(detection: Detection): string;
+  /**
+   * Title of the action group.
+   */
+  actionTitle: string;
+  /**
+   * Skip line shown when nothing is eligible to act on.
+   */
+  emptyMessage: string;
+  /**
+   * Act on one harness — install/update or remove.
+   */
+  act(detection: Detection, output: OutputSink): Promise<InstallResult>;
+  /**
+   * Closing line printed when at least one agent was acted on; `names` are the
+   * affected agents to restart.
+   */
+  closing(names: string[]): string;
 }
 
 // "Claude Code", "Claude Code and Codex", "Claude Code, Codex, and Grok".
@@ -115,14 +173,18 @@ function isCancel(err: unknown): boolean {
   return err instanceof Error && err.name === "ExitPromptError";
 }
 
-// Only agents found on the machine are offered: installing into an undetected
-// agent just runs shell commands that fail with confusing errors. Everything is
-// pre-checked since the whole list is installable; the user deselects to skip.
-async function promptForAgents(detected: Detection[], task: TaskWrapper): Promise<Detection[]> {
+// Only eligible agents are offered: acting on an agent the flow cannot touch
+// just runs shell commands that fail with confusing errors. Everything is
+// pre-checked since the whole list is actionable; the user deselects to skip.
+async function promptForAgents(
+  eligible: Detection[],
+  mode: FlowMode,
+  task: TaskWrapper,
+): Promise<Detection[]> {
   const selectedIds = await task.prompt(ListrInquirerPromptAdapter).run(checkbox, {
-    message: "Select the agents to install the Sentry plugin for",
-    choices: detected.map((detection) => ({
-      name: detection.installed ? `${detection.harness.name} (reinstall)` : detection.harness.name,
+    message: mode.selectMessage,
+    choices: eligible.map((detection) => ({
+      name: mode.label(detection),
       value: detection.harness.id,
       checked: true,
     })),
@@ -141,23 +203,24 @@ async function promptForAgents(detected: Detection[], task: TaskWrapper): Promis
     },
   });
 
-  return detected.filter((detection) => selectedIds.includes(detection.harness.id));
+  return eligible.filter((detection) => selectedIds.includes(detection.harness.id));
 }
 
-// Translate one install result into Listr task display state.
-function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
-  const { harness, installed } = detection;
+// Translate one harness action (install/update or remove) into Listr task
+// display state.
+function actionTask(ctx: Ctx, detection: Detection, mode: FlowMode): ListrTask<Ctx> {
+  const { harness } = detection;
 
   return {
-    title: installed ? `${harness.name} (reinstall)` : harness.name,
+    title: mode.label(detection),
     // outputBar shows every streamed line of the running commands; persistentOutput
     // keeps it (and the trailing notes below) on screen after the task settles.
     rendererOptions: { persistentOutput: true, outputBar: Infinity },
     task: async (_ctx, task: TaskWrapper) => {
-      // Stream the install/cleanup command output live under this task's row,
-      // grayed (the renderer's color map only tints the icon, so gray the body
-      // through a createWritable transform). Trailing notes go to the raw sink so
-      // their text stays full color and reads as ours, not command noise.
+      // Stream the command output live under this task's row, grayed (the
+      // renderer's color map only tints the icon, so gray the body through a
+      // createWritable transform). Trailing notes go to the raw sink so their
+      // text stays full color and reads as ours, not command noise.
       const raw = task.stdout();
       // Gray per line, leaving blank lines genuinely empty — otherwise the gray
       // escapes make them non-empty and defeat the renderer's removeEmptyLines.
@@ -170,7 +233,7 @@ function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
             .join("\n"),
         ),
       );
-      const result = await installHarness(detection, out);
+      const result = await mode.act(detection, out);
       ctx.results.push(result);
 
       // Trailing notes (what cleanup removed, manual steps, restart hints) are not
@@ -184,12 +247,12 @@ function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
         case "done":
           task.title = `${harness.name} — ${result.command}`;
           writeTail(result.cleaned, result.note);
-          ctx.installed.push(harness.name);
+          ctx.affected.push(harness.name);
           return;
         case "manual":
           task.title = `${harness.name} — manual steps required`;
           writeTail(result.cleaned, result.instructions);
-          ctx.installed.push(harness.name);
+          ctx.affected.push(harness.name);
           return;
         case "blocked":
           task.skip(`${harness.name} — ${result.reason}`);
@@ -201,29 +264,71 @@ function installTask(ctx: Ctx, detection: Detection): ListrTask<Ctx> {
   };
 }
 
-export async function runInstaller(
+// Install (and update) targets every detected agent, with a shimmering tagline.
+const installMode: FlowMode = {
+  header: introTitle,
+  animate: true,
+  eligible: (detection) => detection.detected,
+  selectMessage: "Select the agents to install the Sentry plugin for",
+  label: (detection) =>
+    detection.installed ? `${detection.harness.name} (reinstall)` : detection.harness.name,
+  actionTitle: "Installing plugins",
+  emptyMessage: "No agents selected",
+  act: (detection, output) => installHarness(detection, output),
+  closing: (names) => {
+    const speak = names.length === 1 ? "agent now speaks" : "agents now speak";
+    return `\nDone. Restart ${listFormatter.format(names)}. ${color.dim(`Your ${speak} Sentry.`)}`;
+  },
+};
+
+// Remove targets only agents that actually have our plugin, with a static
+// tagline.
+const removeMode: FlowMode = {
+  header: neuralyzeTitle,
+  animate: false,
+  eligible: (detection) => detection.detected && detection.installed,
+  selectMessage: "Select the agents to remove the Sentry plugin from",
+  label: (detection) => detection.harness.name,
+  actionTitle: "Removing plugins",
+  emptyMessage: "No agents to remove",
+  act: (detection, output) => removeHarness(detection, output),
+  closing: (names) =>
+    `\nDone. Restart ${listFormatter.format(names)}. ${color.dim("They won't remember a thing.")}`,
+};
+
+export function runInstaller(harnesses: Harness[], options: RunOptions = {}): Promise<boolean> {
+  return runFlow(harnesses, installMode, options);
+}
+
+export function runRemover(harnesses: Harness[], options: RunOptions = {}): Promise<boolean> {
+  return runFlow(harnesses, removeMode, options);
+}
+
+async function runFlow(
   harnesses: Harness[],
+  mode: FlowMode,
   options: RunOptions = {},
 ): Promise<boolean> {
   const interactive = options.interactive ?? true;
 
   // The header shimmer is painted by ShimmerRenderer, which only runs on a TTY.
-  // colored gates truecolor; animate gates the sweep (off under test).
+  // colored gates truecolor; animate gates the sweep (off under test, and off
+  // entirely for modes whose tagline stays static).
   const isTTY = !!process.stdout.isTTY;
   const colored = isTTY && !process.env.NO_COLOR && !process.env.CI;
-  const animate = colored && !process.env.VITEST;
+  const animate = mode.animate && colored && !process.env.VITEST;
 
   if (!process.env.VITEST) {
     console.log(BANNER);
     // Off a TTY the renderer falls back to a plain logger with no header, so
     // print the tagline once up front to keep it in the output.
     if (!isTTY) {
-      console.log(`${introTitle(colored)}\n`);
+      console.log(`${mode.header(colored)}\n`);
     }
   }
 
-  // The actual install steps. They run nested under the shimmering tagline so
-  // the tagline stays on screen, animating, for the whole run.
+  // The actual steps. They run nested under the tagline so it stays on screen
+  // for the whole run.
   const steps: ListrTask<Ctx>[] = [
     {
       title: "Detecting AI coding tools",
@@ -237,12 +342,12 @@ export async function runInstaller(
     {
       title: "Select agents",
       // Skip the prompt unless we are interactive and actually found something
-      // to install — an empty checkbox is pointless.
-      enabled: (ctx) => interactive && ctx.detections.some((d) => d.detected),
+      // to act on — an empty checkbox is pointless.
+      enabled: (ctx) => interactive && ctx.detections.some(mode.eligible),
       task: async (ctx, task) => {
-        const detected = ctx.detections.filter((d) => d.detected);
+        const eligible = ctx.detections.filter(mode.eligible);
         try {
-          ctx.selected = await promptForAgents(detected, task);
+          ctx.selected = await promptForAgents(eligible, mode, task);
         } catch (err) {
           if (!isCancel(err)) throw err;
           ctx.cancelled = true;
@@ -251,15 +356,15 @@ export async function runInstaller(
       },
     },
     {
-      title: "Installing plugins",
-      // Interactive runs install the user's selection; non-interactive runs
-      // skip the prompt and install every detected agent.
+      title: mode.actionTitle,
+      // Interactive runs act on the user's selection; non-interactive runs skip
+      // the prompt and act on every eligible agent.
       enabled: (ctx) => !ctx.cancelled,
       task: (ctx, task) => {
-        const selected = interactive ? ctx.selected : ctx.detections.filter((d) => d.detected);
+        const selected = interactive ? ctx.selected : ctx.detections.filter(mode.eligible);
 
         if (selected.length === 0) {
-          task.skip("No agents selected");
+          task.skip(mode.emptyMessage);
           return;
         }
 
@@ -269,7 +374,7 @@ export async function runInstaller(
         // and cleanup output) on screen after the group finishes instead of
         // folding them back into the parent line.
         return task.newListr(
-          selected.map((detection) => installTask(ctx, detection)),
+          selected.map((detection) => actionTask(ctx, detection, mode)),
           {
             concurrent: true,
             exitOnError: false,
@@ -280,9 +385,9 @@ export async function runInstaller(
     },
   ];
 
-  // Paint the shimmering tagline as a header above the task list every frame.
-  // The header is not a task, so it carries no spinner icon, and the steps
-  // render as a normal flat list beneath a blank line.
+  // Paint the tagline as a header above the task list every frame. The header is
+  // not a task, so it carries no spinner icon, and the steps render as a normal
+  // flat list beneath a blank line.
   class ShimmerRenderer extends DefaultRenderer {
     // Wall-clock origin for a frame-rate-independent shimmer phase.
     private readonly startedAt = Date.now();
@@ -299,14 +404,14 @@ export async function runInstaller(
         animate && running
           ? Math.floor((Date.now() - this.startedAt) / SHIMMER_INTERVAL_MS)
           : undefined;
-      const header = introTitle(colored, phase);
+      const header = mode.header(colored, phase);
 
       return body.length > 0 ? `${header}\n\n${body}` : header;
     }
   }
 
   const tasks = new Listr<Ctx, typeof ShimmerRenderer>(steps, {
-    // Steps run sequentially; install failures are contained by the inner list.
+    // Steps run sequentially; per-agent failures are contained by the inner list.
     // exitOnError aborts on an unexpected throw (e.g. the prompt erroring).
     // Under vitest we silence the renderer so test runs do not paint.
     concurrent: false,
@@ -333,7 +438,7 @@ export async function runInstaller(
     detections: [],
     selected: [],
     results: [],
-    installed: [],
+    affected: [],
     cancelled: false,
   };
 
@@ -346,17 +451,14 @@ export async function runInstaller(
     return false;
   }
 
-  // A cancelled prompt installed nothing — report failure so the exit code
-  // distinguishes an aborted run from a clean install.
+  // A cancelled prompt did nothing — report failure so the exit code
+  // distinguishes an aborted run from a clean one.
   if (ctx.cancelled) {
     return false;
   }
 
-  if (ctx.installed.length > 0) {
-    const speak = ctx.installed.length === 1 ? "agent now speaks" : "agents now speak";
-    console.log(
-      `\nDone. Restart ${listFormatter.format(ctx.installed)}. ${color.dim(`Your ${speak} Sentry.`)}`,
-    );
+  if (ctx.affected.length > 0) {
+    console.log(mode.closing(ctx.affected));
   }
 
   return ctx.results.every(installSucceeded);


### PR DESCRIPTION
Installing the Sentry plugin was a one-way door — there was no built-in way to take it back out. This adds a `remove` subcommand (aliased as `uninstall`) that mirrors install: it reuses the detect and select steps, then uninstalls the plugin from each chosen agent.

The per-harness teardown uses each CLI's native verb, verified against the live CLIs:

- Claude — `claude plugin uninstall sentry@claude-plugins-official`
- Codex — `codex plugin remove sentry@sentry-plugin-marketplace`
- Grok — `grok plugin uninstall sentry`
- Cursor — deletes the plugin checkout (`rm -rf`, or `rmdir /s /q` on Windows)

Removal only takes out our own plugin. Any marketplace we registered is left in place — Claude's is Anthropic's shared official one, so deregistering it could pull it out from under other plugins — and the install-time cleanup of conflicting plugins does not run.

The UI is factored into a shared `runFlow` driven by a `FlowMode` descriptor, so install and remove share detection, selection, concurrency, and output streaming while differing only in their tagline, prompt copy, per-agent action, and closing line. Remove targets only agents that actually have the plugin installed, and leads with a static "Neuralyzing your agents of Sentry." header (no shimmer), closing with "They won't remember a thing."
