### PR TITLE
docs(agent-monitoring): reflect streamGenAiSpans default in JS skills

### DIFF
--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -341,7 +341,7 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `sendDefaultPii: true` must be set, and `streamGenAiSpans` must be enabled (default since SDK 10.61.0; set it explicitly on 10.53.0–10.60.x) — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** SDK >=10.61.0 (where `streamGenAiSpans` defaults to `true`, so AI spans stream as standalone items) and `sendDefaultPii: true` — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/nestjs";

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -48,7 +48,6 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true, // enables recordInputs/recordOutputs by default
   integrations: [
     Sentry.openAIIntegration(),
@@ -116,7 +115,6 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.vercelAIIntegration(),
@@ -185,7 +183,6 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.anthropicAIIntegration(),
@@ -253,7 +250,6 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   sendDefaultPii: true, // ← enables input/output recording by default
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
 });
 ```
 
@@ -270,7 +266,6 @@ import * as Sentry from "@sentry/nestjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   enableLogs: true,
   integrations: [
@@ -346,7 +341,7 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** `sendDefaultPii: true` must be set, and `streamGenAiSpans` must be enabled (default since SDK 10.61.0; set it explicitly on 10.53.0–10.60.x) — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/nestjs";

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -52,7 +52,6 @@ Sentry.init({
 
   // Tracing MUST be enabled for AI monitoring
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
 
   integrations: [
@@ -120,7 +119,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.vercelAIIntegration({
@@ -137,7 +135,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.vercelAIIntegration(),
@@ -213,7 +210,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.anthropicAIIntegration(),
@@ -285,7 +281,6 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   sendDefaultPii: true, // ← enables input/output recording by default
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
 });
 ```
 
@@ -313,7 +308,6 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.openAIIntegration(),
@@ -405,7 +399,7 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set in your server config — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** `sendDefaultPii: true` must be set in your server config, and `streamGenAiSpans` must be enabled (default since SDK 10.61.0; set it explicitly on 10.53.0–10.60.x) — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/nextjs";

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -399,7 +399,7 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `sendDefaultPii: true` must be set in your server config, and `streamGenAiSpans` must be enabled (default since SDK 10.61.0; set it explicitly on 10.53.0–10.60.x) — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** SDK >=10.61.0 (where `streamGenAiSpans` defaults to `true`, so AI spans stream as standalone items) and `sendDefaultPii: true` set in your server config — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/nextjs";

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -10,7 +10,6 @@ Tracing must be enabled - AI spans require an active trace:
 Sentry.init({
   dsn: "...",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
 });
 ```
@@ -48,7 +47,6 @@ import * as Sentry from "@sentry/node";
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true, // required to capture prompts/outputs
 });
 // OpenAI, Anthropic, LangChain, LangGraph, Google GenAI activate automatically
@@ -60,7 +58,6 @@ Sentry.init({
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.openAIIntegration(),
@@ -220,7 +217,7 @@ If `tracesSampleRate` < 1.0, see the [AI sampling guide](../../sentry-setup-ai-m
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** `sendDefaultPii: true` must be set, and `streamGenAiSpans` must be enabled (default since SDK 10.61.0; set it explicitly on 10.53.0–10.60.x) — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/node";
@@ -266,5 +263,5 @@ Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
 | Prompts not captured | Set `sendDefaultPii: true`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
 | AI Agents Dashboard empty | Ensure traces are being sent; check DSN and `tracesSampleRate` |
 | Wrong cost calculations | Cached/reasoning tokens are subsets of totals, not additions |
-| Conversations view empty | Ensure `streamGenAiSpans: true`, `sendDefaultPii: true`, and a conversation ID is set via `Sentry.setConversationId()` |
+| Conversations view empty | Ensure `streamGenAiSpans` is enabled (default since SDK 10.61.0), `sendDefaultPii: true`, and a conversation ID is set via `Sentry.setConversationId()` |
 | User column shows "Unknown" | Call `Sentry.setUser()` once per request or session |

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring - Sentry Node.js SDK
 
-> Minimum SDK: `@sentry/node` >=10.53.0. OpenAI, Anthropic, LangChain, LangGraph, Google GenAI, Vercel AI SDK auto-instrument.
+> Minimum SDK: `@sentry/node` >=10.61.0 (Gen AI span streaming is on by default at this version). OpenAI, Anthropic, LangChain, LangGraph, Google GenAI, Vercel AI SDK auto-instrument and are available since 10.53.0.
 
 ## Prerequisites
 
@@ -217,7 +217,7 @@ If `tracesSampleRate` < 1.0, see the [AI sampling guide](../../sentry-setup-ai-m
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `sendDefaultPii: true` must be set, and `streamGenAiSpans` must be enabled (default since SDK 10.61.0; set it explicitly on 10.53.0–10.60.x) — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** SDK >=10.61.0 (where `streamGenAiSpans` defaults to `true`, so AI spans stream as standalone items) and `sendDefaultPii: true` — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/node";
@@ -256,7 +256,7 @@ Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
 
 | Issue | Solution |
 |-------|----------|
-| No AI spans appearing | Verify `tracesSampleRate > 0`; check SDK >=10.53.0 |
+| No AI spans appearing | Verify `tracesSampleRate > 0`; check SDK >=10.61.0 |
 | Token counts missing in streams | Add `stream_options: { include_usage: true }` (OpenAI) |
 | Vercel AI spans not tracked | Add `experimental_telemetry: { isEnabled: true }` per call |
 | Browser OpenAI not traced | Use `Sentry.instrumentOpenAiClient()` - auto-instrumentation is server-only |

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -325,7 +325,7 @@ Find it at **Explore > Conversations** in Sentry.
 ### Prerequisites for Conversations
 
 - Tracing enabled with `tracesSampleRate > 0`
-- `streamGenAiSpans` defaults to `true` since JS SDK 10.61.0 (set it explicitly on 10.53.0–10.60.x); Python still requires `stream_gen_ai_spans=True` (Python SDK >=2.60.0). This sends AI spans as standalone items, so spans with large inputs/outputs don't hit transaction payload size limits and get dropped.
+- Gen AI span streaming requires JS SDK >=10.61.0, where `streamGenAiSpans` defaults to `true`; Python still requires `stream_gen_ai_spans=True` (Python SDK >=2.60.0). This sends AI spans as standalone items, so spans with large inputs/outputs don't hit transaction payload size limits and get dropped.
 - **Input and output capture enabled** — Conversations reconstructs the chat from `gen_ai.input.messages` and `gen_ai.output.messages` attributes. Set `sendDefaultPii: true` (JS) / `send_default_pii=True` (Python). Without it, conversations appear empty.
 
 ### Setting a Conversation ID

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -109,7 +109,6 @@ Just ensure tracing is enabled. Integrations auto-enable when the AI package is 
 Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0, // Lower in production (e.g., 0.1)
-  streamGenAiSpans: true, // SDK ≥10.53.0
   // OpenAI, Anthropic, Google GenAI, LangChain integrations auto-enable in Node.js
 });
 ```
