### PR TITLE
refactor(skills): trim duplicated source-map setup from SDK skills

### DIFF
--- a/skills/sentry-cloudflare-sdk/SKILL.md
+++ b/skills/sentry-cloudflare-sdk/SKILL.md
@@ -338,19 +338,11 @@ interface Env {
 
 #### Source Maps Setup
 
-Source maps make production stack traces readable. Without them, you see minified/bundled code.
-
-**Step 1: Generate a Sentry auth token**
-
-Go to [sentry.io/settings/auth-tokens/](https://sentry.io/settings/auth-tokens/) and create a token with `project:releases` and `org:read` scopes.
-
-**Step 2: Install the Sentry Vite plugin** (most Cloudflare projects use Vite via Wrangler):
+Source maps make production stack traces readable. Most Cloudflare projects build with Vite via Wrangler — wire the Sentry Vite plugin so maps upload on build:
 
 ```bash
 npm install @sentry/vite-plugin --save-dev
 ```
-
-**Step 3: Configure `vite.config.ts`** (if your project has one):
 
 ```typescript
 import { defineConfig } from "vite";
@@ -370,20 +362,7 @@ export default defineConfig({
 });
 ```
 
-**Step 4: Set environment variables in CI**
-
-```bash
-SENTRY_AUTH_TOKEN=sntrys_eyJ...
-SENTRY_ORG=my-org
-SENTRY_PROJECT=my-project
-```
-
-**Step 5: Add to `.gitignore`**
-
-```
-.dev.vars
-.env.sentry-build-plugin
-```
+`SENTRY_AUTH_TOKEN` is a build-time secret. For creating the token and wiring it into CI, see [`sentry-source-maps`](../sentry-source-maps/SKILL.md). The `npx @sentry/wizard@latest -i sourcemaps` shortcut noted above automates this setup.
 
 ---
 

--- a/skills/sentry-dotnet-sdk/SKILL.md
+++ b/skills/sentry-dotnet-sdk/SKILL.md
@@ -422,13 +422,7 @@ public class MvcApplication : HttpApplication
 
 ### Symbol Upload (Readable Stack Traces)
 
-Without debug symbols, stack traces show only method names — no file names or line numbers. Upload PDB files to unlock full source context.
-
-**Step 1: Create a Sentry auth token**
-
-Go to [sentry.io/settings/auth-tokens/](https://sentry.io/settings/auth-tokens/) and create a token with `project:releases` and `org:read` scopes.
-
-**Step 2: Add MSBuild properties to `.csproj` or `Directory.Build.props`:**
+Without debug symbols, stack traces show only method names — no file names or line numbers. The SDK uploads PDB files (and optionally sources) via MSBuild properties on Release builds:
 
 ```xml
 <PropertyGroup Condition="'$(Configuration)' == 'Release'">
@@ -441,15 +435,7 @@ Go to [sentry.io/settings/auth-tokens/](https://sentry.io/settings/auth-tokens/)
 </PropertyGroup>
 ```
 
-**Step 3: Set `SENTRY_AUTH_TOKEN` in CI:**
-
-```yaml
-# GitHub Actions
-- name: Build & upload symbols
-  run: dotnet build -c Release
-  env:
-    SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-```
+Upload needs a `SENTRY_AUTH_TOKEN` set in CI (a secret). For creating the token and the CI wiring, see [`sentry-source-maps`](../sentry-source-maps/SKILL.md). The `SentryCreateRelease` / `SentrySetCommits` properties also create a release with suspect commits — see [`sentry-releases`](../sentry-releases/SKILL.md).
 
 ---
 

--- a/skills/sentry-nextjs-sdk/SKILL.md
+++ b/skills/sentry-nextjs-sdk/SKILL.md
@@ -321,43 +321,18 @@ export const config = {
 
 ### Source Maps Setup
 
-Source maps make production stack traces readable — without them, you see minified code. This is non-negotiable for production apps.
-
-**Step 1: Generate a Sentry auth token**
-
-Go to [sentry.io/settings/auth-tokens/](https://sentry.io/settings/auth-tokens/) and create a token with `project:releases` and `org:read` scopes.
-
-**Step 2: Set environment variables**
-
-```bash
-# .env.sentry-build-plugin  (gitignore this file)
-SENTRY_AUTH_TOKEN=sntrys_eyJ...
-```
-
-Or set in CI secrets:
-
-```bash
-SENTRY_AUTH_TOKEN=sntrys_eyJ...
-SENTRY_ORG=my-org        # optional if set in next.config
-SENTRY_PROJECT=my-project # optional if set in next.config
-```
-
-**Step 3: Add to `.gitignore`**
-
-```
-.env.sentry-build-plugin
-```
-
-**Step 4: Verify `authToken` is wired in `next.config.ts`**
+`withSentryConfig` uploads source maps on production builds so stack traces show your original code instead of minified output. The SDK-specific wiring is the `authToken` (plus `widenClientFileUpload`, which improves client stack traces) in `next.config.ts`:
 
 ```typescript
 withSentryConfig(nextConfig, {
   org: "my-org",
   project: "my-project",
-  authToken: process.env.SENTRY_AUTH_TOKEN, // reads from .env.sentry-build-plugin or CI env
+  authToken: process.env.SENTRY_AUTH_TOKEN, // from CI env or a gitignored .env.sentry-build-plugin
   widenClientFileUpload: true,
 });
 ```
+
+`SENTRY_AUTH_TOKEN` is a build-time secret, distinct from the DSN. For creating the token, wiring it into CI, and troubleshooting minified traces, see [`sentry-source-maps`](../sentry-source-maps/SKILL.md).
 
 Source maps are uploaded automatically on every `next build`.
 

--- a/skills/sentry-node-sdk/SKILL.md
+++ b/skills/sentry-node-sdk/SKILL.md
@@ -772,19 +772,7 @@ process.on("SIGTERM", async () => {
 
 ### Source Maps (Node.js)
 
-Readable stack traces in production require source map upload. Use `@sentry/cli` or the webpack/esbuild/rollup plugins:
-
-```bash
-npm install @sentry/cli --save-dev
-```
-
-```bash
-# Create a Sentry auth token at sentry.io/settings/auth-tokens/
-# Set in .env.sentry-build-plugin (gitignore this file):
-SENTRY_AUTH_TOKEN=sntrys_eyJ...
-```
-
-Add upload step to your build:
+Readable stack traces in production require uploading source maps with `@sentry/cli` or the webpack/esbuild/rollup plugins — for example, an inject + upload step in your build:
 
 ```json
 {
@@ -793,6 +781,8 @@ Add upload step to your build:
   }
 }
 ```
+
+Upload needs a `SENTRY_AUTH_TOKEN` (a build-time secret). For creating the token and wiring it into CI, see [`sentry-source-maps`](../sentry-source-maps/SKILL.md).
 
 ---
 

--- a/skills/sentry-react-native-sdk/SKILL.md
+++ b/skills/sentry-react-native-sdk/SKILL.md
@@ -763,11 +763,11 @@ Sentry.init({
 
 ---
 
-## Source Maps & Debug Symbols
+### Source Maps & Debug Symbols
 
-Source maps and debug symbols are what transform minified stack traces into readable ones. When set up correctly, Sentry shows you the exact line of your source code that threw.
+Source maps and debug symbols are what transform minified stack traces into readable ones. When set up correctly, Sentry shows you the exact line of your source code that threw. The generic auth-token and CI setup lives in [`sentry-source-maps`](../sentry-source-maps/SKILL.md); the React Native-specific upload mechanics are below.
 
-### How Uploads Work
+#### How Uploads Work
 
 | Platform | What's uploaded | When |
 |----------|----------------|------|
@@ -776,7 +776,7 @@ Source maps and debug symbols are what transform minified stack traces into read
 | **Android** (JS) | Source maps + Hermes `.hbc.map` | During Gradle build |
 | **Android** (Native) | Proguard mapping + NDK `.so` files | During Gradle build |
 
-### Expo: Automatic Upload
+#### Expo: Automatic Upload
 
 The `@sentry/react-native/expo` config plugin automatically sets up upload hooks for native builds. Source maps are uploaded during `eas build` and `expo run:ios/android` (release).
 
@@ -784,7 +784,7 @@ The `@sentry/react-native/expo` config plugin automatically sets up upload hooks
 SENTRY_AUTH_TOKEN=sntrys_... npx expo run:ios --configuration Release
 ```
 
-### Manual Upload (bare RN)
+#### Manual Upload (bare RN)
 
 If you need to manually upload source maps:
 
@@ -798,7 +798,7 @@ npx sentry-cli sourcemaps upload \
 
 ---
 
-## EAS Build Hooks
+### EAS Build Hooks
 
 Monitor your Expo Application Services (EAS) builds in Sentry. The SDK ships three binary hooks — `sentry-eas-build-on-complete`, `sentry-eas-build-on-error`, and `sentry-eas-build-on-success` — that capture build events as Sentry errors or messages.
 

--- a/skills/sentry-react-sdk/SKILL.md
+++ b/skills/sentry-react-sdk/SKILL.md
@@ -303,13 +303,6 @@ export default defineConfig({
 });
 ```
 
-Add to `.env` (never commit):
-```bash
-SENTRY_AUTH_TOKEN=sntrys_...
-SENTRY_ORG=my-org-slug
-SENTRY_PROJECT=my-project-slug
-```
-
 **Create React App (via CRACO):**
 
 ```bash
@@ -334,6 +327,8 @@ module.exports = {
   },
 };
 ```
+
+`SENTRY_ORG` / `SENTRY_PROJECT` / `SENTRY_AUTH_TOKEN` are build-time values; the auth token is a secret (never commit it). For creating the token and wiring it into CI, see [`sentry-source-maps`](../sentry-source-maps/SKILL.md).
 
 ### For Each Agreed Feature
 


### PR DESCRIPTION
Several SDK skills embedded full source-map / debug-symbol tutorials that duplicate the improve-setup skills: the generic auth-token creation walkthrough ("go to settings/auth-tokens, create a token with these scopes"), CI pipeline YAML (GitHub Actions), env/`.gitignore` boilerplate, and EAS secret orchestration.

The `/sentry-get-started` design doc is explicit that an SDK skill should carry the *platform-specific* note and point to `sentry-source-maps` for the generic setup, rather than reimplement it — and `sentry-verify-instrumentation` already relies on each SDK skill flagging that stack traces stay minified/unsymbolicated until maps/symbols are uploaded.

This keeps the genuinely SDK-coupled mechanics in each skill — `withSentryConfig` `authToken`, the Vite/webpack plugin config, .NET's MSBuild upload properties, the `sentry-cli` build step, and React Native's per-platform symbol-upload table — plus the verification notes, and replaces the generic steps with a one-line prerequisite and a cross-link to `sentry-source-maps` (and `sentry-releases` for .NET's release properties). Every affected skill still mentions source maps and links out.

It also folds React Native's `Source Maps & Debug Symbols` and `EAS Build Hooks` sections under Configuration Reference (the two sections deliberately left out of the previous PR), restoring its canonical top-level skeleton.

Net −75 lines of duplicated tutorial; no SDK-specific content removed. Third of three PRs normalizing SDK skill structure.