### PR TITLE
feat(build): add content-root override and shared-reference hydration

### DIFF
--- a/plugin-src/claude/build.sh
+++ b/plugin-src/claude/build.sh
@@ -12,6 +12,10 @@
 # `.mcp.json` is shipped here; the root `mcp.json` only feeds the Cursor and
 # Codex builds.
 #
+# Skill content (skills/, commands/, references/, SKILL_TREE.md) is read from
+# CONTENT_ROOT, defaulting to the repo root. Point it at an alternate tree (e.g.
+# CONTENT_ROOT=skills-next) to build a different skill set with the same steps.
+#
 # Usage: build.sh <TARGET_DIR>   (TARGET_DIR assumed empty)
 
 set -euo pipefail
@@ -20,16 +24,18 @@ TARGET_DIR="${1:?usage: build.sh <TARGET_DIR>}"
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SRC_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
+source "$REPO_ROOT/scripts/build-common.sh"
+resolve_content_root "$REPO_ROOT"
 
 mkdir -p "$TARGET_DIR/.claude-plugin"
 
 cp "$SRC_DIR/plugin.json" "$TARGET_DIR/.claude-plugin/plugin.json"
 cp "$SRC_DIR/marketplace.json" "$TARGET_DIR/.claude-plugin/marketplace.json"
-rsync -a skills/ "$TARGET_DIR/skills/"
-rsync -a commands/ "$TARGET_DIR/commands/"
+copy_skills "$CONTENT_ROOT" "$TARGET_DIR/skills"
+copy_commands "$CONTENT_ROOT" "$TARGET_DIR/commands"
+copy_skill_tree "$CONTENT_ROOT" "$TARGET_DIR/SKILL_TREE.md"
 rsync -a assets/ "$TARGET_DIR/assets/"
-cp SKILL_TREE.md "$TARGET_DIR/SKILL_TREE.md"
 cp "$SRC_DIR/README.md" "$TARGET_DIR/README.md"
 cp LICENSE "$TARGET_DIR/LICENSE"
 
-echo "Built Claude dist into $TARGET_DIR (root plugin)."
+echo "Built Claude dist into $TARGET_DIR (root plugin, content from $CONTENT_ROOT)."

--- a/plugin-src/codex/build.sh
+++ b/plugin-src/codex/build.sh
@@ -30,6 +30,8 @@ TARGET_DIR="${1:?usage: build.sh <TARGET_DIR>}"
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SRC_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
+source "$REPO_ROOT/scripts/build-common.sh"
+resolve_content_root "$REPO_ROOT"
 
 PLUGIN_NAME="sentry"
 PLUGIN="$TARGET_DIR/plugins/$PLUGIN_NAME"
@@ -42,9 +44,11 @@ cp "$SRC_DIR/README.md" "$TARGET_DIR/README.md"
 cp LICENSE "$TARGET_DIR/LICENSE"
 
 cp mcp.json "$PLUGIN/.mcp.json"
-cp SKILL_TREE.md "$PLUGIN/SKILL_TREE.md"
+copy_skill_tree "$CONTENT_ROOT" "$PLUGIN/SKILL_TREE.md"
 rsync -a assets/ "$PLUGIN/assets/"
-rsync -a skills/ "$PLUGIN/skills/"
+# copy_skills hydrates each skill's shared references before the Codex transform,
+# so the hidden-leaf rewrite sees the final skill tree. (Codex ships no commands.)
+copy_skills "$CONTENT_ROOT" "$PLUGIN/skills"
 
 # Per-skill transform: strip the rejected field + emit agents/openai.yaml for
 # every hidden leaf (skills the source marked disable-model-invocation: true).

--- a/plugin-src/cursor/build.sh
+++ b/plugin-src/cursor/build.sh
@@ -13,6 +13,10 @@
 # bug currently hides plugin-delivered skills entirely. We ship the field
 # as-authored; that is a Cursor-side issue, not a packaging one.
 #
