### PR TITLE
refactor(skills): restore phase skeleton in mobile SDK skills

### DIFF
--- a/skills/sentry-android-sdk/SKILL.md
+++ b/skills/sentry-android-sdk/SKILL.md
@@ -504,59 +504,9 @@ Walk through features one at a time. Load the reference file for each, follow it
 | Logging | `${SKILL_ROOT}/references/logging.md` | Structured logging / log-to-trace correlation |
 | Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom metric tracking (SDK ≥ 8.30.0) |
 | Crons | `${SKILL_ROOT}/references/crons.md` | Scheduled jobs, WorkManager check-ins |
+| Integration Reference | `${SKILL_ROOT}/references/integrations.md` | Built-in, optional, and Gradle bytecode integrations |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
-
----
-
-## Integration Reference
-
-### Built-in (Auto-Enabled)
-
-These integrations activate automatically when `SentryAndroid.init()` is called:
-
-| Integration | What it does |
-|-------------|-------------|
-| `UncaughtExceptionHandlerIntegration` | Captures all uncaught Java/Kotlin exceptions |
-| `AnrIntegration` | ANR detection via watchdog thread (5s) + ApplicationExitInfo (API 30+) |
-| `NdkIntegration` | Native (C/C++) crash capture via `sentry-native` |
-| `ActivityLifecycleIntegration` | Auto-instruments Activity create/resume/pause for TTID/TTFD |
-| `AppStartMetrics` | Measures cold/warm/hot app start time |
-| `NetworkBreadcrumbsIntegration` | Records connectivity changes as breadcrumbs |
-| `SystemEventsBreadcrumbsIntegration` | Records battery, screen on/off, etc. |
-| `AppLifecycleIntegration` | Records foreground/background transitions |
-| `UserInteractionIntegration` | Breadcrumbs for taps, swipes, input events |
-| `CurrentActivityIntegration` | Tracks active Activity for context |
-
-### Optional Integrations
-
-Add the artifact to your `dependencies {}` block (versions managed by BOM):
-
-| Integration | Artifact | When to add |
-|-------------|---------|-------------|
-| **Timber** | `io.sentry:sentry-android-timber` | App uses Timber for logging |
-| **Fragment** | `io.sentry:sentry-android-fragment` | App uses Jetpack Fragments (lifecycle tracing) |
-| **Compose** | `io.sentry:sentry-compose-android` | App uses Jetpack Compose (navigation + masking) |
-| **Navigation** | `io.sentry:sentry-android-navigation` | App uses Jetpack Navigation Component |
-| **OkHttp** | `io.sentry:sentry-okhttp` | App uses OkHttp or Retrofit |
-| **Room/SQLite** | `io.sentry:sentry-android-sqlite` | App uses Room or raw SQLite |
-| **Apollo 3** | `io.sentry:sentry-apollo-3` | App uses Apollo GraphQL v3 |
-| **Apollo 4** | `io.sentry:sentry-apollo-4` | App uses Apollo GraphQL v4 |
-| **Kotlin Extensions** | `io.sentry:sentry-kotlin-extensions` | Kotlin coroutines context propagation |
-| **Ktor Client** | `io.sentry:sentry-ktor-client` | App uses Ktor HTTP client |
-| **LaunchDarkly** | `io.sentry:sentry-launchdarkly-android` | App uses LaunchDarkly feature flags |
-
-### Gradle Plugin Bytecode Instrumentation
-
-The plugin can inject instrumentation automatically (no source changes):
-
-| Feature | Instruments | Enable via |
-|---------|-------------|-----------|
-| `DATABASE` | Room DAO, SupportSQLiteOpenHelper | `tracingInstrumentation.features` |
-| `FILE_IO` | FileInputStream, FileOutputStream | `tracingInstrumentation.features` |
-| `OKHTTP` | OkHttpClient.Builder automatically | `tracingInstrumentation.features` |
-| `COMPOSE` | NavHostController auto-instrumentation | `tracingInstrumentation.features` |
-| `LOGCAT` | `android.util.Log` capturing | `tracingInstrumentation.features` |
 
 ---
 
