### PR TITLE
docs(ai-monitoring): Document gen_ai.request.reasoning_effort attribute

### DIFF
--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -231,6 +231,7 @@ Sentry automatically captures token usage following OpenTelemetry GenAI semantic
 | Span Attribute | Description |
 |----------------|-------------|
 | `gen_ai.request.model` | Model name |
+| `gen_ai.request.reasoning_effort` | Reasoning effort level for reasoning models (e.g., `low`, `medium`, `high`). Supported values vary by provider. |
 | `gen_ai.usage.input_tokens` | Prompt/input token count |
 | `gen_ai.usage.output_tokens` | Completion/output token count |
 | `gen_ai.usage.input_tokens.cached` | Cached input tokens |

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -262,6 +262,7 @@ Sentry automatically captures token usage following OpenTelemetry GenAI semantic
 | Span Attribute | Description |
 |----------------|-------------|
 | `gen_ai.request.model` | Model name |
+| `gen_ai.request.reasoning_effort` | Reasoning effort level for reasoning models (e.g., `low`, `medium`, `high`). Supported values vary by provider. |
 | `gen_ai.usage.input_tokens` | Prompt/input token count |
 | `gen_ai.usage.output_tokens` | Completion/output token count |
 | `gen_ai.usage.input_tokens.cached` | Cached input tokens |

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -152,6 +152,12 @@ await Sentry.startSpan({
 | `gen_ai.operation.name` | string | No | Human-readable operation label |
 | `gen_ai.agent.name` | string | No | Agent name (for agent spans) |
 
+### Model config attributes
+
+| Attribute | Type |
+|-----------|------|
+| `gen_ai.request.reasoning_effort` | string |
+
 ### Content attributes (PII-gated — only when `sendDefaultPii: true` + `recordInputs/recordOutputs: true`)
 
 | Attribute | Type | Description |

--- a/skills/sentry-python-sdk/references/ai-monitoring.md
+++ b/skills/sentry-python-sdk/references/ai-monitoring.md
@@ -142,8 +142,6 @@ messages = [{"role": "user", "content": "Tell me a joke"}]
 with sentry_sdk.start_span(op="gen_ai.request", name="chat gpt-4o") as span:
     span.set_data("gen_ai.request.model", "gpt-4o")
     span.set_data("gen_ai.request.messages", json.dumps(messages))   # must JSON-stringify
-    span.set_data("gen_ai.request.temperature", 0.7)
-    span.set_data("gen_ai.request.max_tokens", 500)
 
     result = my_llm_client.chat(model="gpt-4o", messages=messages)
 
@@ -211,11 +209,7 @@ with sentry_sdk.start_span(op="gen_ai.handoff",
 
 | Attribute | Type |
 |-----------|------|
-| `gen_ai.request.temperature` | float |
-| `gen_ai.request.max_tokens` | int |
-| `gen_ai.request.top_p` | float |
-| `gen_ai.request.frequency_penalty` | float |
-| `gen_ai.request.presence_penalty` | float |
+| `gen_ai.request.reasoning_effort` | string |
 
 ### Content attributes (PII-gated — only when `send_default_pii=True` + `include_prompts=True`)
 

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -263,6 +263,12 @@ await Sentry.startSpan({
 | `gen_ai.operation.name` | No | Operation label (`chat`, `embeddings`, `invoke_agent`, `execute_tool`, `handoff`, etc.) |
 | `gen_ai.agent.name` | No | Agent name (set on agent and tool spans) |
 
+**Model config (LLM call spans):**
+
+| Attribute | Description |
+|-----------|-------------|
+| `gen_ai.request.reasoning_effort` | Reasoning effort level for reasoning models (e.g., `low`, `medium`, `high`). Supported values vary by provider. |
+
 **Request / response content (PII — enable only after confirming; see Data Capture Warning above):**
 
 | Attribute | Description |


### PR DESCRIPTION
Document the `gen_ai.request.reasoning_effort` span attribute in the AI/agent monitoring manual instrumentation references. The attribute records the reasoning effort parameter (e.g. `low`, `medium`, `high`) sent to reasoning-capable models; supported values vary by provider, so the docs note that rather than a fixed enum.

Added to the model-config sections of the Python, Node, Next.js, and NestJS SDK skills and the `sentry-setup-ai-monitoring` skill.

**Drops the other `gen_ai.request.*` model-config attributes**

`temperature`, `max_tokens`, `top_p`, `frequency_penalty`, and `presence_penalty` are removed from the skill references (the Python model-config table and code sample). `reasoning_effort` is now the only documented model-config attribute.

Relates to https://github.com/getsentry/sentry-conventions/pull/334, https://github.com/getsentry/sentry/pull/118144

Refs TET-2506