+# Skill content (skills/, commands/, references/, SKILL_TREE.md) is read from
+# CONTENT_ROOT, defaulting to the repo root. Point it at an alternate tree (e.g.
+# CONTENT_ROOT=skills-next) to build a different skill set with the same steps.
+#
 # Usage: build.sh <TARGET_DIR>   (TARGET_DIR assumed empty)
 
 set -euo pipefail
@@ -21,17 +25,19 @@ TARGET_DIR="${1:?usage: build.sh <TARGET_DIR>}"
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SRC_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
+source "$REPO_ROOT/scripts/build-common.sh"
+resolve_content_root "$REPO_ROOT"
 
 mkdir -p "$TARGET_DIR/.cursor-plugin"
 
 cp "$SRC_DIR/plugin.json" "$TARGET_DIR/.cursor-plugin/plugin.json"
 cp "$SRC_DIR/marketplace.json" "$TARGET_DIR/.cursor-plugin/marketplace.json"
-rsync -a skills/ "$TARGET_DIR/skills/"
-rsync -a commands/ "$TARGET_DIR/commands/"
+copy_skills "$CONTENT_ROOT" "$TARGET_DIR/skills"
+copy_commands "$CONTENT_ROOT" "$TARGET_DIR/commands"
+copy_skill_tree "$CONTENT_ROOT" "$TARGET_DIR/SKILL_TREE.md"
 rsync -a assets/ "$TARGET_DIR/assets/"
 cp mcp.json "$TARGET_DIR/mcp.json"
-cp SKILL_TREE.md "$TARGET_DIR/SKILL_TREE.md"
 cp "$SRC_DIR/README.md" "$TARGET_DIR/README.md"
 cp LICENSE "$TARGET_DIR/LICENSE"
 
-echo "Built Cursor dist into $TARGET_DIR (root plugin)."
+echo "Built Cursor dist into $TARGET_DIR (root plugin, content from $CONTENT_ROOT)."

--- a/plugin-src/grok/build.sh
+++ b/plugin-src/grok/build.sh
@@ -12,6 +12,10 @@
 #
 # MCP is a root `.mcp.json`, built from the repo's `mcp.json` source of truth.
 #
+# Skill content (skills/, commands/, references/, SKILL_TREE.md) is read from
+# CONTENT_ROOT, defaulting to the repo root. Point it at an alternate tree (e.g.
+# CONTENT_ROOT=skills-next) to build a different skill set with the same steps.
+#
 # Usage: build.sh <TARGET_DIR>   (TARGET_DIR assumed empty)
 
 set -euo pipefail
@@ -20,17 +24,19 @@ TARGET_DIR="${1:?usage: build.sh <TARGET_DIR>}"
 SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SRC_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
+source "$REPO_ROOT/scripts/build-common.sh"
+resolve_content_root "$REPO_ROOT"
 
 mkdir -p "$TARGET_DIR/.grok-plugin"
 
 cp "$SRC_DIR/plugin.json" "$TARGET_DIR/.grok-plugin/plugin.json"
 cp "$SRC_DIR/marketplace.json" "$TARGET_DIR/.grok-plugin/marketplace.json"
-rsync -a skills/ "$TARGET_DIR/skills/"
-rsync -a commands/ "$TARGET_DIR/commands/"
+copy_skills "$CONTENT_ROOT" "$TARGET_DIR/skills"
+copy_commands "$CONTENT_ROOT" "$TARGET_DIR/commands"
+copy_skill_tree "$CONTENT_ROOT" "$TARGET_DIR/SKILL_TREE.md"
 rsync -a assets/ "$TARGET_DIR/assets/"
 cp mcp.json "$TARGET_DIR/.mcp.json"
-cp SKILL_TREE.md "$TARGET_DIR/SKILL_TREE.md"
 cp "$SRC_DIR/README.md" "$TARGET_DIR/README.md"
 cp LICENSE "$TARGET_DIR/LICENSE"
 