@@ -633,9 +583,7 @@ The plugin can inject instrumentation automatically (no source changes):
 | `isEnabled` | `Boolean` | `false` | Enable `Sentry.logger()` API (SDK ≥ 8.12.0) |
 | `setBeforeSend` | `BeforeSendLogCallback` | — | Filter/modify log entries before sending |
 
----
-
-## Environment Variables
+### Environment Variables
 
 | Variable | Purpose | Notes |
 |----------|---------|-------|

--- a/skills/sentry-android-sdk/references/integrations.md
+++ b/skills/sentry-android-sdk/references/integrations.md
@@ -1,0 +1,48 @@
+# Integration Reference — Sentry Android SDK
+
+### Built-in (Auto-Enabled)
+
+These integrations activate automatically when `SentryAndroid.init()` is called:
+
+| Integration | What it does |
+|-------------|-------------|
+| `UncaughtExceptionHandlerIntegration` | Captures all uncaught Java/Kotlin exceptions |
+| `AnrIntegration` | ANR detection via watchdog thread (5s) + ApplicationExitInfo (API 30+) |
+| `NdkIntegration` | Native (C/C++) crash capture via `sentry-native` |
+| `ActivityLifecycleIntegration` | Auto-instruments Activity create/resume/pause for TTID/TTFD |
+| `AppStartMetrics` | Measures cold/warm/hot app start time |
+| `NetworkBreadcrumbsIntegration` | Records connectivity changes as breadcrumbs |
+| `SystemEventsBreadcrumbsIntegration` | Records battery, screen on/off, etc. |
+| `AppLifecycleIntegration` | Records foreground/background transitions |
+| `UserInteractionIntegration` | Breadcrumbs for taps, swipes, input events |
+| `CurrentActivityIntegration` | Tracks active Activity for context |
+
+### Optional Integrations
+
+Add the artifact to your `dependencies {}` block (versions managed by BOM):
+
+| Integration | Artifact | When to add |
+|-------------|---------|-------------|
+| **Timber** | `io.sentry:sentry-android-timber` | App uses Timber for logging |
+| **Fragment** | `io.sentry:sentry-android-fragment` | App uses Jetpack Fragments (lifecycle tracing) |
+| **Compose** | `io.sentry:sentry-compose-android` | App uses Jetpack Compose (navigation + masking) |
+| **Navigation** | `io.sentry:sentry-android-navigation` | App uses Jetpack Navigation Component |
+| **OkHttp** | `io.sentry:sentry-okhttp` | App uses OkHttp or Retrofit |
+| **Room/SQLite** | `io.sentry:sentry-android-sqlite` | App uses Room or raw SQLite |
+| **Apollo 3** | `io.sentry:sentry-apollo-3` | App uses Apollo GraphQL v3 |
+| **Apollo 4** | `io.sentry:sentry-apollo-4` | App uses Apollo GraphQL v4 |
+| **Kotlin Extensions** | `io.sentry:sentry-kotlin-extensions` | Kotlin coroutines context propagation |
+| **Ktor Client** | `io.sentry:sentry-ktor-client` | App uses Ktor HTTP client |
+| **LaunchDarkly** | `io.sentry:sentry-launchdarkly-android` | App uses LaunchDarkly feature flags |
+
+### Gradle Plugin Bytecode Instrumentation
+
+The plugin can inject instrumentation automatically (no source changes):
+
+| Feature | Instruments | Enable via |
+|---------|-------------|-----------|
+| `DATABASE` | Room DAO, SupportSQLiteOpenHelper | `tracingInstrumentation.features` |
+| `FILE_IO` | FileInputStream, FileOutputStream | `tracingInstrumentation.features` |
+| `OKHTTP` | OkHttpClient.Builder automatically | `tracingInstrumentation.features` |
+| `COMPOSE` | NavHostController auto-instrumentation | `tracingInstrumentation.features` |
+| `LOGCAT` | `android.util.Log` capturing | `tracingInstrumentation.features` |

--- a/skills/sentry-cocoa-sdk/SKILL.md
+++ b/skills/sentry-cocoa-sdk/SKILL.md
@@ -378,28 +378,7 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | MetricKit | Yes (15+) | No | Yes (12+) | No | No |
 | Metrics API | Yes | Yes | Yes | Verify | Yes |
 
