### PR TITLE
docs(agent-monitoring): Add setUser / user attribution instructions

### DIFF
--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -359,6 +359,14 @@ Sentry.setConversationId("conv_abc123");
 
 A single conversation can span multiple traces, and a single trace can contain multiple conversations.
 
+### User Attribution
+
+To populate the **User** column in Conversations, call `setUser` once per request or session before any AI calls:
+
+```typescript
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -370,3 +378,4 @@ A single conversation can span multiple traces, and a single trace can contain m
 | Cost estimates not showing | Model name must match models.dev/OpenRouter pricing data; custom models may show no estimate |
 | Vercel AI spans not tracked | Pass `experimental_telemetry: { isEnabled: true }` to every AI SDK call |
 | No data in AI Agents dashboard | Ensure traces are being sent; check DSN and `tracesSampleRate` |
+| User column shows "Unknown" | Call `Sentry.setUser()` once per request or session |

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -422,6 +422,14 @@ await openai.chat.completions.create({
 
 A single conversation can span multiple traces, and a single trace can contain multiple conversations.
 
+### User Attribution
+
+To populate the **User** column in Conversations, call `setUser` once per request or session before any AI calls:
+
+```typescript
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -433,5 +441,6 @@ A single conversation can span multiple traces, and a single trace can contain m
 | Anthropic spans missing | Check SDK version supports Anthropic integration; add `anthropicAIIntegration()` explicitly |
 | Cost estimates not showing | Model name must match models.dev/OpenRouter pricing data; custom/fine-tuned models may show no estimate |
 | Edge runtime AI spans missing | Add `vercelAIIntegration()` to `sentry.edge.config.ts` explicitly (not auto-enabled for Edge) |
+| User column shows "Unknown" | Call `Sentry.setUser()` once per request or session |
 | OpenAI browser-side spans missing | Use `instrumentOpenAiClient()` wrapper — `openAIIntegration()` only works server-side |
 | No data in AI Agents dashboard | Ensure traces are being sent; check DSN and `tracesSampleRate` |

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -247,6 +247,14 @@ await openai.chat.completions.create({
 
 A single conversation can span multiple traces (e.g., page refresh), and a single trace can contain multiple conversations.
 
+### User Attribution
+
+To populate the **User** column in Conversations, call `setUser` once per request or session before any AI calls:
+
+```typescript
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
 ## Troubleshooting
 
 | Issue | Solution |
@@ -259,3 +267,4 @@ A single conversation can span multiple traces (e.g., page refresh), and a singl
 | AI Agents Dashboard empty | Ensure traces are being sent; check DSN and `tracesSampleRate` |
 | Wrong cost calculations | Cached/reasoning tokens are subsets of totals, not additions |
 | Conversations view empty | Ensure `streamGenAiSpans: true`, `sendDefaultPii: true`, and a conversation ID is set via `Sentry.setConversationId()` |
+| User column shows "Unknown" | Call `Sentry.setUser()` once per request or session |

--- a/skills/sentry-python-sdk/references/ai-monitoring.md
+++ b/skills/sentry-python-sdk/references/ai-monitoring.md
@@ -283,6 +283,14 @@ response = openai.responses.create(
 
 A single conversation can span multiple traces, and a single trace can contain multiple conversations.
 
+### User Attribution
+
+To populate the **User** column in Conversations, call `set_user` once per request or session before any AI calls:
+
+```python
+sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": "jane"})
+```
+
 ## Streaming
 
 | Integration | Streaming | Token counts in streams |
@@ -316,4 +324,5 @@ If your `traces_sample_rate` is below 1.0, you may be losing entire agent runs. 
 | LiteLLM not tracked | LiteLLM is NOT auto-enabled — add `LiteLLMIntegration` to `integrations=[]` explicitly |
 | Token counts missing for OpenAI streaming | Install `tiktoken>=0.3.0` and set `tiktoken_encoding_name` |
 | AI Agents Dashboard empty | Wrap agent runs in `gen_ai.invoke_agent` spans |
+| User column shows "Unknown" | Call `sentry_sdk.set_user()` once per request or session |
 | Wrong cost calculations | Ensure cached/reasoning token counts are subsets of totals, not additions |

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -378,6 +378,28 @@ response = openai.responses.create(
 )
 ```
 
+### User Attribution
+
+The Conversations view shows a **User** column. To populate it, call `setUser` / `set_user` once per request or session, before any AI calls:
+
+#### JavaScript
+
+```javascript
+import * as Sentry from "@sentry/node"; // or @sentry/nextjs, @sentry/nestjs, etc.
+
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
+#### Python
+
+```python
+import sentry_sdk
+
+sentry_sdk.set_user({"id": "user_123", "email": "jane@example.com", "username": "jane"})
+```
+
+Any of `id`, `email`, or `username` is sufficient — Conversations will display whichever fields are present.
+
 ### Conversations vs Traces
 
 These are independent concepts:
@@ -394,3 +416,4 @@ These are independent concepts:
 | Prompts not captured | Set `sendDefaultPii: true` (JS) or `send_default_pii=True` (Python); use `recordInputs`/`include_prompts` only for explicit overrides |
 | Vercel AI not working | Add `experimental_telemetry` to each call |
 | Conversations view empty | Ensure `streamGenAiSpans: true` / `stream_gen_ai_spans=True`, `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |
+| User column shows "Unknown" | Call `Sentry.setUser()` (JS) or `sentry_sdk.set_user()` (Python) once per request or session |


### PR DESCRIPTION
Adds user attribution guidance to the AI monitoring skill and all four per-SDK ai-monitoring references (node, python, nextjs, nestjs).

Each section adds a 'User Attribution' subsection explaining that calling Sentry.setUser() (JS) or sentry_sdk.set_user() (Python) once per request or session populates the User column in the Conversations view, with a minimal code snippet and a troubleshooting table row.

**Companion PRs:**
- sentry: https://github.com/getsentry/sentry/pull/118441
- sentry-docs: https://github.com/getsentry/sentry-docs/pull/18552

Refs TET-2513