### PR TITLE
docs(skills): Migrate JS SDK skills from sendDefaultPii to dataCollection

### DIFF
--- a/skills/sentry-browser-sdk/references/error-monitoring.md
+++ b/skills/sentry-browser-sdk/references/error-monitoring.md
@@ -278,7 +278,7 @@ Sentry.setUser({
 // Clear user on logout
 Sentry.setUser(null);
 
-// Auto-infer IP address (requires sendDefaultPii: true in init)
+// Auto-infer IP address (collected by default; controlled by dataCollection.userInfo)
 Sentry.setUser({ ip_address: "{{auto}}" });
 ```
 

--- a/skills/sentry-browser-sdk/references/logging.md
+++ b/skills/sentry-browser-sdk/references/logging.md
@@ -223,7 +223,7 @@ These are added by the SDK to every log without any developer configuration:
 | `sentry.sdk.version` | SDK internals | — |
 | `browser.name` | User-Agent parsing | e.g., `"Chrome"` |
 | `browser.version` | User-Agent parsing | e.g., `"121.0.0"` |
-| `user.id`, `user.name`, `user.email` | `Sentry.setUser()` | Requires `sendDefaultPii: true` |
+| `user.id`, `user.name`, `user.email` | `Sentry.setUser()` | Populated when `Sentry.setUser()` is called (`userInfo` defaults to `true`) |
 | `sentry.trace.parent_span_id` | Active tracing span | Enables log ↔ trace correlation |
 | `sentry.replay_id` | Active Session Replay session | Enables log ↔ replay correlation |
 | `message.template` | `logger.fmt` usage | The template string |
@@ -301,4 +301,4 @@ Use `Sentry.logger.*` for **structured, searchable observability data**. Use `ca
 | Log attributes contain `undefined` | Only `string`, `number`, `boolean` are accepted — filter undefined values before passing |
 | `beforeSendLog` not firing | Confirm `enableLogs: true` is set; without it, no logs are sent and no hook is called |
 | Sensitive data appearing in logs | Add filtering in `beforeSendLog`; avoid logging sensitive data at the call site |
-| Logs appear but have no user context | Call `Sentry.setUser({ id, email })` after authentication; set `sendDefaultPii: true` |
+| Logs appear but have no user context | Call `Sentry.setUser({ id, email })` after authentication; `userInfo` is collected by default unless disabled via `dataCollection` |

--- a/skills/sentry-cloudflare-sdk/SKILL.md
+++ b/skills/sentry-cloudflare-sdk/SKILL.md
@@ -408,7 +408,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 | `dsn` | `string` | — | Required. Read from `env.SENTRY_DSN` automatically if not set |
 | `tracesSampleRate` | `number` | — | 0–1; 1.0 in dev, lower in prod recommended |
 | `tracesSampler` | `function` | — | Dynamic sampling function; mutually exclusive with `tracesSampleRate` |
-| `dataCollection` | `object` | `{}` | Controls what data the SDK captures (`userInfo`, `httpBodies`, etc.). See [Data Collection Reference](#data-collection-reference) |
+| `dataCollection` | `object` | conservative unless set | Controls what data the SDK captures (`userInfo`, `httpBodies`, etc.). When omitted, falls back to `sendDefaultPii` (default `false`); passing the object — even `{}` — enables permissive defaults. See [Data Collection Reference](#data-collection-reference) |
 | `sendDefaultPii` | `boolean` | `false` | Legacy. Prefer `dataCollection` for control over captured data |
 | `enableLogs` | `boolean` | `false` | Enable Sentry Logs product |
 | `environment` | `string` | auto | Read from `env.SENTRY_ENVIRONMENT` if not set |

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -49,7 +49,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nestjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.openAIIntegration(),
@@ -118,7 +121,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nestjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.vercelAIIntegration(),
@@ -188,7 +194,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nestjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.anthropicAIIntegration(),
@@ -256,7 +265,7 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    genAI: { inputs: false, outputs: false },
   },
   enableLogs: true,
   integrations: [

--- a/skills/sentry-nestjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/ai-monitoring.md
@@ -49,7 +49,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true, // enables recordInputs/recordOutputs by default
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.openAIIntegration(),
   ],
@@ -67,7 +69,7 @@ import * as Sentry from "@sentry/nestjs";
 const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 // Wrap once at module level — reuse this client everywhere.
-// Input/output recording follows sendDefaultPii unless explicitly overridden.
+// Input/output recording is on by default (governed by dataCollection.genAI) unless explicitly overridden.
 const client = Sentry.instrumentOpenAiClient(openai);
 ```
 
@@ -96,8 +98,8 @@ export class ChatService {
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `recordInputs` | `boolean` | `true` if `sendDefaultPii: true` | Capture prompts/messages sent to OpenAI |
-| `recordOutputs` | `boolean` | `true` if `sendDefaultPii: true` | Capture generated text/responses |
+| `recordInputs` | `boolean` | `true` (governed by `dataCollection.genAI`) | Capture prompts/messages sent to OpenAI |
+| `recordOutputs` | `boolean` | `true` (governed by `dataCollection.genAI`) | Capture generated text/responses |
 
 **Supported versions:** `openai` ≥4.0.0
 
@@ -117,7 +119,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.vercelAIIntegration(),
   ],
@@ -167,8 +171,8 @@ export class AiService {
 
 | Option | Type | Default | Min SDK | Description |
 |--------|------|---------|---------|-------------|
-| `recordInputs` | `boolean` | `true`* | 9.27.0 | Capture inputs. *Defaults to `true` when `sendDefaultPii: true`. |
-| `recordOutputs` | `boolean` | `true`* | 9.27.0 | Capture outputs. *Defaults to `true` when `sendDefaultPii: true`. |
+| `recordInputs` | `boolean` | `true`* | 9.27.0 | Capture inputs. *Defaults to `true` (governed by `dataCollection.genAI`). |
+| `recordOutputs` | `boolean` | `true`* | 9.27.0 | Capture outputs. *Defaults to `true` (governed by `dataCollection.genAI`). |
 
 **Supported versions:** `ai` ≥3.0.0
 
@@ -186,7 +190,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.anthropicAIIntegration(),
   ],
@@ -201,7 +207,7 @@ import * as Sentry from "@sentry/nestjs";
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 
-// Input/output recording follows sendDefaultPii unless explicitly overridden.
+// Input/output recording is on by default (governed by dataCollection.genAI) unless explicitly overridden.
 const client = Sentry.instrumentAnthropicAiClient(anthropic);
 
 const response = await client.messages.create({
@@ -246,18 +252,20 @@ Sentry automatically captures token usage following OpenTelemetry GenAI semantic
 `recordInputs` captures prompts sent to the AI API.
 `recordOutputs` captures the generated text/completions returned.
 
-Both default to `true` only when `sendDefaultPii: true` is set:
+With `dataCollection`, genAI input/output capture is **on by default**. To disable it, set `dataCollection: { genAI: { inputs: false, outputs: false } }`:
 
 ```typescript
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  sendDefaultPii: true, // ← enables input/output recording by default
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
 });
 ```
 
-> ⚠️ **PII warning:** Prompts often contain user-supplied text. If users include personal data in prompts, enabling `recordInputs` will send that data to Sentry. Review your privacy policy before enabling.
+> ⚠️ **PII warning:** Prompts often contain user-supplied text. If users include personal data in prompts, capturing `recordInputs` will send that data to Sentry. Capture is on by default — review your privacy policy and opt out via `dataCollection.genAI` if needed.
 
 ---
 
@@ -271,7 +279,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   enableLogs: true,
   integrations: [
     Sentry.openAIIntegration(),
@@ -346,7 +356,7 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and genAI input/output capture enabled (on by default via `dataCollection`) — Conversations reconstructs the chat from input/output attributes, so if you've disabled genAI capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/nestjs";
@@ -373,7 +383,7 @@ Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
 |-------|----------|
 | No AI spans appearing | Verify `tracesSampleRate` > 0; AI monitoring requires tracing |
 | Token counts missing in streams | Add `stream_options: { include_usage: true }` to all OpenAI streaming calls |
-| `recordInputs`/`recordOutputs` not capturing | Set `sendDefaultPii: true`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
+| `recordInputs`/`recordOutputs` not capturing | genAI capture is on by default; ensure you haven't set `dataCollection: { genAI: { inputs: false } }`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
 | Anthropic spans missing | Check SDK version; add `anthropicAIIntegration()` explicitly |
 | Cost estimates not showing | Model name must match models.dev/OpenRouter pricing data; custom models may show no estimate |
 | Vercel AI spans not tracked | Pass `experimental_telemetry: { isEnabled: true }` to every AI SDK call |

--- a/skills/sentry-nestjs-sdk/references/error-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/error-monitoring.md
@@ -619,7 +619,7 @@ Key `Sentry.init()` options for error monitoring (in `instrument.ts`):
 | `environment` | `string` | `"production"` | Deployment environment tag |
 | `release` | `string` | env `SENTRY_RELEASE` | App version string |
 | `sampleRate` | `number` | `1.0` | Fraction of error events to send (0.0–1.0) |
-| `sendDefaultPii` | `boolean` | `false` | Include IPs, cookies, sessions |
+| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
 | `attachStacktrace` | `boolean` | `false` | Add stack traces to `captureMessage()` |
 | `maxBreadcrumbs` | `number` | `100` | Max breadcrumbs per event |
 | `ignoreErrors` | `Array<string \| RegExp>` | `[]` | Error message patterns to never report |
@@ -705,4 +705,4 @@ Sentry.init({ ignoreErrors: ["string", /regex/] })
 | User context missing from events | Set `Sentry.setUser()` in middleware **before** the request reaches the controller; isolation scope is per-request |
 | `instrument.ts` import order error | `import "./instrument"` must be the **very first line** of `main.ts` — before any other imports |
 | Events not appearing | Verify DSN, enable `debug: true` in `Sentry.init()` to see SDK logs, confirm `SentryModule.forRoot()` is imported |
-| PII appearing in events | Set `sendDefaultPii: false` (default) and scrub in `beforeSend` |
+| PII appearing in events | Data is collected by default; opt out via `dataCollection` (e.g. `userInfo: false`, `httpBodies: []`, `cookies: false`) and scrub remaining values in `beforeSend` |

--- a/skills/sentry-nestjs-sdk/references/error-monitoring.md
+++ b/skills/sentry-nestjs-sdk/references/error-monitoring.md
@@ -619,7 +619,7 @@ Key `Sentry.init()` options for error monitoring (in `instrument.ts`):
 | `environment` | `string` | `"production"` | Deployment environment tag |
 | `release` | `string` | env `SENTRY_RELEASE` | App version string |
 | `sampleRate` | `number` | `1.0` | Fraction of error events to send (0.0–1.0) |
-| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
+| `dataCollection` | `object` | conservative unless set | Fine-grained control over auto-collected categories (`userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`). When omitted, the SDK falls back to `sendDefaultPii` (default `false`). Passing the object — even `{}` — flips unset categories to their permissive defaults; opt out per category. |
 | `attachStacktrace` | `boolean` | `false` | Add stack traces to `captureMessage()` |
 | `maxBreadcrumbs` | `number` | `100` | Max breadcrumbs per event |
 | `ignoreErrors` | `Array<string \| RegExp>` | `[]` | Error message patterns to never report |

--- a/skills/sentry-nextjs-sdk/SKILL.md
+++ b/skills/sentry-nextjs-sdk/SKILL.md
@@ -141,7 +141,10 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? "___PUBLIC_DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   // 100% in dev, 10% in production
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
@@ -171,7 +174,10 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
 
   // Attach local variable values to stack frames
@@ -189,7 +195,10 @@ import * as Sentry from "@sentry/nextjs";
 Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
 
   enableLogs: true,
@@ -392,7 +401,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 | `tracesSampleRate` | `number` | — | 0–1; 1.0 in dev, 0.1 in prod recommended |
 | `replaysSessionSampleRate` | `number` | `0.1` | Fraction of all sessions recorded |
 | `replaysOnErrorSampleRate` | `number` | `1.0` | Fraction of error sessions recorded |
-| `sendDefaultPii` | `boolean` | `false` | Include IP, request headers in events |
+| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
 | `includeLocalVariables` | `boolean` | `false` | Attach local variable values to stack frames (server only) |
 | `enableLogs` | `boolean` | `false` | Enable Sentry Logs product |
 | `environment` | `string` | auto | `"production"`, `"staging"`, etc. |

--- a/skills/sentry-nextjs-sdk/SKILL.md
+++ b/skills/sentry-nextjs-sdk/SKILL.md
@@ -376,7 +376,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 | `tracesSampleRate` | `number` | — | 0–1; 1.0 in dev, 0.1 in prod recommended |
 | `replaysSessionSampleRate` | `number` | `0.1` | Fraction of all sessions recorded |
 | `replaysOnErrorSampleRate` | `number` | `1.0` | Fraction of error sessions recorded |
-| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
+| `dataCollection` | `object` | conservative unless set | Fine-grained control over auto-collected categories (`userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`). When omitted, the SDK falls back to `sendDefaultPii` (default `false`). Passing the object — even `{}` — flips unset categories to their permissive defaults; opt out per category. |
 | `includeLocalVariables` | `boolean` | `false` | Attach local variable values to stack frames (server only) |
 | `enableLogs` | `boolean` | `false` | Enable Sentry Logs product |
 | `environment` | `string` | auto | `"production"`, `"staging"`, etc. |

--- a/skills/sentry-nextjs-sdk/SKILL.md
+++ b/skills/sentry-nextjs-sdk/SKILL.md
@@ -142,6 +142,8 @@ Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN ?? "___PUBLIC_DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -175,6 +177,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -196,6 +200,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -53,17 +53,19 @@ Sentry.init({
   // Tracing MUST be enabled for AI monitoring
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
 
   integrations: [
-    Sentry.openAIIntegration(), // recordInputs/recordOutputs default to true with sendDefaultPii
+    Sentry.openAIIntegration(), // recordInputs/recordOutputs default to true (governed by dataCollection.genAI)
   ],
 });
 ```
 
 ### Client-Side / Manual Wrapping
 
-Prompt/output capture assumes the matching client-side `Sentry.init()` also sets `sendDefaultPii: true`.
+With `dataCollection`, genAI input/output capture is **on by default**. To disable it, set `dataCollection: { genAI: { inputs: false, outputs: false } }` in the matching client-side `Sentry.init()`.
 
 ```typescript
 import OpenAI from "openai";
@@ -74,7 +76,7 @@ const openai = new OpenAI({
 });
 
 // Wrap once at module level — reuse this client everywhere.
-// Input/output recording follows sendDefaultPii unless explicitly overridden.
+// Input/output recording is on by default (governed by dataCollection.genAI) unless explicitly overridden.
 const client = Sentry.instrumentOpenAiClient(openai);
 
 const response = await client.chat.completions.create({
@@ -100,8 +102,8 @@ const stream = await client.chat.completions.create({
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `recordInputs` | `boolean` | `true` if `sendDefaultPii: true` | Capture prompts/messages sent to OpenAI |
-| `recordOutputs` | `boolean` | `true` if `sendDefaultPii: true` | Capture generated text/responses |
+| `recordInputs` | `boolean` | `true` (governed by `dataCollection.genAI`) | Capture prompts/messages sent to OpenAI |
+| `recordOutputs` | `boolean` | `true` (governed by `dataCollection.genAI`) | Capture generated text/responses |
 
 **Supported versions:** `openai` ≥4.0.0 <7
 
@@ -121,7 +123,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.vercelAIIntegration({
       force: true, // ← Required for Vercel production deployments (see note below)
@@ -138,7 +142,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.vercelAIIntegration(),
   ],
@@ -195,8 +201,8 @@ Sentry.vercelAIIntegration({ force: true })
 | Option | Type | Default | Min SDK | Description |
 |--------|------|---------|---------|-------------|
 | `force` | `boolean` | `false` | 9.29.0 | Force-enable regardless of module detection. Use on Vercel. |
-| `recordInputs` | `boolean` | `true`* | 9.27.0 | Capture inputs. *Defaults to `true` when `sendDefaultPii: true`. |
-| `recordOutputs` | `boolean` | `true`* | 9.27.0 | Capture outputs. *Defaults to `true` when `sendDefaultPii: true`. |
+| `recordInputs` | `boolean` | `true`* | 9.27.0 | Capture inputs. *Defaults to `true` (governed by `dataCollection.genAI`). |
+| `recordOutputs` | `boolean` | `true`* | 9.27.0 | Capture outputs. *Defaults to `true` (governed by `dataCollection.genAI`). |
 
 **Supported versions:** `ai` ≥3.0.0 ≤6
 
@@ -214,7 +220,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.anthropicAIIntegration(),
   ],
@@ -231,7 +239,7 @@ const anthropic = new Anthropic({
   apiKey: process.env.ANTHROPIC_API_KEY, // ⚠️ Never expose in the browser!
 });
 
-// Input/output recording follows sendDefaultPii unless explicitly overridden.
+// Input/output recording is on by default (governed by dataCollection.genAI) unless explicitly overridden.
 const client = Sentry.instrumentAnthropicAiClient(anthropic);
 
 const response = await client.messages.create({
@@ -278,23 +286,25 @@ Sentry automatically captures token usage following OpenTelemetry GenAI semantic
 `recordInputs` captures prompts sent to the AI API.  
 `recordOutputs` captures the generated text/completions returned.
 
-Both default to `true` only when `sendDefaultPii: true` is set:
+With `dataCollection`, genAI input/output capture is **on by default**. To disable it, set `dataCollection: { genAI: { inputs: false, outputs: false } }`:
 
 ```typescript
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  sendDefaultPii: true, // ← enables input/output recording by default
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
 });
 ```
 
-Use explicit integration options only when you need per-integration overrides instead of the recommended SDK-level default:
+Use explicit integration options only when you need per-integration overrides instead of the SDK-level default:
 
 ```typescript
 integrations: [
   Sentry.openAIIntegration({
-    recordInputs: false,  // opt out for this integration despite sendDefaultPii: true
+    recordInputs: false,  // opt out for this integration despite genAI capture being on by default
     recordOutputs: false,
   }),
 ],