----
-
-## Verification
-
-Test that Sentry is receiving events:
-
-```swift
-// Trigger a test error event:
-SentrySDK.capture(message: "Sentry Cocoa SDK test")
-
-// Or test crash reporting (without debugger — crashes are intercepted by debugger):
-// SentrySDK.crash()  // uncomment, run without debugger, relaunch to see crash report
-```
-
-Check the Sentry dashboard within a few seconds. If nothing appears:
-1. Set `options.debug = true` — prints SDK internals to Xcode console
-2. Verify the DSN is correct and the project exists
-3. Ensure initialization is on the **main thread**
-
----
-
-## Production Settings
+### Production Settings
 
 Lower sample rates for production to control volume and cost:
 
@@ -418,6 +397,25 @@ options.enableLogs = true
 options.enableMetrics = true             // default true in SDK 9.12+
 options.debug = false                   // never in production
 ```
+
+---
+
+## Verification
+
+Test that Sentry is receiving events:
+
+```swift
+// Trigger a test error event:
+SentrySDK.capture(message: "Sentry Cocoa SDK test")
+
+// Or test crash reporting (without debugger — crashes are intercepted by debugger):
+// SentrySDK.crash()  // uncomment, run without debugger, relaunch to see crash report
+```
+
+Check the Sentry dashboard within a few seconds. If nothing appears:
+1. Set `options.debug = true` — prints SDK internals to Xcode console
+2. Verify the DSN is correct and the project exists
+3. Ensure initialization is on the **main thread**
 
 ---
 

--- a/skills/sentry-flutter-sdk/SKILL.md
+++ b/skills/sentry-flutter-sdk/SKILL.md
@@ -422,6 +422,7 @@ Walk through features one at a time. Load the reference file for each, follow it
 | Profiling | `${SKILL_ROOT}/references/profiling.md` | iOS/macOS performance-sensitive apps |
 | Logging | `${SKILL_ROOT}/references/logging.md` | Structured logging / log-trace correlation |
 | Metrics | `${SKILL_ROOT}/references/metrics.md` | Custom business metrics |
+| Ecosystem Integrations | `${SKILL_ROOT}/references/ecosystem-integrations.md` | HTTP clients, databases, GraphQL, state management |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
 
@@ -533,9 +534,7 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | `beforeBreadcrumb` | `(Breadcrumb, Hint) → Breadcrumb?` | Process breadcrumbs before storage |
 | `beforeSendLog` | `(SentryLog) → SentryLog?` | Filter structured logs before sending |
 
----
-
-## Environment Variables
+### Environment Variables
 
 Pass via `--dart-define` at build time:
 
@@ -564,82 +563,7 @@ options.dsn = const String.fromEnvironment('SENTRY_DSN');
 options.environment = const String.fromEnvironment('SENTRY_ENVIRONMENT', defaultValue: 'development');
 ```
 
