### PR TITLE
refactor(skills): standardize Configuration Reference across SDK skills

### DIFF
--- a/skills/sentry-cloudflare-sdk/SKILL.md
+++ b/skills/sentry-cloudflare-sdk/SKILL.md
@@ -420,40 +420,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 
 ---
 
-## Verification
-
-After setup, verify Sentry is working:
-
-```typescript
-// Add temporarily to your fetch handler, then remove
-export default Sentry.withSentry(
-  (env: Env) => ({
-    dsn: env.SENTRY_DSN,
-    tracesSampleRate: 1.0,
-  }),
-  {
-    async fetch(request, env, ctx) {
-      throw new Error("Sentry test error — delete me");
-    },
-  } satisfies ExportedHandler<Env>,
-);
-```
-
-Deploy and trigger the route, then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
-
-**Verification checklist:**
-
-| Check | How |
-|-------|-----|
-| Errors captured | Throw in a fetch handler, verify in Sentry |
-| Tracing working | Check Performance tab for HTTP spans |
-| Source maps working | Check stack trace shows readable file/line names |
-| D1 spans (if configured) | Run a D1 query, check for `db.query` spans |
-| Scheduled monitoring (if configured) | Trigger a cron, check Crons dashboard |
-
----
-
-## Config Reference
+## Configuration Reference
 
 ### `Sentry.init()` Options
 
@@ -515,6 +482,39 @@ These are registered automatically by `getDefaultIntegrations()`:
 | `honoIntegration` | **Deprecated in v10.55.0** — use `@sentry/hono` package instead. Auto-capture Hono `onError` exceptions |
 | `requestDataIntegration` | Attach request data to events |
 | `consoleIntegration` | Capture `console.*` calls as breadcrumbs |
+
+---
+
+## Verification
+
+After setup, verify Sentry is working:
+
+```typescript
+// Add temporarily to your fetch handler, then remove
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  }),
+  {
+    async fetch(request, env, ctx) {
+      throw new Error("Sentry test error — delete me");
+    },
+  } satisfies ExportedHandler<Env>,
+);
+```
+
+Deploy and trigger the route, then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
+
+**Verification checklist:**
+
+| Check | How |
+|-------|-----|
+| Errors captured | Throw in a fetch handler, verify in Sentry |
+| Tracing working | Check Performance tab for HTTP spans |
+| Source maps working | Check stack trace shows readable file/line names |
+| D1 spans (if configured) | Run a D1 query, check for `db.query` spans |
+| Scheduled monitoring (if configured) | Trigger a cron, check Crons dashboard |
 
 ---
 

--- a/skills/sentry-dotnet-sdk/SKILL.md
+++ b/skills/sentry-dotnet-sdk/SKILL.md
@@ -470,36 +470,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 
 ---
 
-## Verification
-
-After wizard or manual setup, add a test throw and remove it after verifying:
-
-```csharp
-// ASP.NET Core: add a temporary endpoint
-app.MapGet("/sentry-test", () =>
-{
-    throw new Exception("Sentry test error — delete me");
-});
-
-// Or capture explicitly anywhere
-SentrySdk.CaptureException(new Exception("Sentry test error — delete me"));
-```
-
-Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
-
-**Verification checklist:**
-
-| Check | How |
-|-------|-----|
-| Exceptions captured | Throw a test exception, verify in Sentry Issues |
-| Stack traces readable | Check that file names and line numbers appear |
-| Tracing active | Check Performance tab for transactions |
-| Logging wired | Log an error via `ILogger`, check it appears as Sentry breadcrumb |
-| Symbol upload working | Stack trace shows `Controllers/HomeController.cs:42` not `<unknown>` |
-
----
-
-## Config Reference
+## Configuration Reference
 
 ### Core `SentryOptions`
 
@@ -575,6 +546,35 @@ export Sentry__TracesSampleRate="0.1"
 | `SentryCreateRelease` | `bool` | `false` | Auto-create a Sentry release during build |
 | `SentrySetCommits` | `bool` | `false` | Associate git commits with the release |
 | `SentryUrl` | `string` | — | Self-hosted Sentry URL |
+
+---
+
+## Verification
+
+After wizard or manual setup, add a test throw and remove it after verifying:
+
+```csharp
+// ASP.NET Core: add a temporary endpoint
+app.MapGet("/sentry-test", () =>
+{
+    throw new Exception("Sentry test error — delete me");
+});
+
+// Or capture explicitly anywhere
+SentrySdk.CaptureException(new Exception("Sentry test error — delete me"));
+```
+
+Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
+
+**Verification checklist:**
+
+| Check | How |
+|-------|-----|
+| Exceptions captured | Throw a test exception, verify in Sentry Issues |
+| Stack traces readable | Check that file names and line numbers appear |
+| Tracing active | Check Performance tab for transactions |
+| Logging wired | Log an error via `ILogger`, check it appears as Sentry breadcrumb |
+| Symbol upload working | Stack trace shows `Controllers/HomeController.cs:42` not `<unknown>` |
 
 ---
 

