### PR TITLE
release: add 0.1.3 changelog entry

### DIFF
--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.1.3
+
+- Lead the README with the install command and add a demo to the npm package
+  page.
+
 ## 0.1.2
 
 - Add `--no-telemetry` flag and `DO_NOT_TRACK=1` env var support to opt out


### PR DESCRIPTION
Prep for the 0.1.3 release. Since 0.1.2 the only published-package changes are README updates (#199, #200) — lead with the install command and add the demo gifs — so 0.1.3 ships the refreshed README to the npm package page.

craft's `simple` changelog policy requires the version's entry to exist on main before `prepare` runs.