----
-
-## Ecosystem Integrations
-
-Add these packages alongside `sentry_flutter` for deeper instrumentation:
-
-### HTTP Clients
-
-**Standard `http` package** — built into `sentry_flutter`, no extra install:
-
-```dart
-import 'package:sentry/sentry.dart';
-
-// Wrap your http client
-final client = SentryHttpClient(
-  captureFailedRequests: true,
-  failedRequestStatusCodes: [SentryStatusCode.range(400, 599)],
-);
-try {
-  final response = await client.get(Uri.parse('https://api.example.com/users'));
-} finally {
-  client.close();
-}
-```
-
-**Dio** — install `sentry_dio`:
-
-```bash
-flutter pub add sentry_dio
-```
-
-```dart
-import 'package:dio/dio.dart';
-import 'package:sentry_dio/sentry_dio.dart';
-
-final dio = Dio();
-// Add your interceptors first, THEN addSentry() last
-dio.addSentry(
-  captureFailedRequests: true,
-  failedRequestStatusCodes: [SentryStatusCode.range(400, 599)],
-);
-```
-
-### Databases
-
-| Package | Install | Setup |
-|---------|---------|-------|
-| `sentry_sqflite` | `flutter pub add sentry_sqflite` | `databaseFactory = SentrySqfliteDatabaseFactory();` |
-| `sentry_drift` | `flutter pub add sentry_drift` | `.interceptWith(SentryQueryInterceptor(databaseName: 'db'))` |
-| `sentry_hive` | `flutter pub add sentry_hive` | Use `SentryHive` instead of `Hive` |
-| `sentry_isar` | `flutter pub add sentry_isar` | Use `SentryIsar.open()` instead of `Isar.open()` |
-
-### Other
-
-| Package | Install | Purpose |
-|---------|---------|---------|
-| `sentry_logging` | `flutter pub add sentry_logging` | Dart `logging` package → Sentry breadcrumbs/events |
-| `sentry_link` | `flutter pub add sentry_link` | GraphQL (gql, graphql_flutter, ferry) tracing |
-| `sentry_supabase` | `flutter pub add sentry_supabase` | Supabase query tracing (SDK ≥9.9.0) |
-| `sentry_firebase_remote_config` | `flutter pub add sentry_firebase_remote_config` | Feature flag tracking |
-| `sentry_file` | `flutter pub add sentry_file` | File I/O tracing via `.sentryTrace()` extension |
-
-### State Management Patterns
-
-No official packages — wire Sentry via observer APIs:
-
-| Framework | Hook point | Pattern |
-|-----------|-----------|---------|
-| **BLoC/Cubit** | `BlocObserver.onError` | `Sentry.captureException(error, stackTrace: stackTrace)` inside `onError`; set `Bloc.observer = SentryBlocObserver()` before init |
-| **Riverpod** | `ProviderObserver.providerDidFail` | Fires for `FutureProvider`/`StreamProvider` failures; wrap app with `ProviderScope(observers: [SentryProviderObserver()])` |
-| **Provider/ChangeNotifier** | `try/catch` in `notifyListeners` callers | Manually call `Sentry.captureException(e, stackTrace: stack)` in catch blocks |
-| **GetX** | `GetMaterialApp.onError` | `GetMaterialApp(onError: (details) => Sentry.captureException(...))` |
-
----
-
-## Production Settings
+### Production Settings
 
 Lower sample rates and harden config before shipping:
 