@@ -314,7 +324,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.openAIIntegration(),
     Sentry.vercelAIIntegration({ force: true }),
@@ -405,7 +417,7 @@ If your `tracesSampleRate` is below 1.0, you may be losing entire agent runs. Se
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set in your server config — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and genAI input/output capture enabled (on by default via `dataCollection`) in your server config — Conversations reconstructs the chat from input/output attributes, so without input/output capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/nextjs";
@@ -437,7 +449,7 @@ Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
 | No AI spans appearing | Verify `tracesSampleRate` > 0; AI monitoring requires tracing |
 | Token counts missing in streams | Add `stream_options: { include_usage: true }` to all OpenAI streaming calls |
 | Vercel AI spans show raw names (`ai.toolCall`) | Add `vercelAIIntegration({ force: true })` in server config |
-| `recordInputs`/`recordOutputs` not capturing | Set `sendDefaultPii: true`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
+| `recordInputs`/`recordOutputs` not capturing | genAI capture is on by default; ensure you haven't set `dataCollection: { genAI: { inputs: false } }`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
 | Anthropic spans missing | Check SDK version supports Anthropic integration; add `anthropicAIIntegration()` explicitly |
 | Cost estimates not showing | Model name must match models.dev/OpenRouter pricing data; custom/fine-tuned models may show no estimate |
 | Edge runtime AI spans missing | Add `vercelAIIntegration()` to `sentry.edge.config.ts` explicitly (not auto-enabled for Edge) |