-echo "Built Grok dist into $TARGET_DIR (root plugin)."
+echo "Built Grok dist into $TARGET_DIR (root plugin, content from $CONTENT_ROOT)."

--- a/scripts/build-common.sh
+++ b/scripts/build-common.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# build-common.sh — Shared helpers for the per-agent plugin builders.
+#
+# Each plugin-src/<agent>/build.sh sources this for the steps that are identical
+# across agents: resolving the content root and assembling the skill tree (copy +
+# reference hydration), commands, and SKILL_TREE.md. Agent-specific bits —
+# manifest locations, the MCP file, Codex's subdir layout and skill transform —
+# stay inline in each builder.
+#
+# Source it after cd-ing to the repo root:
+#   source "$REPO_ROOT/scripts/build-common.sh"
+#   resolve_content_root "$REPO_ROOT"
+
+# Directory holding this file and its sibling scripts (hydrate-references.py).
+_BUILD_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve CONTENT_ROOT to an absolute path, defaulting to the given repo root, so
+# a relative override (e.g. CONTENT_ROOT=skills-next) resolves predictably.
+#   resolve_content_root <repo_root>   -> sets global CONTENT_ROOT
+resolve_content_root() {
+    CONTENT_ROOT="$(cd "${CONTENT_ROOT:-$1}" && pwd)"
+}
+
+# Copy the skill tree from a content root into <dest>, then hydrate each skill's
+# declared shared references and strip the build-time manifests. Copy and
+# hydration are paired here so the two can never drift apart. The hydration step
+# only runs (and only spawns uv) when some skill actually declares references.
+#   copy_skills <content_root> <dest_skills_dir>
+copy_skills() {
+    rsync -a "$1/skills/" "$2/"
+    if compgen -G "$1/skills/*/references.yml" > /dev/null; then
+        uv run --script "$_BUILD_COMMON_DIR/hydrate-references.py" \
+            --references "$1/references" --skills-source "$1/skills" --skills-output "$2"
+    fi
+}
+
+# Copy commands/ from a content root, if it has any.
+#   copy_commands <content_root> <dest_commands_dir>
+copy_commands() {
+    if [[ -d "$1/commands" ]]; then
+        rsync -a "$1/commands/" "$2/"
+    fi
+}
+
+# Copy SKILL_TREE.md from a content root, if present.
+#   copy_skill_tree <content_root> <dest_path>
+copy_skill_tree() {
+    if [[ -f "$1/SKILL_TREE.md" ]]; then
+        cp "$1/SKILL_TREE.md" "$2"
+    fi
+}