@@ -669,6 +593,25 @@ Future<void> main() async {
   );
 }
 ```
+
+### Default Auto-Enabled Integrations
+
+These are active with no extra config when you call `SentryFlutter.init()`:
+
+| Integration | What it does |
+|-------------|-------------|
+| `FlutterErrorIntegration` | Captures `FlutterError.onError` framework errors |
+| `RunZonedGuardedIntegration` | Catches unhandled Dart exceptions in runZonedGuarded |
+| `NativeAppStartIntegration` | App start timing (iOS/Android) |
+| `FramesTrackingIntegration` | Slow/frozen frames (iOS/Android/macOS) |
+| `NativeUserInteractionIntegration` | User interaction breadcrumbs from native layer |
+| `UserInteractionIntegration` | Dart-layer tap/click transactions (requires `SentryWidget`) |
+| `DeviceContextIntegration` | Device model, OS version, screen resolution |
+| `AppContextIntegration` | App version, build number, bundle ID |
+| `ConnectivityIntegration` | Network connectivity change breadcrumbs |
+| `HttpClientIntegration` | Auto-instrument Dart `http` requests |
+| `SdkIntegration` | SDK metadata tagging |
+| `ReleaseIntegration` | Auto-set release on iOS/Android from package info |
 
 ---
 
@@ -712,27 +655,6 @@ ElevatedButton(
 > - Native crashes, session replay, slow/frozen frames, and app start metrics only fully work in release builds on iOS/Android
 > - Run `flutter run --release` or use a real device/emulator to test native features
 > - Debug mode uses the Dart VM with JIT compilation — some native integrations behave differently
-
----
-
-## Default Auto-Enabled Integrations
-
-These are active with no extra config when you call `SentryFlutter.init()`:
-
-| Integration | What it does |
-|-------------|-------------|
-| `FlutterErrorIntegration` | Captures `FlutterError.onError` framework errors |
-| `RunZonedGuardedIntegration` | Catches unhandled Dart exceptions in runZonedGuarded |
-| `NativeAppStartIntegration` | App start timing (iOS/Android) |
-| `FramesTrackingIntegration` | Slow/frozen frames (iOS/Android/macOS) |
-| `NativeUserInteractionIntegration` | User interaction breadcrumbs from native layer |
-| `UserInteractionIntegration` | Dart-layer tap/click transactions (requires `SentryWidget`) |
-| `DeviceContextIntegration` | Device model, OS version, screen resolution |
-| `AppContextIntegration` | App version, build number, bundle ID |
-| `ConnectivityIntegration` | Network connectivity change breadcrumbs |
-| `HttpClientIntegration` | Auto-instrument Dart `http` requests |
-| `SdkIntegration` | SDK metadata tagging |
-| `ReleaseIntegration` | Auto-set release on iOS/Android from package info |
 
 ---
 

--- a/skills/sentry-flutter-sdk/references/ecosystem-integrations.md
+++ b/skills/sentry-flutter-sdk/references/ecosystem-integrations.md
@@ -1,0 +1,70 @@
+# Ecosystem Integrations — Sentry Flutter SDK
+
+Add these packages alongside `sentry_flutter` for deeper instrumentation:
+
+### HTTP Clients
+
+**Standard `http` package** — built into `sentry_flutter`, no extra install:
+
+```dart
+import 'package:sentry/sentry.dart';
+
+// Wrap your http client
+final client = SentryHttpClient(
+  captureFailedRequests: true,
+  failedRequestStatusCodes: [SentryStatusCode.range(400, 599)],
+);
+try {
+  final response = await client.get(Uri.parse('https://api.example.com/users'));
+} finally {
+  client.close();
+}
+```
+
+**Dio** — install `sentry_dio`:
+
+```bash
+flutter pub add sentry_dio
+```
+
+```dart
+import 'package:dio/dio.dart';
+import 'package:sentry_dio/sentry_dio.dart';
+
+final dio = Dio();
+// Add your interceptors first, THEN addSentry() last
+dio.addSentry(
+  captureFailedRequests: true,
+  failedRequestStatusCodes: [SentryStatusCode.range(400, 599)],
+);
+```
+
+### Databases
+
+| Package | Install | Setup |
+|---------|---------|-------|
+| `sentry_sqflite` | `flutter pub add sentry_sqflite` | `databaseFactory = SentrySqfliteDatabaseFactory();` |
+| `sentry_drift` | `flutter pub add sentry_drift` | `.interceptWith(SentryQueryInterceptor(databaseName: 'db'))` |
+| `sentry_hive` | `flutter pub add sentry_hive` | Use `SentryHive` instead of `Hive` |
+| `sentry_isar` | `flutter pub add sentry_isar` | Use `SentryIsar.open()` instead of `Isar.open()` |
+
+### Other
+
+| Package | Install | Purpose |
+|---------|---------|---------|
+| `sentry_logging` | `flutter pub add sentry_logging` | Dart `logging` package → Sentry breadcrumbs/events |
+| `sentry_link` | `flutter pub add sentry_link` | GraphQL (gql, graphql_flutter, ferry) tracing |
+| `sentry_supabase` | `flutter pub add sentry_supabase` | Supabase query tracing (SDK ≥9.9.0) |
+| `sentry_firebase_remote_config` | `flutter pub add sentry_firebase_remote_config` | Feature flag tracking |
+| `sentry_file` | `flutter pub add sentry_file` | File I/O tracing via `.sentryTrace()` extension |
+
+### State Management Patterns
+
+No official packages — wire Sentry via observer APIs:
+
+| Framework | Hook point | Pattern |
+|-----------|-----------|---------|
+| **BLoC/Cubit** | `BlocObserver.onError` | `Sentry.captureException(error, stackTrace: stackTrace)` inside `onError`; set `Bloc.observer = SentryBlocObserver()` before init |
+| **Riverpod** | `ProviderObserver.providerDidFail` | Fires for `FutureProvider`/`StreamProvider` failures; wrap app with `ProviderScope(observers: [SentryProviderObserver()])` |
+| **Provider/ChangeNotifier** | `try/catch` in `notifyListeners` callers | Manually call `Sentry.captureException(e, stackTrace: stack)` in catch blocks |
+| **GetX** | `GetMaterialApp.onError` | `GetMaterialApp(onError: (details) => Sentry.captureException(...))` |

--- a/skills/sentry-react-native-sdk/SKILL.md
+++ b/skills/sentry-react-native-sdk/SKILL.md
@@ -535,6 +535,7 @@ Walk through features one at a time. Load the reference file for each, follow it
 | Session Replay | `${SKILL_ROOT}/references/session-replay.md` | User-facing apps |
 | Logging | `${SKILL_ROOT}/references/logging.md` | Structured logging / log-to-trace correlation |
 | User Feedback | `${SKILL_ROOT}/references/user-feedback.md` | Collecting user-submitted reports |
+| Expo Config Plugin | `${SKILL_ROOT}/references/expo-config-plugin.md` | Configuring the `@sentry/react-native/expo` plugin |
 
 For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exactly, verify it works.
 
@@ -646,9 +647,7 @@ Sentry.init({
 | `beforeBreadcrumb` | `(breadcrumb, hint) => breadcrumb \| null` | Process breadcrumbs before storage |
 | `onNativeLog` | `(log: { level, component, message }) => void` | Intercept native SDK log messages and forward to JS console. Only fires when `debug: true` |
 
----
-
-## Environment Variables
+### Environment Variables
 
 | Variable | Purpose | Notes |
 |----------|---------|-------|
@@ -664,44 +663,7 @@ Sentry.init({
 | `SENTRY_EAS_BUILD_CAPTURE_SUCCESS` | EAS build hook: capture successful builds | Set `true` in EAS secrets |
 | `SENTRY_EAS_BUILD_TAGS` | EAS build hook: additional tags JSON | e.g., `{"team":"mobile"}` |
 
----
-
-## Source Maps & Debug Symbols
-
-Source maps and debug symbols are what transform minified stack traces into readable ones. When set up correctly, Sentry shows you the exact line of your source code that threw.
-
-### How Uploads Work
-
-| Platform | What's uploaded | When |
-|----------|----------------|------|
-| **iOS** (JS) | Source maps (`.map` files) | During Xcode build |
-| **iOS** (Native) | dSYM bundles | During Xcode archive / Xcode Cloud |
-| **Android** (JS) | Source maps + Hermes `.hbc.map` | During Gradle build |
-| **Android** (Native) | Proguard mapping + NDK `.so` files | During Gradle build |
-
-### Expo: Automatic Upload
-
-The `@sentry/react-native/expo` config plugin automatically sets up upload hooks for native builds. Source maps are uploaded during `eas build` and `expo run:ios/android` (release).
-
-```bash
-SENTRY_AUTH_TOKEN=sntrys_... npx expo run:ios --configuration Release
-```
-
-### Manual Upload (bare RN)
-
-If you need to manually upload source maps:
-
-```bash
-npx sentry-cli sourcemaps upload \
-  --org YOUR_ORG \
-  --project YOUR_PROJECT \
-  --release "my-app@1.0.0+1" \
-  ./dist
-```
-
----
-
-## Default Integrations (Auto-Enabled)
+### Default Integrations (Auto-Enabled)
 
 These integrations are enabled automatically — no config needed:
 
@@ -771,51 +733,68 @@ When a native crash occurs inside a tracked TurboModule method call, the crash r
 </Sentry.TouchEventBoundary>
 ```
 