--- a/skills/sentry-nextjs-sdk/references/ai-monitoring.md
+++ b/skills/sentry-nextjs-sdk/references/ai-monitoring.md
@@ -53,7 +53,10 @@ Sentry.init({
   // Tracing MUST be enabled for AI monitoring
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
 
   integrations: [
@@ -122,7 +125,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.vercelAIIntegration({
@@ -140,7 +146,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.vercelAIIntegration(),
@@ -217,7 +226,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.anthropicAIIntegration(),
@@ -288,7 +300,7 @@ With `dataCollection`, genAI input/output capture is **on by default**. To disab
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    genAI: { inputs: false, outputs: false },
   },
   tracesSampleRate: 1.0,
 });
@@ -319,7 +331,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/nextjs/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.openAIIntegration(),

--- a/skills/sentry-nextjs-sdk/references/logging.md
+++ b/skills/sentry-nextjs-sdk/references/logging.md
@@ -250,7 +250,7 @@ These are added by the SDK to every log without any developer configuration:
 | `sentry.sdk.name` | e.g., `"sentry.javascript.nextjs"` |
 | `sentry.sdk.version` | Always present |
 | `browser.name`, `browser.version` | Client-side only |
-| `user.id`, `user.name`, `user.email` | When `Sentry.setUser()` + `sendDefaultPii: true` |
+| `user.id`, `user.name`, `user.email` | When `Sentry.setUser()` is called (`userInfo` defaults to `true`) |
 | `sentry.trace.parent_span_id` | When inside an active span (enables log ↔ trace correlation) |
 | `sentry.replay_id` | Client-side with Replay enabled |
 | `server.address` | Server-side only |

--- a/skills/sentry-node-sdk/SKILL.md
+++ b/skills/sentry-node-sdk/SKILL.md
@@ -177,7 +177,10 @@ const Sentry = require("@sentry/node");
 Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
 
   // 100% in dev, lower in production
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
@@ -198,7 +201,10 @@ import * as Sentry from "@sentry/node";
 Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   includeLocalVariables: true,
   enableLogs: true,
@@ -390,7 +396,10 @@ import * as Sentry from "@sentry/bun";
 Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
   enableLogs: true,
 });