--- a/scripts/hydrate-references.py
+++ b/scripts/hydrate-references.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = ["pyyaml", "braceexpand"]
+# ///
+#
+# hydrate-references.py — Copy each skill's declared shared references into it.
+#
+# Task skills keep large, shared reference material (per-platform SDK guides,
+# per-signal concepts) in a single maintained library rather than duplicating
+# it across skills. Each skill declares what it needs in a `references.yml`
+# manifest; at build time this script walks a skills directory and, for every
+# skill that has a manifest, expands those patterns against the library and
+# copies the matches into the built skill, so the shipped skill is
+# self-contained.
+#
+# The manifest is a build-time artifact — it is removed from each output skill so
+# it never ships in the plugin.
+#
+# Manifest format (<skills-source>/<skill>/references.yml):
+#
+#     needs:
+#       - sdks/*/{index,error-monitoring,tracing}.md
+#       - concepts/{errors,tracing}.md
+#       - setup-verification.md
+#
+# Paths are relative to --references; `*`, `**`, and `{a,b}` brace groups are
+# supported. A matched file at `<references>/<rel>` is copied to
+# `<skills-output>/<skill>/references/<rel>`.
+#
+# Run via uv so the dependencies above are resolved automatically:
+#   uv run --script hydrate-references.py \
+#       --references <dir> --skills-source <dir> --skills-output <dir>
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+import yaml
+from braceexpand import braceexpand
+
+
+def parse_needs(manifest: Path) -> list[str]:
+    """Read the `needs:` list out of a references.yml manifest."""
+    data = yaml.safe_load(manifest.read_text(encoding="utf-8")) or {}
+    needs = data.get("needs", [])
+    if not isinstance(needs, list):
+        raise ValueError(f"{manifest}: 'needs' must be a list of paths")
+    return [str(item) for item in needs]
+
+
+def hydrate(references: Path, manifest: Path, output: Path) -> int:
+    copied = 0
+    for pattern in parse_needs(manifest):
+        for expanded in braceexpand(pattern):
+            matches = [m for m in sorted(references.glob(expanded)) if m.is_file()]
+            if not matches:
+                print(f"warning: no match for '{expanded}' under {references}", file=sys.stderr)
+                continue
+            for match in matches:
+                dest = output / "references" / match.relative_to(references)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(match, dest)
+                copied += 1
+    return copied
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Copy each skill's declared shared references into it.")
+    parser.add_argument("--references", type=Path, required=True, help="Shared reference library root")
+    parser.add_argument("--skills-source", type=Path, required=True, help="Source skills dir (each skill may hold a references.yml)")
+    parser.add_argument("--skills-output", type=Path, required=True, help="Built skills dir to copy references into")
+    args = parser.parse_args()
+
+    manifests = sorted(args.skills_source.glob("*/references.yml"))
+    if manifests and not args.references.is_dir():
+        parser.error(f"references library not found: {args.references}")
+
+    for manifest in manifests:
+        skill = manifest.parent.name
+        output = args.skills_output / skill
+        if not output.is_dir():
+            continue
+        copied = hydrate(args.references, manifest, output)
+        # The manifest is a build-time artifact; never let it ship in the plugin.
+        (output / "references.yml").unlink(missing_ok=True)
+        print(f"{skill}: hydrated {copied} reference(s)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

We're moving the Sentry skills to a task-shaped layout where each skill is one task a user names, and the large shared material (per-platform SDK guides, per-signal concepts) lives in a single maintained `references/` library rather than being duplicated across skills. A shipped skill must still be self-contained, so the build needs to copy a skill's declared references into it. We also want to assemble alternate skill trees (the in-progress `skills-next/`) with the exact same build steps.

## What

- **`CONTENT_ROOT` env var** (default: repo root) on all four agent builders. Production is unchanged; `CONTENT_ROOT=skills-next` builds an alternate tree with the same steps.
- **`scripts/hydrate-references.py`** — given one skill folder, reads its `references.yml`, expands the `needs:` patterns (glob `*`/`**` plus `{a,b}` brace groups), copies matches into the skill's `references/` preserving subpaths, and strips the manifest so it never ships in the plugin. Runs via `uv run --script` with inline PyYAML + `braceexpand` dependencies (PEP 723), the same uv toolchain `validate.sh` already uses.
- **`scripts/hydrate-references.sh`** — runs the Python script per skill, and skips any skill without a `references.yml`. Existing skills are unaffected, and the common case spawns no interpreter at all (a warm `uv` spawn is ~0.1s, so the guard keeps a full 50-skill build under a second instead of ~6s).
- **`scripts/build-common.sh`** — the steps that were identical across the four builders (content-root resolution, skill copy+hydrate, commands, SKILL_TREE) factored into sourced helpers. Agent-specific bits (manifest locations, MCP file, Codex's subdir layout and skill transform) stay inline.

The `skills-next/` restructure and the actual `references.yml` manifests land in follow-up PRs; this is just the build machinery.

## Testing

Built all four agents in both modes (default root + `CONTENT_ROOT=skills-next`): production output is unchanged in shape (50 skills, SKILL_TREE present, Codex still emits its 44 hidden-leaf `openai.yaml` files), no stray `references.yml` ships, and `commands/` is never miscopied as a skill. A wired end-to-end run with a sample manifest confirmed brace+glob expansion, subpath-preserving copy, exclusion of undeclared references, and manifest stripping.