+### Production Settings
+
+Lower sample rates and harden config before shipping to production:
+
+```typescript
+Sentry.init({
+  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
+  environment: __DEV__ ? "development" : "production",
+
+  // Trace 10–20% of transactions in high-traffic production
+  tracesSampleRate: __DEV__ ? 1.0 : 0.1,
+
+  // Profile 100% of traced transactions (profiling is always a subset of tracing)
+  profilesSampleRate: 1.0,
+
+  // Replay all error sessions, sample 5% of normal sessions
+  replaysOnErrorSampleRate: 1.0,
+  replaysSessionSampleRate: __DEV__ ? 1.0 : 0.05,
+
+  // Set release and dist for accurate source map lookup
+  release: "my-app@" + Application.nativeApplicationVersion,
+  dist: String(Application.nativeBuildVersion),
+
+  // Disable debug logging in production
+  debug: __DEV__,
+});
+```
+
 ---
 
-## Expo Config Plugin Reference
+## Source Maps & Debug Symbols
 
-Configure the plugin in `app.json` or `app.config.js`:
+Source maps and debug symbols are what transform minified stack traces into readable ones. When set up correctly, Sentry shows you the exact line of your source code that threw.
 
-```json
-{
-  "expo": {
-    "plugins": [
-      [
-        "@sentry/react-native/expo",
-        {
-          "url": "https://sentry.io/",
-          "project": "my-project",
-          "organization": "my-org",
-          "note": "Set SENTRY_AUTH_TOKEN env var for native builds"
-        }
-      ]
-    ]
-  }
-}
+### How Uploads Work
+
+| Platform | What's uploaded | When |
+|----------|----------------|------|
+| **iOS** (JS) | Source maps (`.map` files) | During Xcode build |
+| **iOS** (Native) | dSYM bundles | During Xcode archive / Xcode Cloud |
+| **Android** (JS) | Source maps + Hermes `.hbc.map` | During Gradle build |
+| **Android** (Native) | Proguard mapping + NDK `.so` files | During Gradle build |
+
+### Expo: Automatic Upload
+
+The `@sentry/react-native/expo` config plugin automatically sets up upload hooks for native builds. Source maps are uploaded during `eas build` and `expo run:ios/android` (release).
+
+```bash
+SENTRY_AUTH_TOKEN=sntrys_... npx expo run:ios --configuration Release
 ```
 
-Or in `app.config.js` (allows env var interpolation):
+### Manual Upload (bare RN)
 
-```javascript
-export default {
-  expo: {
-    plugins: [
-      [
-        "@sentry/react-native/expo",
-        {
-          url: "https://sentry.io/",
-          project: process.env.SENTRY_PROJECT,
-          organization: process.env.SENTRY_ORG,
-          disableAutoUpload: process.env.NODE_ENV === "development",
-        },
-      ],
-    ],
-  },
-};
+If you need to manually upload source maps:
+
+```bash
+npx sentry-cli sourcemaps upload \
+  --org YOUR_ORG \
+  --project YOUR_PROJECT \
+  --release "my-app@1.0.0+1" \
+  ./dist
 ```