--- a/skills/sentry-nextjs-sdk/SKILL.md
+++ b/skills/sentry-nextjs-sdk/SKILL.md
@@ -382,34 +382,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 
 ---
 
-## Verification
-
-After wizard or manual setup, verify Sentry is working:
-
-```typescript
-// Add temporarily to a server action or API route, then remove
-import * as Sentry from "@sentry/nextjs";
-
-throw new Error("Sentry test error — delete me");
-// or
-Sentry.captureException(new Error("Sentry test error — delete me"));
-```
-
-Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
-
-**Verification checklist:**
-
-| Check | How |
-|-------|-----|
-| Client errors captured | Throw in a client component, verify in Sentry |
-| Server errors captured | Throw in a server action or API route |
-| Edge errors captured | Throw in middleware or edge route handler |
-| Source maps working | Check stack trace shows readable file names |
-| Session Replay working | Check Replays tab in Sentry dashboard |
-
----
-
-## Config Reference
+## Configuration Reference
 
 ### `Sentry.init()` Options
 
@@ -449,6 +422,33 @@ Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the err
 | `SENTRY_PROJECT` | Build | Project slug (alternative to `project` in config) |
 | `SENTRY_RELEASE` | Server | Release version string (auto-detected from git) |
 | `NEXT_RUNTIME` | Server / Edge | `"nodejs"` or `"edge"` (set by Next.js internally) |
+
+---
+
+## Verification
+
+After wizard or manual setup, verify Sentry is working:
+
+```typescript
+// Add temporarily to a server action or API route, then remove
+import * as Sentry from "@sentry/nextjs";
+
+throw new Error("Sentry test error — delete me");
+// or
+Sentry.captureException(new Error("Sentry test error — delete me"));
+```
+
+Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
+
+**Verification checklist:**
+
+| Check | How |
+|-------|-----|
+| Client errors captured | Throw in a client component, verify in Sentry |
+| Server errors captured | Throw in a server action or API route |
+| Edge errors captured | Throw in middleware or edge route handler |
+| Source maps working | Check stack trace shows readable file names |
+| Session Replay working | Check Replays tab in Sentry dashboard |
 
 ---
 

--- a/skills/sentry-node-sdk/SKILL.md
+++ b/skills/sentry-node-sdk/SKILL.md
@@ -697,38 +697,7 @@ Metrics collected: same as Node.js except no event loop delay percentiles (unava
 
 ---
 
-## Verification
-
-After setup, verify Sentry is receiving events:
-
-```javascript
-// Add temporarily to your entry file or a test route, then remove
-import * as Sentry from "@sentry/node"; // or @sentry/bun / @sentry/deno
-
-Sentry.captureException(new Error("Sentry test error — delete me"));
-```
-
-Or trigger an unhandled exception:
-
-```javascript
-// In a route handler or startup — will be captured automatically
-throw new Error("Sentry test error — delete me");
-```
-
-Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
-
-**Verification checklist:**
-
-| Check | How |
-|-------|-----|
-| Error captured | Throw in a handler, verify in Sentry Issues |
-| Tracing working | Check Performance tab — should show HTTP spans |
-| `includeLocalVariables` working | Stack frame in Sentry should show variable values |
-| Source maps working | Stack trace shows readable file names, not minified |
-
----
-
-## Config Reference
+## Configuration Reference
 
 ### `Sentry.init()` Core Options
 
@@ -824,6 +793,37 @@ Add upload step to your build:
   }
 }
 ```
+
+---
+
+## Verification
+
+After setup, verify Sentry is receiving events:
+
+```javascript
+// Add temporarily to your entry file or a test route, then remove
+import * as Sentry from "@sentry/node"; // or @sentry/bun / @sentry/deno
+
+Sentry.captureException(new Error("Sentry test error — delete me"));
+```
+
+Or trigger an unhandled exception:
+
+```javascript
+// In a route handler or startup — will be captured automatically
+throw new Error("Sentry test error — delete me");
+```
+
+Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
+
+**Verification checklist:**
+
+| Check | How |
+|-------|-----|
+| Error captured | Throw in a handler, verify in Sentry Issues |
+| Tracing working | Check Performance tab — should show HTTP spans |
+| `includeLocalVariables` working | Stack frame in Sentry should show variable values |
+| Source maps working | Stack trace shows readable file names, not minified |
 
 ---
 


### PR DESCRIPTION
The SDK skills had drifted into two conventions for the same section. 15 of 19 used the heading "Configuration Reference" while 4 used the short "Config Reference", and 14 of 19 placed it before "Verification" while the same 4 placed it after.

This aligns the four outliers (`cloudflare`, `dotnet`, `nextjs`, `node`) with the majority convention so every SDK skill follows the same order: Guide -> Configuration Reference -> Verification -> Cross-Link.

Pure reorder and rename — insertions equal deletions, no content changed. First of three PRs normalizing SDK skill structure.