### PR TITLE
docs(agent-monitoring): reflect stream_gen_ai_spans default in Python skills

### DIFF
--- a/skills/sentry-python-sdk/references/ai-monitoring.md
+++ b/skills/sentry-python-sdk/references/ai-monitoring.md
@@ -1,6 +1,6 @@
 # AI Monitoring — Sentry Python SDK
 
-> Minimum SDK: `sentry-sdk` >=2.60.0
+> Minimum SDK: `sentry-sdk` >=2.64.0 (Gen AI span streaming is on by default at this version; the `stream_gen_ai_spans` option is available since 2.60.0).
 
 ## Prerequisites
 
@@ -10,7 +10,6 @@ Tracing must be enabled — AI spans require an active transaction:
 sentry_sdk.init(
     dsn="...",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
 )
 ```
@@ -54,7 +53,6 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="https://<key>@<org>.ingest.sentry.io/<project>",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,    # required to capture prompts/outputs
 )
 
@@ -71,7 +69,6 @@ from sentry_sdk.integrations.anthropic import AnthropicIntegration
 sentry_sdk.init(
     dsn="...",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         OpenAIIntegration(
@@ -92,7 +89,6 @@ from sentry_sdk.integrations.litellm import LiteLLMIntegration
 sentry_sdk.init(
     dsn="...",
     traces_sample_rate=1.0,
-    stream_gen_ai_spans=True,
     send_default_pii=True,
     integrations=[
         LiteLLMIntegration(include_prompts=True),   # 100+ providers via proxy
@@ -255,7 +251,7 @@ This populates the **AI Agents Dashboard** in Sentry with per-agent latency, too
 
 Link AI spans across turns in a multi-turn conversation. Sentry groups spans by `gen_ai.conversation.id` into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `stream_gen_ai_spans=True` (SDK >=2.60.0) and `send_default_pii=True` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** SDK >=2.64.0 (where `stream_gen_ai_spans` defaults to `True`, so AI spans stream as standalone items) and `send_default_pii=True` — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
 
 ```python
 import sentry_sdk.ai

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -189,7 +189,6 @@ import sentry_sdk
 sentry_sdk.init(
     dsn="YOUR_DSN",
     traces_sample_rate=1.0,  # Lower in production (e.g., 0.1)
-    stream_gen_ai_spans=True,  # SDK ≥2.60.0
     send_default_pii=True,
     # Integrations auto-enable when the AI package is installed.
     # Only specify explicitly to customize (e.g., include_prompts):
@@ -325,7 +324,7 @@ Find it at **Explore > Conversations** in Sentry.
 ### Prerequisites for Conversations
 
 - Tracing enabled with `tracesSampleRate > 0`
-- Gen AI span streaming requires JS SDK >=10.61.0, where `streamGenAiSpans` defaults to `true`; Python still requires `stream_gen_ai_spans=True` (Python SDK >=2.60.0). This sends AI spans as standalone items, so spans with large inputs/outputs don't hit transaction payload size limits and get dropped.
+- Gen AI span streaming is on by default — `streamGenAiSpans` defaults to `true` since JS SDK 10.61.0 and `stream_gen_ai_spans` defaults to `True` since Python SDK 2.64.0. This sends AI spans as standalone items, so spans with large inputs/outputs don't hit transaction payload size limits and get dropped. (The options are available since JS 10.53.0 / Python 2.60.0 if you need to set them explicitly on older SDKs.)
 - **Input and output capture enabled** — Conversations reconstructs the chat from `gen_ai.input.messages` and `gen_ai.output.messages` attributes. Set `sendDefaultPii: true` (JS) / `send_default_pii=True` (Python). Without it, conversations appear empty.
 
 ### Setting a Conversation ID
@@ -411,5 +410,5 @@ These are independent concepts:
 | Negative or wrong costs in dashboard | Cached/reasoning tokens are subsets of totals — see Token Usage and Cost Calculation |
 | Prompts not captured | Set `sendDefaultPii: true` (JS) or `send_default_pii=True` (Python); use `recordInputs`/`include_prompts` only for explicit overrides |
 | Vercel AI not working | Add `experimental_telemetry` to each call |
-| Conversations view empty | Ensure `streamGenAiSpans` is enabled (default since JS SDK 10.61.0) / `stream_gen_ai_spans=True` (Python), `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |
+| Conversations view empty | Ensure Gen AI span streaming is enabled (default since JS SDK 10.61.0 / Python SDK 2.64.0), `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |
 | User column shows "Unknown" | Call `Sentry.setUser()` (JS) or `sentry_sdk.set_user()` (Python) once per request or session |


### PR DESCRIPTION
The AI monitoring setup skill and the Python SDK reference drop `stream_gen_ai_spans=True` from their examples and raise the recommended minimum to SDK 2.64.0, where the option defaults to `True`. Below that, users following the examples would silently stop streaming Gen AI spans. The option stays available since 2.60.0 for explicit use on older SDKs.

Mirrors the earlier JS change. Companion PRs:

- Product onboarding: getsentry/sentry#118714
- Python docs: getsentry/sentry-docs#18591

Refs TET-2553