-
-> **Tip:** Set `disableAutoUpload: true` during local development to speed up builds by skipping source map and dSYM uploads. The option is available in SDK ≥8.13.0.
 
 ---
 
@@ -853,36 +832,6 @@ The hook reads `SENTRY_DSN` from the build environment — it does not share the
 | `SENTRY_EAS_BUILD_SUCCESS_MESSAGE` | Custom message for successful builds |
 
 > **How it works:** The hook script is an EAS [npm lifecycle hook](https://docs.expo.dev/build-reference/npm-hooks/). EAS calls `package.json` scripts matching `eas-build-on-*` at the end of the build process. The script loads env from `@expo/env`, `.env`, or `.env.sentry-build-plugin` — without overwriting EAS secrets already in the environment.
-
----
-
-## Production Settings
-
-Lower sample rates and harden config before shipping to production:
-
-```typescript
-Sentry.init({
-  dsn: process.env.EXPO_PUBLIC_SENTRY_DSN,
-  environment: __DEV__ ? "development" : "production",
-
-  // Trace 10–20% of transactions in high-traffic production
-  tracesSampleRate: __DEV__ ? 1.0 : 0.1,
-
-  // Profile 100% of traced transactions (profiling is always a subset of tracing)
-  profilesSampleRate: 1.0,
-
-  // Replay all error sessions, sample 5% of normal sessions
-  replaysOnErrorSampleRate: 1.0,
-  replaysSessionSampleRate: __DEV__ ? 1.0 : 0.05,
-
-  // Set release and dist for accurate source map lookup
-  release: "my-app@" + Application.nativeApplicationVersion,
-  dist: String(Application.nativeBuildVersion),
-
-  // Disable debug logging in production
-  debug: __DEV__,
-});
-```
 
 ---
 

--- a/skills/sentry-react-native-sdk/references/expo-config-plugin.md
+++ b/skills/sentry-react-native-sdk/references/expo-config-plugin.md
@@ -1,0 +1,43 @@
+# Expo Config Plugin Reference — Sentry React Native SDK
+
+Configure the plugin in `app.json` or `app.config.js`:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "@sentry/react-native/expo",
+        {
+          "url": "https://sentry.io/",
+          "project": "my-project",
+          "organization": "my-org",
+          "note": "Set SENTRY_AUTH_TOKEN env var for native builds"
+        }
+      ]
+    ]
+  }
+}
+```
+
+Or in `app.config.js` (allows env var interpolation):
+
+```javascript
+export default {
+  expo: {
+    plugins: [
+      [
+        "@sentry/react-native/expo",
+        {
+          url: "https://sentry.io/",
+          project: process.env.SENTRY_PROJECT,
+          organization: process.env.SENTRY_ORG,
+          disableAutoUpload: process.env.NODE_ENV === "development",
+        },
+      ],
+    ],
+  },
+};
+```
+
+> **Tip:** Set `disableAutoUpload: true` during local development to speed up builds by skipping source map and dSYM uploads. The option is available in SDK ≥8.13.0.

--- a/skills/sentry-svelte-sdk/SKILL.md
+++ b/skills/sentry-svelte-sdk/SKILL.md
@@ -336,19 +336,6 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 
 ---
 
-## SvelteKit File Summary
-
-| File | Purpose | Modern | Legacy |
-|------|---------|--------|--------|
-| `src/instrumentation.server.ts` | Server `Sentry.init()` — runs once at startup | ✅ Required | ❌ |
-| `src/hooks.client.ts` | Client `Sentry.init()` + `handleError` | ✅ Required | ✅ Required |
-| `src/hooks.server.ts` | `handleError` + `sentryHandle()` (no init) | ✅ Required | ✅ Init goes here |
-| `svelte.config.js` | Enable `experimental.instrumentation.server` | ✅ Required | ❌ |
-| `vite.config.ts` | `sentrySvelteKit()` plugin for source maps | ✅ Recommended | ✅ Recommended |
-| `.env` | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` | ✅ For source maps | ✅ For source maps |
-
----
-
 ## Configuration Reference
 
 ### Key `Sentry.init()` Options
