### PR TITLE
feat(skills): Add Sentry Snapshots setup skill for Apple/Cocoa

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,7 @@ Skills use YAML frontmatter with `allowed-tools` — this is required by Cursor 
 | `sentry-span-streaming-python` | Migrate Python SDK from transaction-based to streamed span delivery |
 | `sentry-span-streaming-dart` | Migrate Dart/Flutter SDK from transaction-based to streamed span delivery |
 | `sentry-instrumentation-guide` | Decide which signal to reach for — error vs span vs log vs metric |
+| `sentry-snapshots-cocoa` | Setup Sentry Snapshots for Apple/Cocoa projects, including SnapshotPreviews and Apple snapshot CI |
 
 ### Workflow Skills
 | Skill | Description |

--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -112,6 +112,7 @@ Configure specific Sentry capabilities beyond basic SDK setup.
 | Decide which Sentry signal to reach for when instrumenting code — error, span, span attribute, log, or metric | [`sentry-instrumentation-guide`](skills/sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
 | Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
 | Setup Sentry AI Agent Monitoring in any project | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+| Full Sentry Snapshots setup for Apple/Cocoa projects | [`sentry-snapshots-cocoa`](skills/sentry-snapshots-cocoa/SKILL.md) | `sentry-snapshots-cocoa/SKILL.md` |
 | Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-dart`](skills/sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
 | Migrate JavaScript SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-js`](skills/sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
 | Migrate Python SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-python`](skills/sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |

--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-feature-setup
-description: Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry pipelines, create alerts and notifications, or enable span streaming.
+description: Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry pipelines, create alerts and notifications, enable span streaming, or set up Sentry Snapshots.
 license: Apache-2.0
 role: router
 ---
@@ -28,6 +28,7 @@ Append the path from the `Path` column in the table below to `https://skills.sen
 3. If the user mentions **alerts, notifications, on-call, Slack/PagerDuty/Discord integration, or workflow rules** → `sentry-create-alert`
 4. If the user mentions **span streaming, traceLifecycle, trace_lifecycle, spanStreamingIntegration, or switching from transactions to streamed spans** → `sentry-span-streaming-js` (JavaScript), `sentry-span-streaming-python` (Python), or `sentry-span-streaming-dart` (Dart/Flutter)
 5. If the user is unsure **which signal to use** — log vs span vs metric, "what to instrument where", or how to choose between errors, traces, logs, and metrics → `sentry-instrumentation-guide`
+6. If the user mentions **Apple/Cocoa snapshot testing or Sentry Snapshots for Apple platforms** — SnapshotPreviews, Apple Snapshots, Cocoa snapshots, Xcode snapshot testing, Swift previews for Sentry Snapshots, iOS, macOS, tvOS, watchOS, or visionOS → `sentry-snapshots-cocoa`.
 
 When unclear, **ask the user** which feature they want to configure. Do not guess.
 
@@ -38,6 +39,7 @@ When unclear, **ask the user** which feature they want to configure. Do not gues
 | Feature | Skill | Path |
 |---|---|---|
 | AI/LLM monitoring and conversations — instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI | [`sentry-setup-ai-monitoring`](../sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+| Sentry Snapshots for Apple/Cocoa — upload Apple snapshot images to Sentry; prefer SnapshotPreviews when Swift previews exist | [`sentry-snapshots-cocoa`](../sentry-snapshots-cocoa/SKILL.md) | `sentry-snapshots-cocoa/SKILL.md` |
 | OpenTelemetry Collector with Sentry Exporter — multi-project routing, automatic project creation | [`sentry-otel-exporter-setup`](../sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
 | Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
 | Span streaming (JavaScript) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-js`](../sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |

--- a/skills/sentry-snapshots-cocoa/SKILL.md
+++ b/skills/sentry-snapshots-cocoa/SKILL.md
@@ -46,21 +46,25 @@ Record: existing SnapshotPreviews setup, existing snapshot generator/library, ou
 
 ## Route
 
-Apply rows top-down. When multiple generators are detected, use the generator the user explicitly named; otherwise prefer SnapshotPreviews as Sentry's first-party snapshot source.
+Resolve routing in this order; setup is the primary path and CI is optional follow-up.
 
-| State | Action |
-|---|---|
-| User asks for GitHub Actions/CI and SnapshotPreviews exists with one simulator destination | Read `references/github-actions-simple.md`. |
-| User asks for GitHub Actions/CI and SnapshotPreviews exists with multiple simulators/device families, matrix, or selective CI | Read `references/github-actions-fanout.md`; read `references/snapshot-previews.md` for selective-rendering mechanics. |
-| User asks for GitHub Actions/CI and Point-Free `swift-snapshot-testing` is the selected generator | Preserve generator; read `references/github-actions-swift-snapshot-testing.md` and `references/snapshots.md` for upload behavior. |
-| User asks for GitHub Actions/CI and a non-SnapshotPreviews generator exists | Preserve generator; read `references/snapshots.md` for upload behavior and adapt the project's existing CI. |
-| User asks for GitHub Actions/CI but no snapshot generator or SnapshotPreviews setup exists | Establish the image source first using the rows below; do not write CI that has nothing to run. |
-| SnapshotPreviews already present | Verify export/upload; read `references/snapshot-previews.md` for SnapshotPreviews-specific debugging or advanced options; read `references/snapshots.md` for upload behavior. |
-| Existing non-SnapshotPreviews generator/library, including Point-Free `swift-snapshot-testing` | Preserve generator; read `references/snapshots.md` for upload behavior. |
-| Package-only SwiftPM with no `.xcodeproj` host app | Stop and ask for the host app/test target; standalone `swift test` rendering is not supported. |
-| No hosted XCTest target exists for the selected app target | Stop and ask the user to add or identify a hosted XCTest target before continuing; SnapshotPreviews requires `xcodebuild test` against a hosted test bundle. |
-| No existing generator/setup and user wants SnapshotPreviews | Read `references/wizard-setup.md`. |
-| Wizard reports no Swift previews | Stop and ask whether to add Swift previews for SnapshotPreviews or identify the intended Sentry Snapshot image source; do not create, restore, or infer previews without explicit user approval. |
+1. Select or create the image generator:
+   - named generator wins;
+   - multiple existing generators with no user choice -> ask;
+   - existing non-SnapshotPreviews generator -> preserve it;
+   - existing SnapshotPreviews -> use it;
+   - no existing generator -> set up SnapshotPreviews by default for Sentry Snapshots or Apple snapshot testing.
+2. For SnapshotPreviews, stop before setup/verification/CI if there is no `.xcodeproj` host app or no hosted XCTest target. These stops do not apply when preserving another generator.
+3. For setup or verification:
+   - existing non-SnapshotPreviews generator -> read `references/snapshots.md`;
+   - existing SnapshotPreviews -> read `references/snapshot-previews.md` and `references/snapshots.md`;
+   - new SnapshotPreviews setup -> read `references/wizard-setup.md`;
+   - wizard reports no Swift previews -> ask before adding previews or choosing another generator.
+4. For GitHub Actions/CI only after an image generator exists:
+   - Point-Free `swift-snapshot-testing` -> read `references/github-actions-swift-snapshot-testing.md` and `references/snapshots.md`;
+   - other non-SnapshotPreviews generator -> read `references/snapshots.md` and adapt existing CI/upload;
+   - SnapshotPreviews, one simulator only, no matrix/fanout/selective CI -> read `references/github-actions-simple.md`;
+   - SnapshotPreviews with multiple simulators, device families, matrix, or any selective CI -> read `references/github-actions-fanout.md` and `references/snapshot-previews.md`.
 
 ## Optional References
 
@@ -75,7 +79,7 @@ Apply rows top-down. When multiple generators are detected, use the generator th
 
 ## Completion Checks
 
-- The selected snapshot image source is documented and preserved or configured according to the route above.
+- The selected snapshot image generator is documented and preserved or configured according to the route above.
 - Snapshot generation appears in the relevant local or CI test logs.
 - Export directory contains `.png` files and any generated `.json` sidecars.
 - Upload succeeds and prints a Sentry URL or snapshot id.

--- a/skills/sentry-snapshots-cocoa/SKILL.md
+++ b/skills/sentry-snapshots-cocoa/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: sentry-snapshots-cocoa
+description: Full Sentry Snapshots setup for Apple/Cocoa projects. Use when asked to "setup SnapshotPreviews", "setup Apple snapshot testing", "upload Apple snapshots to Sentry", "setup Apple snapshot GitHub Actions", or "setup Apple selective snapshot testing".
+license: Apache-2.0
+category: feature-setup
+parent: sentry-feature-setup
+disable-model-invocation: true
+---
+
+> [All Skills](../../SKILL_TREE.md) > [Feature Setup](../sentry-feature-setup/SKILL.md) > Sentry Snapshots
+
+# Sentry Snapshots for Apple/Cocoa
+
+## Scope
+
+- Goal: generate Apple snapshot images and upload them to Sentry Snapshots.
+- Detect existing snapshot generation first, including Point-Free `swift-snapshot-testing`; preserve it when it already emits or can emit PNGs or JPEGs.
+- Use the Sentry Wizard `appleSnapshots` flow only when setting up Sentry's first-party SnapshotPreviews solution.
+- Use manual setup only if the wizard is unavailable, cannot resolve targets non-interactively after disambiguation, or fails after explicit disambiguation.
+- Package-only SwiftPM: stop and ask for the host app/test target; standalone `swift test` rendering is not supported.
+
+## Detect
+
+Do only enough detection to route before calling the wizard:
+
+```bash
+# Manifest/project files to scan for generator signatures
+SNAP_FILES=$(find . \( -name Package.swift -o -name Package.resolved -o -path '*/project.pbxproj' \) 2>/dev/null)
+
+# SnapshotPreviews (Sentry first-party) -> prefer wizard / SnapshotPreviews routing
+echo "$SNAP_FILES" | xargs grep -lE "SnapshotPreviews" 2>/dev/null
+
+# Point-Free swift-snapshot-testing -> preserve generator, swift-snapshot-testing CI path
+echo "$SNAP_FILES" | xargs grep -lE "swift-snapshot-testing|SnapshotTesting|assertSnapshot|__Snapshots__|TEST_RUNNER_SNAPSHOT_TESTING_RECORD" 2>/dev/null
+
+# Required wizard input
+find . -name '*.xcodeproj' -print 2>/dev/null | head -20
+
+# Workflow shape
+ls fastlane/Fastfile Gemfile 2>/dev/null
+
+# Sentry auth presence only -> never print secret values
+for v in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do
+  [ -n "${!v}" ] && echo "$v=set" || echo "$v=unset"
+done
+```
+
+Record: existing SnapshotPreviews setup, existing snapshot generator/library, output directory if known, Xcode project directory, CI provider, Fastlane, and Sentry auth. For each `.xcodeproj` match, record the containing directory for `--xcode-project-dir`; if `find` prints `./MyApp/MyApp.xcodeproj`, pass `./MyApp`, not the bundle path. Let the wizard detect app targets, hosted XCTest targets, and Swift previews only when no existing generator is present.
+
+## Route
+
+Apply rows top-down. When multiple generators are detected, use the generator the user explicitly named; otherwise prefer SnapshotPreviews as Sentry's first-party snapshot source.
+
+| State | Action |
+|---|---|
+| User asks for GitHub Actions/CI and SnapshotPreviews exists with one simulator destination | Read `references/github-actions-simple.md`. |
+| User asks for GitHub Actions/CI and SnapshotPreviews exists with multiple simulators/device families, matrix, or selective CI | Read `references/github-actions-fanout.md`; read `references/snapshot-previews.md` for selective-rendering mechanics. |
+| User asks for GitHub Actions/CI and Point-Free `swift-snapshot-testing` is the selected generator | Preserve generator; read `references/github-actions-swift-snapshot-testing.md` and `references/snapshots.md` for upload behavior. |
+| User asks for GitHub Actions/CI and a non-SnapshotPreviews generator exists | Preserve generator; read `references/snapshots.md` for upload behavior and adapt the project's existing CI. |
+| User asks for GitHub Actions/CI but no snapshot generator or SnapshotPreviews setup exists | Establish the image source first using the rows below; do not write CI that has nothing to run. |
+| SnapshotPreviews already present | Verify export/upload; read `references/snapshot-previews.md` for SnapshotPreviews-specific debugging or advanced options; read `references/snapshots.md` for upload behavior. |
+| Existing non-SnapshotPreviews generator/library, including Point-Free `swift-snapshot-testing` | Preserve generator; read `references/snapshots.md` for upload behavior. |
+| Package-only SwiftPM with no `.xcodeproj` host app | Stop and ask for the host app/test target; standalone `swift test` rendering is not supported. |
+| No hosted XCTest target exists for the selected app target | Stop and ask the user to add or identify a hosted XCTest target before continuing; SnapshotPreviews requires `xcodebuild test` against a hosted test bundle. |
+| No existing generator/setup and user wants SnapshotPreviews | Read `references/wizard-setup.md`. |
+| Wizard reports no Swift previews | Stop and ask whether to add Swift previews for SnapshotPreviews or identify the intended Sentry Snapshot image source; do not create, restore, or infer previews without explicit user approval. |
+
+## Optional References
+
+| Need | Read |
+|---|---|
+| First-party SnapshotPreviews setup, disambiguation, or manual fallback | `references/wizard-setup.md` |
+| SnapshotPreviews metadata, rendering preferences, selective rendering, or SnapshotPreviews-specific troubleshooting | `references/snapshot-previews.md` |
+| Upload any generated snapshot images to Sentry with Fastlane, `sentry-cli`, manifests, CI notes, or upload troubleshooting | `references/snapshots.md` |
+| One-destination GitHub Actions workflow | `references/github-actions-simple.md` |
+| Multi-destination/fan-out GitHub Actions workflow | `references/github-actions-fanout.md` |
+| Point-Free `swift-snapshot-testing` GitHub Actions workflow | `references/github-actions-swift-snapshot-testing.md` |
+
+## Completion Checks
+
+- The selected snapshot image source is documented and preserved or configured according to the route above.
+- Snapshot generation appears in the relevant local or CI test logs.
+- Export directory contains `.png` files and any generated `.json` sidecars.
+- Upload succeeds and prints a Sentry URL or snapshot id.
+- Base branch upload is full; selective PR upload includes the full image-name manifest.

--- a/skills/sentry-snapshots-cocoa/SKILL.md
+++ b/skills/sentry-snapshots-cocoa/SKILL.md
@@ -37,9 +37,9 @@ find . -name '*.xcodeproj' -print 2>/dev/null | head -20
 ls fastlane/Fastfile Gemfile 2>/dev/null
 
 # Sentry auth presence only -> never print secret values
-for v in SENTRY_AUTH_TOKEN SENTRY_ORG SENTRY_PROJECT; do
-  [ -n "${!v}" ] && echo "$v=set" || echo "$v=unset"
-done
+[ -n "$SENTRY_AUTH_TOKEN" ] && echo "SENTRY_AUTH_TOKEN=set" || echo "SENTRY_AUTH_TOKEN=unset"
+[ -n "$SENTRY_ORG" ] && echo "SENTRY_ORG=set" || echo "SENTRY_ORG=unset"
+[ -n "$SENTRY_PROJECT" ] && echo "SENTRY_PROJECT=set" || echo "SENTRY_PROJECT=unset"
 ```
 
 Record: existing SnapshotPreviews setup, existing snapshot generator/library, output directory if known, Xcode project directory, CI provider, Fastlane, and Sentry auth. For each `.xcodeproj` match, record the containing directory for `--xcode-project-dir`; if `find` prints `./MyApp/MyApp.xcodeproj`, pass `./MyApp`, not the bundle path. Let the wizard detect app targets, hosted XCTest targets, and Swift previews only when no existing generator is present.

--- a/skills/sentry-snapshots-cocoa/SKILL.md
+++ b/skills/sentry-snapshots-cocoa/SKILL.md
@@ -24,14 +24,11 @@ disable-model-invocation: true
 Do only enough detection to route before calling the wizard:
 
 ```bash
-# Manifest/project files to scan for generator signatures
-SNAP_FILES=$(find . \( -name Package.swift -o -name Package.resolved -o -path '*/project.pbxproj' \) -print0 2>/dev/null)
-
 # SnapshotPreviews (Sentry first-party) -> prefer wizard / SnapshotPreviews routing
-echo -n "$SNAP_FILES" | xargs -0 grep -lE "SnapshotPreviews" 2>/dev/null
+find . \( -name Package.swift -o -name Package.resolved -o -path '*/project.pbxproj' \) -print0 2>/dev/null | xargs -0 grep -lE "SnapshotPreviews" 2>/dev/null
 
 # Point-Free swift-snapshot-testing -> preserve generator, swift-snapshot-testing CI path
-echo -n "$SNAP_FILES" | xargs -0 grep -lE "swift-snapshot-testing|SnapshotTesting|assertSnapshot|__Snapshots__|TEST_RUNNER_SNAPSHOT_TESTING_RECORD" 2>/dev/null
+find . \( -name Package.swift -o -name Package.resolved -o -path '*/project.pbxproj' \) -print0 2>/dev/null | xargs -0 grep -lE "swift-snapshot-testing|SnapshotTesting|assertSnapshot|__Snapshots__|TEST_RUNNER_SNAPSHOT_TESTING_RECORD" 2>/dev/null
 
 # Required wizard input
 find . -name '*.xcodeproj' -print 2>/dev/null | head -20

--- a/skills/sentry-snapshots-cocoa/SKILL.md
+++ b/skills/sentry-snapshots-cocoa/SKILL.md
@@ -25,13 +25,13 @@ Do only enough detection to route before calling the wizard:
 
 ```bash
 # Manifest/project files to scan for generator signatures
-SNAP_FILES=$(find . \( -name Package.swift -o -name Package.resolved -o -path '*/project.pbxproj' \) 2>/dev/null)
+SNAP_FILES=$(find . \( -name Package.swift -o -name Package.resolved -o -path '*/project.pbxproj' \) -print0 2>/dev/null)
 
 # SnapshotPreviews (Sentry first-party) -> prefer wizard / SnapshotPreviews routing
-echo "$SNAP_FILES" | xargs grep -lE "SnapshotPreviews" 2>/dev/null
+echo -n "$SNAP_FILES" | xargs -0 grep -lE "SnapshotPreviews" 2>/dev/null
 
 # Point-Free swift-snapshot-testing -> preserve generator, swift-snapshot-testing CI path
-echo "$SNAP_FILES" | xargs grep -lE "swift-snapshot-testing|SnapshotTesting|assertSnapshot|__Snapshots__|TEST_RUNNER_SNAPSHOT_TESTING_RECORD" 2>/dev/null
+echo -n "$SNAP_FILES" | xargs -0 grep -lE "swift-snapshot-testing|SnapshotTesting|assertSnapshot|__Snapshots__|TEST_RUNNER_SNAPSHOT_TESTING_RECORD" 2>/dev/null
 
 # Required wizard input
 find . -name '*.xcodeproj' -print 2>/dev/null | head -20

--- a/skills/sentry-snapshots-cocoa/references/github-actions-fanout.md
+++ b/skills/sentry-snapshots-cocoa/references/github-actions-fanout.md
@@ -1,0 +1,193 @@
+# Fan-out GitHub Actions Workflow for SnapshotPreviews
+
+Use this when a SnapshotPreviews project needs multiple simulator destinations or device families, parallel rendering, matrix execution, or selective/large-suite CI. This is the maintained multi-simulator pattern: build once, render each simulator in parallel with `test-without-building`, export each simulator to its own subdirectory, aggregate artifacts, then upload once.
+
+Do not replace this with a sequential loop of multiple `xcodebuild test` invocations in the simple workflow. Sequential multi-simulator rendering is slower and not the recommended path.
+
+Do not use this template for Point-Free `swift-snapshot-testing` or another existing generator. For `swift-snapshot-testing`, use `github-actions-swift-snapshot-testing.md`; for other generators, preserve the generator and adapt its existing CI/upload path.
+
+This pattern follows the public [EmergeTools HackerNews SnapshotPreviews workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_sentry_upload_snapshots.yml).
+
+Adapt target names, paths, Xcode version, simulator list, package setup, and Fastlane/CLI upload to the project.
+
+```yaml
+name: Upload iOS snapshots to Sentry
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  DERIVED_DATA_PATH: ${{ github.workspace }}/DerivedData-snapshot-upload
+  SNAPSHOT_UPLOAD_BASE_DIR: ${{ github.workspace }}/snapshot-images
+  BUILD_PRODUCTS_ARCHIVE: ${{ github.workspace }}/snapshot-build-products.tar.gz
+  XCTESTRUN_FILENAME: MyAppSnapshotTests.xctestrun
+  SNAPSHOT_PROJECT: MyApp.xcodeproj
+  SNAPSHOT_SCHEME: MyApp
+  BUILD_DESTINATION: platform=iOS Simulator,name=iPhone 17 Pro Max,arch=arm64
+
+  # GitHub Actions does not inherit local sentry-cli config.
+  # Define SENTRY_AUTH_TOKEN as a repository secret and SENTRY_ORG/SENTRY_PROJECT as repository variables.
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+  SENTRY_APP_ID: com.example.MyApp
+
+jobs:
+  build_for_testing:
+    runs-on: macos-26
+
+    steps:
+      # On PRs, checkout builds the merge candidate; sentry-cli labels uploads from GitHub event head/base SHAs.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+
+      - name: Prepare DerivedData directory
+        run: mkdir -p "${DERIVED_DATA_PATH}"
+
+      - name: Cache Swift Package Manager
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ${{ env.DERIVED_DATA_PATH }}/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: ${{ runner.os }}-spm-
+
+      - name: Build snapshot tests
+        run: |
+          xcodebuild build-for-testing \
+            -project "${SNAPSHOT_PROJECT}" \
+            -scheme "${SNAPSHOT_SCHEME}" \
+            -sdk iphonesimulator \
+            -destination "${BUILD_DESTINATION}" \
+            -derivedDataPath "${DERIVED_DATA_PATH}" \
+            -resultBundlePath SnapshotBuildForTesting.xcresult \
+            -skipPackagePluginValidation \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Normalize xctestrun path
+        run: |
+          XCTESTRUN_SOURCE="$(find "${DERIVED_DATA_PATH}/Build/Products" -name '*.xctestrun' -print -quit)"
+          if [ -z "${XCTESTRUN_SOURCE}" ]; then
+            echo "No .xctestrun file found under ${DERIVED_DATA_PATH}/Build/Products" >&2
+            exit 1
+          fi
+          cp "${XCTESTRUN_SOURCE}" "${DERIVED_DATA_PATH}/Build/Products/${XCTESTRUN_FILENAME}"
+
+      - name: Archive test products
+        run: tar -C "${DERIVED_DATA_PATH}/Build" -czf "${BUILD_PRODUCTS_ARCHIVE}" Products
+
+      - name: Upload build products artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: snapshot-build-products
+          path: ${{ env.BUILD_PRODUCTS_ARCHIVE }}
+          if-no-files-found: error
+
+  generate_snapshots:
+    runs-on: macos-26
+    needs: build_for_testing
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - simulator_name: iPhone 17 Pro Max
+            slug: iphone-17-pro-max
+          - simulator_name: iPhone 17e
+            slug: iphone-17e
+          - simulator_name: iPad Air 11-inch (M4)
+            slug: ipad-air-11-inch-m4
+
+    env:
+      # Export each simulator to a separate subdirectory. SnapshotPreviews filenames are preview-based,
+      # so the same preview rendered on multiple devices would otherwise collide during aggregation.
+      TEST_RUNNER_SNAPSHOTS_EXPORT_DIR: ${{ github.workspace }}/snapshot-images/${{ matrix.slug }}
+
+    steps:
+      # On PRs, checkout builds the merge candidate; sentry-cli labels uploads from GitHub event head/base SHAs.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+
+      - name: Download build products artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: snapshot-build-products
+          path: ${{ github.workspace }}
+
+      - name: Extract test products
+        run: |
+          mkdir -p "${DERIVED_DATA_PATH}/Build"
+          tar -C "${DERIVED_DATA_PATH}/Build" -xzf "${BUILD_PRODUCTS_ARCHIVE}"
+
+      - name: Boot simulator
+        run: xcrun simctl boot "${{ matrix.simulator_name }}" || true
+
+      - name: Prepare snapshot export directory
+        run: mkdir -p "${TEST_RUNNER_SNAPSHOTS_EXPORT_DIR}"
+
+      - name: Generate snapshot images
+        run: |
+          xcodebuild test-without-building \
+            -xctestrun "${DERIVED_DATA_PATH}/Build/Products/${XCTESTRUN_FILENAME}" \
+            -destination "platform=iOS Simulator,name=${{ matrix.simulator_name }},arch=arm64" \
+            -resultBundlePath "SnapshotResults-${{ matrix.slug }}.xcresult"
+
+      - name: Upload snapshots artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: snapshots-${{ matrix.slug }}
+          path: ${{ env.TEST_RUNNER_SNAPSHOTS_EXPORT_DIR }}
+          if-no-files-found: error
+
+  upload_snapshots:
+    runs-on: macos-26
+    needs: generate_snapshots
+
+    steps:
+      # On PRs, checkout builds the merge candidate; sentry-cli labels uploads from GitHub event head/base SHAs.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Download generated snapshots
+        uses: actions/download-artifact@v5
+        with:
+          path: ${{ env.SNAPSHOT_UPLOAD_BASE_DIR }}
+          pattern: snapshots-*
+
+      - name: List aggregated snapshot files
+        run: |
+          find "${SNAPSHOT_UPLOAD_BASE_DIR}" -type f | sort
+          echo "Total PNG images: $(find "${SNAPSHOT_UPLOAD_BASE_DIR}" -type f -name '*.png' | wc -l | tr -d ' ')"
+
+      - name: Install sentry-cli
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Upload snapshots to Sentry
+        run: |
+          sentry-cli snapshots upload "${SNAPSHOT_UPLOAD_BASE_DIR}" \
+            --org "${SENTRY_ORG}" \
+            --project "${SENTRY_PROJECT}" \
+            --app-id "${SENTRY_APP_ID}"
+```
+
+For selective PR rendering, add a separate manifest job with `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE`, aggregate all shard manifests with `sort -u`, and pass `--all-image-file-names-file` only for pull-request uploads. Do not add this complexity unless selective testing is actually required.

--- a/skills/sentry-snapshots-cocoa/references/github-actions-simple.md
+++ b/skills/sentry-snapshots-cocoa/references/github-actions-simple.md
@@ -1,0 +1,89 @@
+# Simple GitHub Actions Workflow for SnapshotPreviews
+
+Use this when adding Sentry Snapshots CI for a SnapshotPreviews Apple app with one simulator destination. Start here by default for single-device SnapshotPreviews onboarding.
+
+Do not extend this template with sequential loops over multiple simulators. If the user asks for multiple simulator destinations or device families, use `github-actions-fanout.md` instead.
+
+Do not use this template for Point-Free `swift-snapshot-testing` or another existing generator. For `swift-snapshot-testing`, use `github-actions-swift-snapshot-testing.md`; for other generators, preserve the generator and adapt its existing CI/upload path.
+
+For a public production SnapshotPreviews workflow, compare against the [EmergeTools HackerNews fan-out workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_sentry_upload_snapshots.yml). This simple template intentionally keeps the same upload model but removes matrix fan-out and build-product sharing.
+
+Before adapting this template:
+
+1. Verify the runner image has the required Xcode, SDK, and simulator. Do not guess from memory.
+2. Prefer the project's existing shared scheme and single simulator destination.
+3. Keep base-branch uploads full. Add selective flags only for selective PR uploads.
+4. Use Fastlane instead of direct `sentry-cli` when the project already has a Sentry Fastlane lane.
+
+```yaml
+name: Upload iOS snapshots to Sentry
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  SNAPSHOT_EXPORT_DIR: ${{ github.workspace }}/snapshot-images
+  SNAPSHOT_PROJECT: MyApp.xcodeproj
+  SNAPSHOT_SCHEME: MyApp
+  SNAPSHOT_DESTINATION: platform=iOS Simulator,name=iPhone 17 Pro Max,arch=arm64
+
+  # Define SENTRY_AUTH_TOKEN as a repository secret and SENTRY_ORG/SENTRY_PROJECT as repository variables.
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+  SENTRY_APP_ID: com.example.MyApp
+jobs:
+  upload_snapshots:
+    runs-on: macos-26
+
+    steps:
+      # On PRs, checkout builds the merge candidate; sentry-cli labels uploads from GitHub event head/base SHAs.
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "${SNAPSHOT_PROJECT}" \
+            -scheme "${SNAPSHOT_SCHEME}"
+
+      - name: Render snapshots
+        env:
+          TEST_RUNNER_SNAPSHOTS_EXPORT_DIR: ${{ env.SNAPSHOT_EXPORT_DIR }}
+        run: |
+          xcodebuild test \
+            -project "${SNAPSHOT_PROJECT}" \
+            -scheme "${SNAPSHOT_SCHEME}" \
+            -sdk iphonesimulator \
+            -destination "${SNAPSHOT_DESTINATION}" \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Install sentry-cli
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Upload snapshots to Sentry
+        run: |
+          sentry-cli snapshots upload "${SNAPSHOT_EXPORT_DIR}" \
+            --org "${SENTRY_ORG}" \
+            --project "${SENTRY_PROJECT}" \
+            --app-id "${SENTRY_APP_ID}"
+```
+
+If using Fastlane, replace the install/upload steps with the project's existing Ruby setup and lane, for example:
+
+```yaml
+      - name: Upload snapshots to Sentry
+        run: bundle exec fastlane ios upload_sentry_snapshots path:"${SNAPSHOT_EXPORT_DIR}"
+```

--- a/skills/sentry-snapshots-cocoa/references/github-actions-swift-snapshot-testing.md
+++ b/skills/sentry-snapshots-cocoa/references/github-actions-swift-snapshot-testing.md
@@ -1,0 +1,106 @@
+# GitHub Actions Workflow for Point-Free swift-snapshot-testing
+
+Use this when a project already uses Point-Free `swift-snapshot-testing` and the user wants GitHub Actions/CI upload to Sentry Snapshots. Do not run the `appleSnapshots` wizard or use the SnapshotPreviews workflow templates for this path.
+
+This pattern follows the public [EmergeTools HackerNews workflow](https://github.com/EmergeTools/hackernews/blob/main/.github/workflows/ios_sentry_upload_swift_snapshots.yml). Run the existing XCTest suite in record mode, allow the recording step to fail because `swift-snapshot-testing` treats recording as test failures, then upload the generated `__Snapshots__` directory to Sentry.
+
+Before adapting this template:
+
+1. Locate the test target/class that owns the `assertSnapshot` calls.
+2. Confirm the generated `__Snapshots__/<TestClass>/` path.
+3. Prefer the project's existing Ruby/Fastlane setup if it already uploads snapshots.
+4. Keep local test behavior unchanged; set record mode only in CI through the environment.
+
+```yaml
+name: Upload iOS swift-snapshot-testing snapshots to Sentry
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+env:
+  SNAPSHOT_PROJECT: MyApp.xcodeproj
+  SNAPSHOT_SCHEME: MyApp
+  SNAPSHOT_DESTINATION: platform=iOS Simulator,name=iPhone 17 Pro Max,arch=arm64
+  SNAPSHOT_TEST_IDENTIFIER: MyAppTests/MyAppSnapshotTest
+  SNAPSHOT_OUTPUT_DIR: MyAppTests/__Snapshots__/MyAppSnapshotTest
+
+  # Define SENTRY_AUTH_TOKEN as a repository secret and SENTRY_ORG/SENTRY_PROJECT as repository variables.
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+  SENTRY_ORG: ${{ vars.SENTRY_ORG }}
+  SENTRY_PROJECT: ${{ vars.SENTRY_PROJECT }}
+  SENTRY_APP_ID: com.example.MyApp.swift-snapshot-testing
+
+jobs:
+  upload_swift_snapshots:
+    runs-on: macos-26
+
+    env:
+      # Propagates SNAPSHOT_TESTING_RECORD=all into the iOS test runner.
+      TEST_RUNNER_SNAPSHOT_TESTING_RECORD: all
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+
+      - name: Resolve Swift packages
+        run: |
+          xcodebuild -resolvePackageDependencies \
+            -project "${SNAPSHOT_PROJECT}" \
+            -scheme "${SNAPSHOT_SCHEME}"
+
+      - name: Boot simulator
+        run: xcrun simctl boot "iPhone 17 Pro Max" || true
+
+      - name: Generate snapshot images
+        continue-on-error: true
+        run: |
+          xcodebuild test \
+            -project "${SNAPSHOT_PROJECT}" \
+            -scheme "${SNAPSHOT_SCHEME}" \
+            -sdk iphonesimulator \
+            -destination "${SNAPSHOT_DESTINATION}" \
+            -only-testing:"${SNAPSHOT_TEST_IDENTIFIER}" \
+            -resultBundlePath SnapshotResults-swift-snapshots.xcresult \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: List generated images
+        run: |
+          find "${SNAPSHOT_OUTPUT_DIR}" -type f | sort
+          echo "Total PNG images: $(find "${SNAPSHOT_OUTPUT_DIR}" -type f -name '*.png' | wc -l | tr -d ' ')"
+
+      - name: Install sentry-cli
+        run: curl -sL https://sentry.io/get-cli/ | bash
+
+      - name: Upload snapshots to Sentry
+        run: |
+          sentry-cli snapshots upload "${SNAPSHOT_OUTPUT_DIR}" \
+            --org "${SENTRY_ORG}" \
+            --project "${SENTRY_PROJECT}" \
+            --app-id "${SENTRY_APP_ID}"
+```
+
+If using Fastlane, replace the install/upload steps with the project's existing lane, for example:
+
+```yaml
+      - name: Upload snapshots to Sentry
+        run: bundle exec fastlane ios upload_sentry_snapshots_swift_snapshot_testing
+```
+
+Rules:
+
+- Use `TEST_RUNNER_SNAPSHOT_TESTING_RECORD=all`, not `SNAPSHOT_TESTING_RECORD=all`, so the value reaches the iOS test runner.
+- Keep `continue-on-error: true` on the recording test step; otherwise recording failures prevent upload.
+- Upload the generated `__Snapshots__` directory that contains PNG images.
+- Use a stable `--app-id`. If the same app also uploads SnapshotPreviews images, give this generator a distinct app id to avoid mixing baselines.

--- a/skills/sentry-snapshots-cocoa/references/snapshot-previews.md
+++ b/skills/sentry-snapshots-cocoa/references/snapshot-previews.md
@@ -1,0 +1,86 @@
+# SnapshotPreviews Details
+
+Use this reference when the project uses Sentry's first-party SnapshotPreviews library and needs SnapshotPreviews-specific metadata, rendering preferences, selective rendering, or troubleshooting.
+
+Wizard setup, target disambiguation, and manual fallback live in `wizard-setup.md`. Shared upload guidance for `sentry-cli`, Fastlane, manifests, and CI lives in `snapshots.md`.
+
+## Metadata and Rendering Preferences
+
+Add `SnapshotPreferences` to the preview-declaring target only when default SnapshotPreviews sidecar metadata is insufficient. See Sentry's SnapshotPreviews metadata docs: https://docs.sentry.io/platforms/apple/snapshots/snapshotpreviews-metadata/
+
+```swift
+import SnapshotPreferences
+
+#Preview("Map") {
+  MapPreview()
+    .snapshotTags(["screen": "map"])
+    .snapshotAdditionalContext(["fixture": "city-route"])
+}
+```
+
+| Modifier | Use when |
+|---|---|
+| `.snapshotTags([String: String])` | Sentry needs searchable filters beyond defaults. |
+| `.snapshotAdditionalContext([String: Any])` | Reviewers need extra sidecar context. |
+| `.snapshotDiffThreshold(Float?)` | A deterministic snapshot still has tolerated visual noise. |
+| `.snapshotAccessibility(true)` | Need an accessibility-overlay variant on iOS. |
+| `.snapshotRenderingMode(.coreAnimation)` | Default renderer is wrong for blur, maps, video, or renderer-sensitive content. |
+| `.snapshotExpansion(false)` | Expanded scroll views create unstable or unhelpful images. |
+
+Rules:
+
+- Prefer deterministic previews over thresholds.
+- Avoid live network, timers, animations, current-clock dates, locale-dependent data, and real user data.
+- Use fixed fixtures and mocked dependencies.
+
+## Selective Rendering
+
+Use for PRs that should render only changed/high-signal SnapshotPreviews while preserving Sentry comparison semantics.
+
+1. Generate the full image-name manifest without rendering:
+
+```bash
+TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE="$PWD/all-image-names.txt" \
+xcodebuild test \
+  -scheme MyApp \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro'
+```
+
+2. Render the subset with `snapshotPreviews()`, `snapshotPreviewModules()`, `excludedSnapshotPreviews()`, `excludedSnapshotPreviewModules()`, or `-only-testing:` while `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` is set.
+
+3. Upload the rendered subset using the full manifest. Read `snapshots.md` for the upload command and manifest flags.
+
+Rules:
+
+- `TEST_RUNNER_`-prefixed environment variables are forwarded into the app/test process.
+- Sharded simulators export into separate subdirectories.
+- Sharded manifests must be merged and de-duplicated with `sort -u` before upload.
+- Generate the manifest and rendered subset from the same commit.
+
+## GitHub Actions Notes
+
+Do not duplicate workflow templates here.
+
+| CI shape | Read |
+|---|---|
+| One simulator destination | `github-actions-simple.md` |
+| Multiple simulators/device families, parallel rendering, large suites | `github-actions-fanout.md` |
+
+Before writing workflows:
+
+- Verify current runner image, Xcode path, SDKs, and simulator names from existing CI or current runner docs.
+- Use `fetch-depth: 0` so `sentry-cli` can resolve base/head commits.
+- Prefer existing Fastlane upload lanes when present; upload configuration lives in `snapshots.md`.
+
+## Troubleshooting
+
+| Issue | Fix |
+|---|---|
+| No generated tests/previews | Confirm previews are loaded by the hosted app/test process, build conditions match, and test target depends on `SnapshottingTests`. |
+| Package-only project | Ask for the host app/test target; standalone `swift test` rendering is not supported. |
+| Export directory empty | Set `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR`; ensure `TEST_RUNNER_SNAPSHOTS_ALL_IMAGE_NAMES_FILE` is not also set. |
+| Manifest mismatch | Regenerate manifest and subset from same commit; merge shard manifests. |
+| Image too large | Keep images below 40M pixels; constrain preview layout or use `.snapshotExpansion(false)`. |
+| Flaky snapshots | Remove nondeterminism first; then try rendering mode or per-preview diff threshold. |
+| Duplicate path warnings | Make display names unique and avoid overlapping shard filters. |

--- a/skills/sentry-snapshots-cocoa/references/snapshots.md
+++ b/skills/sentry-snapshots-cocoa/references/snapshots.md
@@ -1,0 +1,98 @@
+# Sentry Snapshots Upload
+
+Use this reference after an image source has been selected and the project can produce PNG or JPEG snapshots. The image source can be Sentry's first-party SnapshotPreviews, Point-Free `swift-snapshot-testing`, or a custom generator.
+
+This skill integrates generated snapshot images with Sentry's Snapshot service. It does not replace existing third-party generators. If the project already has an image generator, preserve it and upload the images it already produces.
+
+For SnapshotPreviews-specific generation, metadata, and selective rendering mechanics, read `snapshot-previews.md`.
+
+## Image Source Rules
+
+- Preserve the selected image source.
+- Point `sentry-cli snapshots upload` or Fastlane at the directory containing generated `.png` or `.jpg`/`.jpeg` files.
+- For existing generators, do not run the `appleSnapshots` wizard; it configures Sentry's first-party SnapshotPreviews flow.
+- For Point-Free `swift-snapshot-testing`, keep `SnapshotTesting` linked from the XCTest target or package test target that owns `assertSnapshot` calls; do not link it into the app/library target just to satisfy Sentry upload.
+- For Point-Free `swift-snapshot-testing`, set `TEST_RUNNER_SNAPSHOT_TESTING_RECORD=all` so CI pushes `SNAPSHOT_TESTING_RECORD=all` into the iOS test runner without hardcoding record mode in tests. This keeps local Xcode diffing normal while CI records images for Sentry to diff as a service.
+- For Point-Free `swift-snapshot-testing`, upload the relevant `__Snapshots__/<TestClass>/` directory, and allow the recording test step to continue so upload still runs.
+- Add JSON sidecars only when the project needs Sentry display names, tags, custom context, or per-image thresholds. SnapshotPreviews can emit sidecars through its own metadata API; other generators should use Sentry's generic sidecar schema: https://docs.sentry.io/product/snapshots/uploading-snapshots/#json-metadata
+
+## Fastlane Upload
+
+Use when the project already has Fastlane or wants upload logic in `fastlane/Fastfile`.
+
+```ruby
+lane :upload_sentry_snapshots do |options|
+  sentry_upload_snapshots(
+    auth_token: ENV["SENTRY_AUTH_TOKEN"],
+    org_slug: "your-org",
+    project_slug: "your-ios-project",
+    app_id: "com.example.MyApp",
+    path: options[:path]
+  )
+end
+```
+
+```bash
+bundle exec fastlane ios upload_sentry_snapshots path:"$PWD/snapshot-images"
+```
+
+Verify exact `fastlane-plugin-sentry` action parameter names against the installed plugin version before finalizing.
+
+## `sentry-cli` Upload Flags
+
+```bash
+sentry-cli snapshots upload "$PWD/snapshot-images" \
+  --org your-org \
+  --project your-ios-project \
+  --app-id com.example.MyApp
+```
+
+| Flag | Purpose |
+|---|---|
+| `--app-id <APP_ID>` | Required stable application identifier; usually bundle id. |
+| `--diff-threshold <0.0-1.0>` | Global changed-pixel threshold; prefer per-image sidecar values when available. |
+| `--selective` | Marks upload as a subset. Use a manifest when removals/renames must be detected. |
+| `--all-image-file-names-file <PATH>` | Full suite image-name manifest; implies `--selective`. |
+| `--all-image-file-names <NAMES>` | Inline comma-separated manifest; conflicts with file variant. |
+| `--base-sha <SHA>` | Base commit when CI cannot expose a merge base. |
+
+Rules:
+
+- Auth comes from `SENTRY_AUTH_TOKEN` or `--auth-token`.
+- PR number without resolvable base SHA fails upload; pass `--base-sha` or check out full history.
+- Images above 40 million pixels are rejected.
+- Base branch uploads the full snapshot set without selective flags.
+- PR subset uploads should include the full image-name manifest so Sentry can detect removals and renames.
+- Every uploaded image must appear in the manifest.
+- Generate the manifest and rendered subset from the same commit.
+- Sharded manifests must be merged and de-duplicated with `sort -u` before upload.
+- `--selective` without a manifest cannot detect removals or renames.
+
+## GitHub Actions Notes
+
+Do not duplicate workflow templates here.
+
+| CI shape | Read |
+|---|---|
+| SnapshotPreviews with one simulator destination | `github-actions-simple.md` |
+| SnapshotPreviews with multiple simulators/device families, parallel rendering, large suites | `github-actions-fanout.md` |
+| Point-Free `swift-snapshot-testing` | `github-actions-swift-snapshot-testing.md` |
+| Other existing generator | Adapt the project's existing CI and upload the generated image directory. |
+
+Before writing workflows:
+
+- Verify current runner image, Xcode path, SDKs, and simulator names from existing CI or current runner docs.
+- Use `fetch-depth: 0` so `sentry-cli` can resolve base/head commits.
+- Prefer existing Fastlane upload lanes when present.
+
+## Troubleshooting
+
+| Issue | Fix |
+|---|---|
+| Upload says no images found | Point upload at the directory containing PNGs; hidden files/directories are skipped. |
+| Auth failure | Set `SENTRY_AUTH_TOKEN` or `--auth-token`; confirm `--org` and `--project`. |
+| PR upload needs base SHA | Check out full history or pass `--base-sha`. |
+| Manifest mismatch | Regenerate manifest and subset from same commit; merge shard manifests. |
+| Image too large | Keep images below 40M pixels; constrain snapshot layout or renderer output. |
+| Flaky snapshots | Remove nondeterminism first; then use generator-specific diff tolerance or Sentry sidecar thresholds. |
+| Wrong comparisons in Sentry | Use stable `--app-id`, usually bundle id, not project slug. |

--- a/skills/sentry-snapshots-cocoa/references/wizard-setup.md
+++ b/skills/sentry-snapshots-cocoa/references/wizard-setup.md
@@ -73,17 +73,15 @@ https://github.com/getsentry/SnapshotPreviews
 
 1. Link products:
 
-
 | Product               | Target                                                                       |
 | --------------------- | ---------------------------------------------------------------------------- |
 | `SnapshottingTests`   | Hosted snapshot/layout XCTest target                                         |
 | `SnapshotPreferences` | Preview-declaring target only when custom tags/context/thresholds are needed |
 | `PreviewGallery`      | Internal app target only when an in-app preview gallery is requested         |
 
-
-1. Add or verify one hosted XCTest class importing `SnapshottingTests` and inheriting from `SnapshotTest`.
-2. Export images with `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` and `xcodebuild test`.
-3. Upload with `sentry-cli snapshots upload`.
+2. Add or verify one hosted XCTest class importing `SnapshottingTests` and inheriting from `SnapshotTest`.
+3. Export images with `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` and `xcodebuild test`.
+4. Upload with `sentry-cli snapshots upload`.
 
 ```bash
 TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="$PWD/snapshot-images" \

--- a/skills/sentry-snapshots-cocoa/references/wizard-setup.md
+++ b/skills/sentry-snapshots-cocoa/references/wizard-setup.md
@@ -41,12 +41,10 @@ Use this only when the wizard asks for target values or reports that no hosted X
 
 Only gather values the wizard asked for. Probe first; ask the user only if probing cannot identify a safe single target.
 
-
-| Wizard asks for      | How to investigate                                          | Add flag                                                  |
-| -------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
-| App target           | `xcodebuild -list -project <Project>.xcodeproj 2>/dev/null` | `--app-target <AppTarget>`                                |
-| Hosted XCTest target | `grep -rE "TEST_HOST`                                       | BUNDLE_LOADER" --include='project.pbxproj' . 2>/dev/null` |
-
+| Wizard asks for      | How to investigate                                                              | Add flag                                    |
+| -------------------- | ------------------------------------------------------------------------------- | ------------------------------------------ |
+| App target           | `xcodebuild -list -project <Project>.xcodeproj 2>/dev/null`                     | `--app-target <AppTarget>`                 |
+| Hosted XCTest target | `grep -rE "TEST_HOST\|BUNDLE_LOADER" --include='project.pbxproj' . 2>/dev/null` | `--hosted-test-target <HostedTestsTarget>` |
 
 If the wizard asks for multiple values, gather all requested values through probing or user clarification, then rerun once with the complete requested flag set.
 

--- a/skills/sentry-snapshots-cocoa/references/wizard-setup.md
+++ b/skills/sentry-snapshots-cocoa/references/wizard-setup.md
@@ -1,0 +1,120 @@
+# SnapshotPreviews Wizard Setup
+
+Use this only when no existing snapshot generator/setup exists and the user explicitly wants Sentry's first-party SnapshotPreviews image source.
+
+## Flow
+
+1. Run the non-interactive wizard first.
+2. If the wizard succeeds, continue with the main skill's completion checks.
+3. If the wizard stops for a known recoverable reason, follow the matching section below.
+4. Use manual fallback only after the wizard is unavailable, rejects `appleSnapshots`, or still cannot complete after requested disambiguation.
+
+## Run the Wizard
+
+Pass the directory that contains the selected `.xcodeproj` and let the wizard auto-detect app targets, hosted XCTest targets, and Swift previews:
+
+```bash
+npx @sentry/wizard@latest -i appleSnapshots --non-interactive \
+  --xcode-project-dir <path-to-xcode-project-dir>
+```
+
+Use `.` when the `.xcodeproj` is in the repository root. Use the parent directory when detection returned a nested bundle path, for example `ios` for `ios/MyApp.xcodeproj`.
+
+## Handle Wizard Outcomes
+
+
+| Outcome                                                                                        | Action                                                                                                                                                                                                                                    |
+| ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Wizard completes                                                                               | Continue with the main skill's completion checks.                                                                                                                                                                                         |
+| Dirty working tree blocks non-interactive mode                                                 | Inspect `git status --short`. If dirty files are pre-existing or expected for the user's scenario, rerun the same command with `--ignore-git-changes`. Do not clean, stash, or revert user files just to satisfy the wizard safety check. |
+| Wizard asks for app target or hosted XCTest target                                             | Follow [Target Disambiguation](#target-disambiguation).                                                                                                                                                                                   |
+| Wizard reports no hosted XCTest target                                                         | Follow [Target Disambiguation](#target-disambiguation) to confirm. If no hosted target exists, stop and ask the user to add or identify one.                                                                                              |
+| Wizard reports no Swift previews                                                               | Stop and ask whether to add Swift previews or use another snapshot image source. Do not add, restore, or rewrite previews just to make SnapshotPreviews produce images unless the user explicitly approves that source change.            |
+| Wizard is unavailable, rejects `appleSnapshots`, or still fails after requested disambiguation | Follow [Manual Fallback](#manual-fallback) only if a hosted XCTest target exists.                                                                                                                                                         |
+
+
+
+
+## Target Disambiguation
+
+Use this only when the wizard asks for target values or reports that no hosted XCTest target was found. Start from the wizard's error output. `--xcode-project-dir` should already be present.
+
+Only gather values the wizard asked for. Probe first; ask the user only if probing cannot identify a safe single target.
+
+
+| Wizard asks for      | How to investigate                                          | Add flag                                                  |
+| -------------------- | ----------------------------------------------------------- | --------------------------------------------------------- |
+| App target           | `xcodebuild -list -project <Project>.xcodeproj 2>/dev/null` | `--app-target <AppTarget>`                                |
+| Hosted XCTest target | `grep -rE "TEST_HOST`                                       | BUNDLE_LOADER" --include='project.pbxproj' . 2>/dev/null` |
+
+
+If the wizard asks for multiple values, gather all requested values through probing or user clarification, then rerun once with the complete requested flag set.
+
+```bash
+npx @sentry/wizard@latest -i appleSnapshots --non-interactive \
+  --xcode-project-dir <path-to-xcode-project-dir> \
+  --app-target <AppTarget> \
+  --hosted-test-target <HostedTestsTarget>
+```
+
+Use only the target flags the wizard requested.
+
+If the hosted-target probe returns no `TEST_HOST` or `BUNDLE_LOADER` entries, stop and ask the user to add a hosted Unit Testing Bundle target for the app or identify an existing hosted test target. Do not use the manual fallback until a hosted XCTest target exists; SnapshotPreviews renders through `xcodebuild test`, and a standalone app target cannot run the generated `SnapshotTest` class.
+
+If the rerun still fails after requested disambiguation, use manual fallback only when a hosted XCTest target exists.
+
+## Manual Fallback
+
+Use this only if the wizard is unavailable, rejects `appleSnapshots`, or cannot complete after disambiguation and the project has a hosted XCTest target. If no hosted XCTest target exists, stop and ask for one first.
+
+1. Add the Swift package to the Xcode project/workspace that builds the app and hosted snapshot test target:
+
+```text
+https://github.com/getsentry/SnapshotPreviews
+```
+
+1. Link products:
+
+
+| Product               | Target                                                                       |
+| --------------------- | ---------------------------------------------------------------------------- |
+| `SnapshottingTests`   | Hosted snapshot/layout XCTest target                                         |
+| `SnapshotPreferences` | Preview-declaring target only when custom tags/context/thresholds are needed |
+| `PreviewGallery`      | Internal app target only when an in-app preview gallery is requested         |
+
+
+1. Add or verify one hosted XCTest class importing `SnapshottingTests` and inheriting from `SnapshotTest`.
+2. Export images with `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` and `xcodebuild test`.
+3. Upload with `sentry-cli snapshots upload`.
+
+```bash
+TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="$PWD/snapshot-images" \
+xcodebuild test \
+  -scheme MyApp \
+  -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+  -only-testing:MyAppTests/MyAppSnapshotTest
+
+sentry-cli snapshots upload "$PWD/snapshot-images" \
+  --org your-org \
+  --project your-ios-project \
+  --app-id com.example.MyApp
+```
+
+Only after non-interactive wizard setup, requested target disambiguation, and manual fallback all fail, tell the user they can run the wizard interactively and return with the error output:
+
+```bash
+npx @sentry/wizard@latest -i appleSnapshots --xcode-project-dir <path-to-xcode-project-dir>
+```
+
+
+
+## Rules
+
+- `--app-id` is a stable app identifier/bundle id, not the Sentry project slug.
+- Use `sentry-cli snapshots upload`, not deprecated `sentry-cli build snapshots`.
+- SnapshotPreviews test-runner environment variables use the `TEST_RUNNER_` prefix so values are forwarded into the app/test process.
+- Base branch uploads the full set.
+- PR selective uploads require a full image-name manifest; read `snapshots.md`.
+
+Completion for this route means the wizard completed, or manual fallback completed with the same project changes.


### PR DESCRIPTION
Adds a `sentry-snapshots-cocoa` feature-setup skill so the agent can guide Apple/Cocoa projects through generating snapshot images and uploading them to Sentry Snapshots. It detects the existing image source first — Sentry's SnapshotPreviews, Point-Free `swift-snapshot-testing`, or another generator — and routes to the matching procedure instead of assuming one, preserving any generator that already produces PNGs/JPEGs.

The skill is a thin router (`Scope` -> `Detect` -> `Route` -> completion checks) backed by six reference files: the `appleSnapshots` wizard flow with manual fallback, generic `sentry-cli`/Fastlane upload with selective-PR manifest rules, SnapshotPreviews metadata and selective-rendering details, and three GitHub Actions templates (single-simulator, multi-simulator fan-out, and `swift-snapshot-testing`). Routes stop and ask the user rather than guess when prerequisites are missing (package-only SwiftPM, no hosted XCTest target, or no Swift previews).

Wiring is additive: the `sentry-feature-setup` router advertises snapshots in its description and routing table, and the skill is registered in `SKILL_TREE.md` and `AGENTS.md`. It carries `disable-model-invocation: true`, so it stays hidden until the router points to it and adds nothing to startup metadata.

## Example Claude transcript:

````markdown
## User

> Please can you add Sentry snapshot testing to this project

## Assistant — approach

Routed the request through the `sentry:sentry-feature-setup` skill, which pointed to
`sentry-snapshots-cocoa` for Apple/Cocoa projects. That skill's decision:
use Sentry's first-party **SnapshotPreviews** (via the Sentry Wizard) when no existing
snapshot generator is present and Swift previews exist.

---

## Detection

Findings from scanning the project:

- **App target:** `test` — SwiftUI, `ContentView` has a `#Preview`.
- **Hosted XCTest target:** `testTests`.
- **Local package:** `MyLibrary` (also has a `#Preview` in `MyLibrary.swift`).
- **Existing snapshot generator:** none (no SnapshotPreviews, no Point-Free `swift-snapshot-testing`).
- **`.xcodeproj`:** at repo root → `--xcode-project-dir .`
- **Scheme:** `test`
- **Tooling:** Sentry Wizard present, node v26, `sentry-cli` 3.5.0.
- **Sentry auth:** `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT` all set.
- **CI:** no Fastlane, no GitHub Actions.
- **Working tree:** only `UserInterfaceState.xcuserstate` dirty (pre-existing Xcode user state — not touched).

Route selected: **first-party SnapshotPreviews via the Sentry Wizard.**

---

## Steps performed

### 1. Ran the Sentry Wizard (non-interactive)

```bash
node /Users/cameroncooke/Developer/sentry-wizard/dist/bin.js -i appleSnapshots --non-interactive \
  --xcode-project-dir . \
  --ignore-git-changes
```

`--ignore-git-changes` was passed because the only dirty file was pre-existing Xcode user state.

**Result:** Apple Snapshots setup complete. The wizard:
- Added the `SnapshotPreviews` SwiftPM package (0.17.0+).
- Linked `SnapshottingTests` → `testTests` (hosted XCTest target).
- Linked `SnapshotPreferences` → `test` (app target).
- Generated `testTests/TestTestsSnapshotTest.swift`.

Generated test class:

```swift
import SnapshottingTests

final class TestTestsSnapshotTest: SnapshotTest {
  override class func snapshotPreviews() -> [String]? { nil }
  override class func excludedSnapshotPreviews() -> [String]? { nil }
  override class func snapshotPreviewModules() -> [String]? { nil }
  override class func excludedSnapshotPreviewModules() -> [String]? { nil }
}
```

### 2. Generated snapshot images

```bash
TEST_RUNNER_SNAPSHOTS_EXPORT_DIR="$PWD/snapshot-images" \
xcodebuild test \
  -project test.xcodeproj \
  -scheme test \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
  -only-testing:testTests/TestTestsSnapshotTest \
  CODE_SIGNING_ALLOWED=NO
```

> Note: XcodeBuildMCP was not connected in this session, and the export requires the
> `TEST_RUNNER_SNAPSHOTS_EXPORT_DIR` test-runner env var, so the documented `xcodebuild`
> command was used directly.

**Result:** `** TEST SUCCEEDED **` — two previews rendered:
- `portrait-Content View-0-0` (from `ContentView`)
- `portrait-My Library-0-1` (from `MyLibrary`)

Export directory contained:
- `snapshot-images/test_ContentView.swift_line-22.png` + `.json`
- `snapshot-images/MyLibrary_MyLibrary.swift_line-9.png` + `.json`

(2 PNG + 2 JSON sidecars.)

### 3. Uploaded to Sentry

```bash
sentry-cli snapshots upload "$PWD/snapshot-images" \
  --org "$SENTRY_ORG" \
  --project "$SENTRY_PROJECT" \
  --app-id io.sentry.test
```

**Result:**

```
> Found 2 image files
> Created snapshot 95 with 2 images
> View snapshots at .../organizations/sentry/preprod/snapshots/95
```

(`--app-id` is the app bundle id `io.sentry.test`, not the Sentry project slug. Base upload — no selective flags, since this is not a PR.)

### 4. Housekeeping

- Removed the temporary build log.
- Added a root `.gitignore` to keep generated output out of version control:

```gitignore
# Sentry Snapshots — locally generated snapshot images
snapshot-images/
```

---

## Files changed (working tree, not committed)

| File | Change |
|---|---|
| `test.xcodeproj/project.pbxproj` | Added `SnapshotPreviews` package + product linking |
| `test.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` | Pins `SnapshotPreviews` 0.17.0 (+ transitive deps) |
| `testTests/TestTestsSnapshotTest.swift` | Generated snapshot test class |
| `.gitignore` | New — ignores `snapshot-images/` |

`UserInterfaceState.xcuserstate` was already dirty before this work and was left untouched.

---

## Verification (all completion checks passed)

- ✅ Image source configured (SnapshotPreviews via wizard).
- ✅ Snapshot generation appears in test logs (2 tests passed).
- ✅ Export directory contains `.png` files + `.json` sidecars.
- ✅ Upload succeeded and printed a Sentry URL + snapshot id (95).
- ✅ Base upload was the full set.

---

## Outstanding / next steps

- **CI not set up** — the wizard intentionally does not write workflow files. Natural next step:
  a GitHub Actions workflow that uploads the full set on the base branch and a selective subset
  (with a full image-name manifest) on PRs so Sentry can diff and detect renames/removals.
- **Changes not committed** — staged in the working tree only.
````

> [!NOTE]
> Requires https://github.com/getsentry/sentry-wizard/pull/1297 to be merged and deployed. 

Refs EME-1059