@@ -120,7 +119,6 @@ To customize (e.g., enable prompt capture after user confirmation — see Data C
 Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.openAIIntegration({
@@ -148,7 +146,6 @@ const openai = Sentry.instrumentOpenAiClient(new OpenAI());
 Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [
     Sentry.langChainIntegration(),
@@ -164,7 +161,6 @@ Add to `sentry.edge.config.ts` for Edge runtime:
 Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
-  streamGenAiSpans: true,
   sendDefaultPii: true,
   integrations: [Sentry.vercelAIIntegration()],
 });
@@ -329,7 +325,7 @@ Find it at **Explore > Conversations** in Sentry.
 ### Prerequisites for Conversations
 
 - Tracing enabled with `tracesSampleRate > 0`
-- `streamGenAiSpans: true` (JS SDK >=10.53.0) / `stream_gen_ai_spans=True` (Python SDK >=2.60.0) — required so AI spans are sent as standalone items. Without this, spans with large inputs/outputs can hit transaction payload size limits and be dropped.
+- `streamGenAiSpans` defaults to `true` since JS SDK 10.61.0 (set it explicitly on 10.53.0–10.60.x); Python still requires `stream_gen_ai_spans=True` (Python SDK >=2.60.0). This sends AI spans as standalone items, so spans with large inputs/outputs don't hit transaction payload size limits and get dropped.
 - **Input and output capture enabled** — Conversations reconstructs the chat from `gen_ai.input.messages` and `gen_ai.output.messages` attributes. Set `sendDefaultPii: true` (JS) / `send_default_pii=True` (Python). Without it, conversations appear empty.
 
 ### Setting a Conversation ID
@@ -415,5 +411,5 @@ These are independent concepts:
 | Negative or wrong costs in dashboard | Cached/reasoning tokens are subsets of totals — see Token Usage and Cost Calculation |
 | Prompts not captured | Set `sendDefaultPii: true` (JS) or `send_default_pii=True` (Python); use `recordInputs`/`include_prompts` only for explicit overrides |
 | Vercel AI not working | Add `experimental_telemetry` to each call |
-| Conversations view empty | Ensure `streamGenAiSpans: true` / `stream_gen_ai_spans=True`, `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |
+| Conversations view empty | Ensure `streamGenAiSpans` is enabled (default since JS SDK 10.61.0) / `stream_gen_ai_spans=True` (Python), `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |
 | User column shows "Unknown" | Call `Sentry.setUser()` (JS) or `sentry_sdk.set_user()` (Python) once per request or session |


### PR DESCRIPTION
The AI monitoring setup skill and the Node, NestJS, and Next.js SDK references drop `streamGenAiSpans: true` from their JS examples and raise the recommended minimum to SDK 10.61.0, where the option defaults to `true`. Without bumping the minimum, users on 10.53.x–10.60.x following the examples would silently stop streaming Gen AI spans. Per-integration availability stays at 10.53.0 as a historical fact, and Python (`stream_gen_ai_spans`) is unchanged because that option still defaults to off.

Paired with getsentry/sentry#118654, which makes the same change in the product onboarding snippets. Opt-out guidance stays in the docs, which already document the new default (getsentry/sentry-docs#18535).

Refs TET-2553