@@ -389,6 +376,17 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | `@sveltejs/adapter-node` | ✅ Full |
 | `@sveltejs/adapter-cloudflare` | ⚠️ Partial — requires extra setup |
 | Vercel Edge Runtime | ❌ Not supported |
+
+### SvelteKit File Summary
+
+| File | Purpose | Modern | Legacy |
+|------|---------|--------|--------|
+| `src/instrumentation.server.ts` | Server `Sentry.init()` — runs once at startup | ✅ Required | ❌ |
+| `src/hooks.client.ts` | Client `Sentry.init()` + `handleError` | ✅ Required | ✅ Required |
+| `src/hooks.server.ts` | `handleError` + `sentryHandle()` (no init) | ✅ Required | ✅ Init goes here |
+| `svelte.config.js` | Enable `experimental.instrumentation.server` | ✅ Required | ❌ |
+| `vite.config.ts` | `sentrySvelteKit()` plugin for source maps | ✅ Recommended | ✅ Recommended |
+| `.env` | `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` | ✅ For source maps | ✅ For source maps |
 
 ---
 


### PR DESCRIPTION
The mobile and native SDK skills (Android, Cocoa, Flutter, React Native, Svelte) had accreted extra top-level `##` sections over time — Environment Variables, Production Settings, Ecosystem Integrations, Integration Reference, Expo Config Plugin Reference, Default Auto-Enabled Integrations, SvelteKit File Summary — which broke the canonical `Phase 1-4 -> Configuration Reference -> Verification -> Cross-Link` skeleton that every SDK skill is meant to follow (and that the backend/dynamic-language skills already follow cleanly).

This relocates them without changing any content:

- Config-reference-grade material (env vars, default integrations, production hardening, file summaries) folds into `Configuration Reference` as `###` subsections, matching the backend SDK skills.
- Longer standalone deep-dives move to new `references/` files pointed to from the Phase 3 feature table: Android `integrations.md`, Flutter `ecosystem-integrations.md`, React Native `expo-config-plugin.md`.

Pure relocation — verified that every removed body line is preserved either in place (folded) or in the new reference files; the only deletions are the extracted section headings (reformatted as the reference-file title) and a few section separators.

The React Native `Source Maps & Debug Symbols` and `EAS Build Hooks` sections are intentionally left at top level here — the third PR in this series trims those down to a cross-link. Second of three PRs normalizing SDK skill structure.