@@ -487,7 +496,10 @@ import * as Sentry from "@sentry/deno";
 Sentry.init({
   dsn: Deno.env.get("SENTRY_DSN") ?? "___DSN___",
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   tracesSampleRate: Deno.env.get("DENO_ENV") === "development" ? 1.0 : 0.1,
   enableLogs: true,
 });
@@ -591,7 +603,10 @@ provider.register();
 Sentry.init({
   dsn: process.env.SENTRY_DSN ?? '___DSN___',
 
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   enableLogs: true,
 
   // Do NOT set tracesSampleRate — OTel controls sampling
@@ -705,7 +720,7 @@ Metrics collected: same as Node.js except no event loop delay percentiles (unava
 |--------|------|---------|-------|
 | `dsn` | `string` | — | Required. Also from `SENTRY_DSN` env var |
 | `tracesSampleRate` | `number` | — | 0–1; required to enable tracing; **do not set when using OTLP path** |
-| `sendDefaultPii` | `boolean` | `false` | Include IP, request headers, user info |
+| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
 | `includeLocalVariables` | `boolean` | `false` | Add local variable values to stack frames (Node.js) |
 | `enableLogs` | `boolean` | `false` | Enable Sentry Logs product (v9.41.0+) |
 | `environment` | `string` | `"production"` | Also from `SENTRY_ENVIRONMENT` env var |

--- a/skills/sentry-node-sdk/SKILL.md
+++ b/skills/sentry-node-sdk/SKILL.md
@@ -720,7 +720,7 @@ Metrics collected: same as Node.js except no event loop delay percentiles (unava
 |--------|------|---------|-------|
 | `dsn` | `string` | — | Required. Also from `SENTRY_DSN` env var |
 | `tracesSampleRate` | `number` | — | 0–1; required to enable tracing; **do not set when using OTLP path** |
-| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
+| `dataCollection` | `object` | conservative unless set | Fine-grained control over auto-collected categories (`userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`). When omitted, the SDK falls back to `sendDefaultPii` (default `false`). Passing the object — even `{}` — flips unset categories to their permissive defaults; opt out per category. |
 | `includeLocalVariables` | `boolean` | `false` | Add local variable values to stack frames (Node.js) |
 | `enableLogs` | `boolean` | `false` | Enable Sentry Logs product (v9.41.0+) |
 | `environment` | `string` | `"production"` | Also from `SENTRY_ENVIRONMENT` env var |

--- a/skills/sentry-node-sdk/SKILL.md
+++ b/skills/sentry-node-sdk/SKILL.md
@@ -178,6 +178,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -202,6 +204,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -397,6 +401,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN ?? "___DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -497,6 +503,8 @@ Sentry.init({
   dsn: Deno.env.get("SENTRY_DSN") ?? "___DSN___",
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -604,6 +612,8 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN ?? '___DSN___',
 
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -11,7 +11,10 @@ Sentry.init({
   dsn: "...",
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
 });
 ```
@@ -50,7 +53,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
 });
 // OpenAI, Anthropic, LangChain, LangGraph, Google GenAI activate automatically
@@ -63,7 +69,10 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.openAIIntegration(),

--- a/skills/sentry-node-sdk/references/ai-monitoring.md
+++ b/skills/sentry-node-sdk/references/ai-monitoring.md
@@ -11,7 +11,9 @@ Sentry.init({
   dsn: "...",
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
 });
 ```
 
@@ -30,13 +32,13 @@ Sentry.init({
 
 ## PII Control
 
-| `sendDefaultPii` | `recordInputs` | Prompts captured? |
+| `dataCollection.genAI` | `recordInputs` | Prompts captured? |
 |-------------------|-----------------|-------------------|
-| `false` (default) | `true` | No |
-| `true` | `true` (default) | Yes |
-| `true` | `false` | No |
+| default on | `true` (default) | Yes |
+| `{ inputs: false }` | `true` | No |
+| default on | `false` | No |
 
-Set `sendDefaultPii: true` in `Sentry.init()` to let supported integrations default `recordInputs`/`recordOutputs` to `true`. Use integration-level options to opt out or override specific integrations.
+With `dataCollection`, genAI input/output capture is **on by default**. Supported integrations default `recordInputs`/`recordOutputs` to `true` (governed by `dataCollection.genAI`). To disable it, set `dataCollection: { genAI: { inputs: false, outputs: false } }`. Use integration-level options to opt out or override specific integrations.
 
 ## Configuration Examples
 
@@ -49,7 +51,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true, // required to capture prompts/outputs
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
 });
 // OpenAI, Anthropic, LangChain, LangGraph, Google GenAI activate automatically
 ```
@@ -61,7 +65,9 @@ Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.openAIIntegration(),
     Sentry.vercelAIIntegration(),
@@ -158,7 +164,7 @@ await Sentry.startSpan({
 |-----------|------|
 | `gen_ai.request.reasoning_effort` | string |
 
-### Content attributes (PII-gated — only when `sendDefaultPii: true` + `recordInputs/recordOutputs: true`)
+### Content attributes (captured by default; gated by `dataCollection.genAI` + `recordInputs/recordOutputs`)
 
 | Attribute | Type | Description |
 |-----------|------|-------------|
@@ -220,7 +226,7 @@ If `tracesSampleRate` < 1.0, see the [AI sampling guide](../../sentry-setup-ai-m
 
 Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
 
-**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and `sendDefaultPii: true` must be set — Conversations reconstructs the chat from input/output attributes, so without PII capture the view will be empty.
+**Prerequisites:** `streamGenAiSpans: true` (SDK >=10.53.0) and genAI input/output capture enabled (on by default via `dataCollection`) — Conversations reconstructs the chat from input/output attributes, so without input/output capture the view will be empty.
 
 ```typescript
 import * as Sentry from "@sentry/node";
@@ -263,8 +269,8 @@ Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
 | Token counts missing in streams | Add `stream_options: { include_usage: true }` (OpenAI) |
 | Vercel AI spans not tracked | Add `experimental_telemetry: { isEnabled: true }` per call |
 | Browser OpenAI not traced | Use `Sentry.instrumentOpenAiClient()` - auto-instrumentation is server-only |
-| Prompts not captured | Set `sendDefaultPii: true`, or explicitly pass `recordInputs: true` / `recordOutputs: true` to the integration |
+| Prompts not captured | genAI capture is on by default; ensure you haven't set `dataCollection: { genAI: { inputs: false } }`, or pass `recordInputs: true` explicitly |
 | AI Agents Dashboard empty | Ensure traces are being sent; check DSN and `tracesSampleRate` |
 | Wrong cost calculations | Cached/reasoning tokens are subsets of totals, not additions |
-| Conversations view empty | Ensure `streamGenAiSpans: true`, `sendDefaultPii: true`, and a conversation ID is set via `Sentry.setConversationId()` |
+| Conversations view empty | Ensure `streamGenAiSpans: true`, genAI capture is on (default; not disabled via `dataCollection: { genAI: { inputs: false } }`), and a conversation ID is set via `Sentry.setConversationId()` |
 | User column shows "Unknown" | Call `Sentry.setUser()` once per request or session |

--- a/skills/sentry-node-sdk/references/error-monitoring.md
+++ b/skills/sentry-node-sdk/references/error-monitoring.md
@@ -943,7 +943,7 @@ Sentry.init({
   normalizeDepth?: number;         // default: 3
 
   // Privacy
-  dataCollection?: DataCollectionOptions; // collects by default; opt out per category
+  dataCollection?: DataCollectionOptions; // omitted => falls back to sendDefaultPii (conservative); pass an object (even {}) to enable permissive collection, then opt out per category
 
   // Filtering
   ignoreErrors?: Array<string | RegExp>;

--- a/skills/sentry-node-sdk/references/error-monitoring.md
+++ b/skills/sentry-node-sdk/references/error-monitoring.md
@@ -20,7 +20,10 @@ Sentry.init({
   release: "my-app@1.2.3",
   environment: process.env.NODE_ENV ?? "production",
   tracesSampleRate: 1.0,
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
 });
 ```
 
@@ -822,13 +825,16 @@ Auto-enabled. Attaches HTTP request data to all events during a request. Each fr
 | `method` | ✅ Always | GET, POST, etc. |
 | `headers` | ✅ Always | Auth header scrubbed automatically |
 | `query_string` | ✅ Always | URL query params |
-| `data` (body) | ⚠️ Opt-in | Requires `sendDefaultPii: true` |
-| `cookies` | ⚠️ Opt-in | Requires `sendDefaultPii: true` |
-| `ip_address` | ⚠️ Opt-in | Requires `sendDefaultPii: true` |
+| `data` (body) | ✅ Default on | Controlled by `dataCollection` (`httpBodies`); set to `[]` to opt out |
+| `cookies` | ✅ Default on | Controlled by `dataCollection` (`cookies`); set to `false` to opt out |
+| `ip_address` | ✅ Default on | Controlled by `dataCollection` (`userInfo`); set to `false` to opt out |
 
 ```javascript
 Sentry.init({
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   integrations: [
     Sentry.requestDataIntegration({
       include: {
@@ -937,7 +943,7 @@ Sentry.init({
   normalizeDepth?: number;         // default: 3
 
   // Privacy
-  sendDefaultPii?: boolean;        // default: false — enables body/cookies/IP
+  dataCollection?: DataCollectionOptions; // collects by default; opt out per category
 
   // Filtering
   ignoreErrors?: Array<string | RegExp>;
@@ -970,7 +976,10 @@ import * as Sentry from "@sentry/bun";
 Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
   tracesSampleRate: 1.0,
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
 });
 ```
 

--- a/skills/sentry-node-sdk/references/error-monitoring.md
+++ b/skills/sentry-node-sdk/references/error-monitoring.md
@@ -21,6 +21,8 @@ Sentry.init({
   environment: process.env.NODE_ENV ?? "production",
   tracesSampleRate: 1.0,
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -832,6 +834,8 @@ Auto-enabled. Attaches HTTP request data to all events during a request. Each fr
 ```javascript
 Sentry.init({
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },
@@ -977,6 +981,8 @@ Sentry.init({
   dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
   tracesSampleRate: 1.0,
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },

--- a/skills/sentry-react-sdk/SKILL.md
+++ b/skills/sentry-react-sdk/SKILL.md
@@ -361,8 +361,7 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | `dsn` | `string` | — | **Required.** SDK disabled when empty |
 | `environment` | `string` | `"production"` | e.g., `"staging"`, `"development"` |
 | `release` | `string` | — | e.g., `"my-app@1.0.0"` or git SHA — links errors to releases |
-| `dataCollection` | `object` | — | Fine-grained control over data collection (see table below); **recommended over `sendDefaultPii`** |
-| `sendDefaultPii` | `boolean` | `false` | ⚠️ **Legacy** — use `dataCollection` instead; includes IP addresses and request headers |
+| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
 | `tracesSampleRate` | `number` | — | 0–1; `1.0` in dev, `0.1–0.2` in prod |
 | `tracesSampler` | `function` | — | Per-transaction sampling; overrides rate |
 | `tracePropagationTargets` | `(string\|RegExp)[]` | — | Outgoing URLs that receive distributed tracing headers |
@@ -376,11 +375,11 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 
 ### `dataCollection` Options (SDK ≥10.57.0)
 
-Fine-grained control over what data the SDK collects. Replaces the simple `sendDefaultPii` boolean with per-feature toggles:
+Fine-grained control over what data the SDK collects. Collection is on by default (with sensitive-value scrubbing); opt out per category:
 
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
-| `userInfo` | `boolean` | `true` | Collect user IP and headers (equivalent to `sendDefaultPii: true`) |
+| `userInfo` | `boolean` | `true` | Collect user id, email, and IP |
 | `cookies` | `boolean \| { allow: string[] } \| { deny: string[] }` | `true` | Cookie collection and filtering; `true` = all cookies (sensitive keys filtered) |
 | `httpHeaders.request` | `boolean \| { allow: string[] } \| { deny: string[] }` | `true` | HTTP request header collection |
 | `httpHeaders.response` | `boolean \| { allow: string[] } \| { deny: string[] }` | `true` | HTTP response header collection |

--- a/skills/sentry-react-sdk/SKILL.md
+++ b/skills/sentry-react-sdk/SKILL.md
@@ -356,7 +356,7 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | `dsn` | `string` | — | **Required.** SDK disabled when empty |
 | `environment` | `string` | `"production"` | e.g., `"staging"`, `"development"` |
 | `release` | `string` | — | e.g., `"my-app@1.0.0"` or git SHA — links errors to releases |
-| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
+| `dataCollection` | `object` | conservative unless set | Fine-grained control over auto-collected categories (`userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`). When omitted, the SDK falls back to `sendDefaultPii` (default `false`). Passing the object — even `{}` — flips unset categories to their permissive defaults; opt out per category. |
 | `tracesSampleRate` | `number` | — | 0–1; `1.0` in dev, `0.1–0.2` in prod |
 | `tracesSampler` | `function` | — | Per-transaction sampling; overrides rate |
 | `tracePropagationTargets` | `(string\|RegExp)[]` | — | Outgoing URLs that receive distributed tracing headers |

--- a/skills/sentry-react-sdk/references/error-monitoring.md
+++ b/skills/sentry-react-sdk/references/error-monitoring.md
@@ -644,14 +644,14 @@ Sentry.setUser({
 // On logout — clears user from all subsequent events:
 Sentry.setUser(null);
 
-// Auto-infer IP address (requires sendDefaultPii: true):
+// Auto-infer IP address (userInfo defaults to true):
 Sentry.setUser({
   id: "usr_abc123",
   ip_address: "{{ auto }}",
 });
 ```
 
-> **Privacy:** `sendDefaultPii: true` in `Sentry.init` enables automatic IP inference. To prevent IP storage entirely, enable "Prevent Storing of IP Addresses" in your project's Security & Privacy settings in Sentry.
+> **Privacy:** `userInfo` (in `dataCollection`) defaults to `true`, which enables automatic IP inference. Set `dataCollection: { userInfo: false }` to opt out, or enable "Prevent Storing of IP Addresses" in your project's Security & Privacy settings in Sentry to prevent IP storage entirely.
 
 ---
 

--- a/skills/sentry-react-sdk/references/logging.md
+++ b/skills/sentry-react-sdk/references/logging.md
@@ -245,7 +245,7 @@ These are added by the SDK to every log without any developer configuration:
 | `sentry.sdk.version` | SDK internals | — |
 | `browser.name` | User-Agent parsing | e.g., `"Chrome"` |
 | `browser.version` | User-Agent parsing | e.g., `"121.0.0"` |
-| `user.id`, `user.name`, `user.email` | `Sentry.setUser()` | Requires `sendDefaultPii: true` |
+| `user.id`, `user.name`, `user.email` | `Sentry.setUser()` | Added when `Sentry.setUser()` is called (`userInfo` defaults to `true`) |
 | `sentry.trace.parent_span_id` | Active tracing span | Enables log ↔ trace correlation |
 | `sentry.replay_id` | Active Session Replay session | Enables log ↔ replay correlation |
 | `message.template` | `logger.fmt` usage | The template string |
@@ -347,4 +347,4 @@ Use `Sentry.logger.*` for **structured, searchable observability data**. Use `ca
 | Log attributes contain `undefined` | Only `string`, `number`, `boolean` are accepted — filter undefined values before passing |
 | `beforeSendLog` not firing | Confirm `enableLogs: true` is set; without it, no logs are sent and no hook is called |
 | Sensitive data appearing in logs | Add filtering in `beforeSendLog`; better yet, avoid logging sensitive data at the call site |
-| Logs appear but have no user context | Call `Sentry.setUser({ id, email })` after authentication and set `sendDefaultPii: true` |
+| Logs appear but have no user context | Call `Sentry.setUser({ id, email })` after authentication (`userInfo` defaults to `true`) |

--- a/skills/sentry-react-sdk/references/react-features.md
+++ b/skills/sentry-react-sdk/references/react-features.md
@@ -879,8 +879,10 @@ Sentry.init({
       ],
     }),
   ],
-  // Required to capture request/response bodies (PII risk — use cautiously)
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
 });
 ```
 

--- a/skills/sentry-react-sdk/references/react-features.md
+++ b/skills/sentry-react-sdk/references/react-features.md
@@ -880,6 +880,8 @@ Sentry.init({
     }),
   ],
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/react/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -29,7 +29,7 @@ If the app has multi-turn chats, set a conversation ID by default anywhere it ma
 
 ## Data Capture Warning
 
-**Prompt and output recording captures user content that is likely PII.** Before enabling send-default-PII (`sendDefaultPii: true` in JavaScript or `send_default_pii=True` in Python) or per-integration prompt/output capture (`recordInputs`/`recordOutputs` in JS, `include_prompts` in Python), confirm:
+**Prompt and output recording captures user content that is likely PII.** In JavaScript, genAI input/output capture is **on by default** (governed by `dataCollection.genAI`); in Python it is enabled via `send_default_pii=True`. Before relying on this capture (or per-integration overrides — `recordInputs`/`recordOutputs` in JS, `include_prompts` in Python), confirm:
 
 - The application's privacy policy permits capturing user prompts and model responses
 - Captured data complies with applicable regulations (GDPR, CCPA, etc.)
@@ -121,10 +121,12 @@ Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.openAIIntegration({
-      // recordInputs/recordOutputs default to true when sendDefaultPii is true
+      // recordInputs/recordOutputs default to true (governed by dataCollection.genAI)
     }),
   ],
 });
@@ -149,7 +151,9 @@ Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [
     Sentry.langChainIntegration(),
     Sentry.langGraphIntegration(),
@@ -165,7 +169,9 @@ Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
   streamGenAiSpans: true,
-  sendDefaultPii: true,
+  dataCollection: {
+    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+  },
   integrations: [Sentry.vercelAIIntegration()],
 });
 ```
@@ -330,7 +336,7 @@ Find it at **Explore > Conversations** in Sentry.
 
 - Tracing enabled with `tracesSampleRate > 0`
 - `streamGenAiSpans: true` (JS SDK >=10.53.0) / `stream_gen_ai_spans=True` (Python SDK >=2.60.0) — required so AI spans are sent as standalone items. Without this, spans with large inputs/outputs can hit transaction payload size limits and be dropped.
-- **Input and output capture enabled** — Conversations reconstructs the chat from `gen_ai.input.messages` and `gen_ai.output.messages` attributes. Set `sendDefaultPii: true` (JS) / `send_default_pii=True` (Python). Without it, conversations appear empty.
+- **Input and output capture enabled** — Conversations reconstructs the chat from `gen_ai.input.messages` and `gen_ai.output.messages` attributes. In JS this is on by default (via `dataCollection`); in Python, set `send_default_pii=True`. Without it, conversations appear empty.
 
 ### Setting a Conversation ID
 
@@ -413,7 +419,7 @@ These are independent concepts:
 | AI spans not appearing | Verify `tracesSampleRate > 0`, check SDK version |
 | Token counts missing | Some providers don't return tokens for streaming |
 | Negative or wrong costs in dashboard | Cached/reasoning tokens are subsets of totals — see Token Usage and Cost Calculation |
-| Prompts not captured | Set `sendDefaultPii: true` (JS) or `send_default_pii=True` (Python); use `recordInputs`/`include_prompts` only for explicit overrides |
+| Prompts not captured | In JS, genAI capture is on by default — ensure you haven't set `dataCollection: { genAI: { inputs: false } }`, or pass `recordInputs: true` explicitly. In Python, set `send_default_pii=True`; use `include_prompts` only for explicit overrides |
 | Vercel AI not working | Add `experimental_telemetry` to each call |
-| Conversations view empty | Ensure `streamGenAiSpans: true` / `stream_gen_ai_spans=True`, `sendDefaultPii: true` / `send_default_pii=True`, and a conversation ID is set |
+| Conversations view empty | Ensure `streamGenAiSpans: true` / `stream_gen_ai_spans=True`, genAI input/output capture enabled (on by default in JS via `dataCollection`; `send_default_pii=True` in Python), and a conversation ID is set |
 | User column shows "Unknown" | Call `Sentry.setUser()` (JS) or `sentry_sdk.set_user()` (Python) once per request or session |

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -120,7 +120,10 @@ Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.openAIIntegration({
@@ -149,7 +152,10 @@ Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [
     Sentry.langChainIntegration(),
@@ -166,7 +172,10 @@ Sentry.init({
   dsn: "YOUR_DSN",
   tracesSampleRate: 1.0,
   dataCollection: {
-    // genAI: { inputs: false, outputs: false }, // input/output capture is on by default
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
   },
   integrations: [Sentry.vercelAIIntegration()],
 });

--- a/skills/sentry-tanstack-start-sdk/SKILL.md
+++ b/skills/sentry-tanstack-start-sdk/SKILL.md
@@ -118,7 +118,10 @@ export const getRouter = () => {
   if (!router.isServer) {
     Sentry.init({
       dsn: "___PUBLIC_DSN___",
-      sendDefaultPii: true,
+      dataCollection: {
+        // userInfo: false,
+        // httpBodies: [],
+      },
 
       integrations: [
         Sentry.tanstackRouterBrowserTracingIntegration(router),
@@ -148,7 +151,10 @@ import * as Sentry from "@sentry/tanstackstart-react";
 
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
-  sendDefaultPii: true,
+  dataCollection: {
+    // userInfo: false,
+    // httpBodies: [],
+  },
   enableLogs: true,
   tracesSampleRate: 1.0,
 });
@@ -266,7 +272,7 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `dsn` | `string` | — | Required; SDK is disabled when empty |
-| `sendDefaultPii` | `boolean` | `false` | Sends request headers and IP-derived user context |
+| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
 | `integrations` | `Integration[]` | SDK defaults | Include TanStack Router tracing, replay, feedback as needed |
 | `enableLogs` | `boolean` | `false` | Enables `Sentry.logger.*` APIs |
 | `tracesSampleRate` | `number` | — | `1.0` in development, lower in production |

--- a/skills/sentry-tanstack-start-sdk/SKILL.md
+++ b/skills/sentry-tanstack-start-sdk/SKILL.md
@@ -272,7 +272,7 @@ For each feature: `Read ${SKILL_ROOT}/references/<feature>.md`, follow steps exa
 | Option | Type | Default | Notes |
 |--------|------|---------|-------|
 | `dsn` | `string` | — | Required; SDK is disabled when empty |
-| `dataCollection` | `object` | collects by default | Controls auto-collected data categories: `userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`. Opt out per category. |
+| `dataCollection` | `object` | conservative unless set | Fine-grained control over auto-collected categories (`userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`). When omitted, the SDK falls back to `sendDefaultPii` (default `false`). Passing the object — even `{}` — flips unset categories to their permissive defaults; opt out per category. |
 | `integrations` | `Integration[]` | SDK defaults | Include TanStack Router tracing, replay, feedback as needed |
 | `enableLogs` | `boolean` | `false` | Enables `Sentry.logger.*` APIs |
 | `tracesSampleRate` | `number` | — | `1.0` in development, lower in production |

--- a/skills/sentry-tanstack-start-sdk/SKILL.md
+++ b/skills/sentry-tanstack-start-sdk/SKILL.md
@@ -152,6 +152,8 @@ import * as Sentry from "@sentry/tanstackstart-react";
 Sentry.init({
   dsn: "___PUBLIC_DSN___",
   dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/configuration/options/#dataCollection
     // userInfo: false,
     // httpBodies: [],
   },


### PR DESCRIPTION
This should prevent creating setups with the legacy `sendDefaultpii` option