### PR TITLE
feat(skills-next): add SDK reference organization

### DIFF
--- a/skills-next/references/sdks/STRUCTURE.md
+++ b/skills-next/references/sdks/STRUCTURE.md
@@ -1,0 +1,238 @@
+> [!WARNING]
+> THIS IS AN INTERNAL DOCUMENT. It is not part of the reference content itself — it exists only for
+> the development and maintenance of the SDK references. Skip it during normal use.
+
+# `sdks/[sdk]/` structure
+
+This document is the contract every SDK reference tree must follow. It exists so that all 19 SDKs
+read the same way and a reader can predict exactly where a given piece of information lives. When you
+add or edit an SDK reference, conform to this — don't invent a per-SDK shape.
+
+These references are the platform **HOW** — install commands, `Sentry.init()` options, and the code
+to wire up each signal. They are **standalone**: a reference must not reference or link to a skill,
+nor to reference docs in another domain (e.g. the `concepts/` strategy docs). The skill that loads a
+reference supplies the surrounding WHY and orchestration; the reference stays focused on the code.
+The only links a reference carries are to **sibling files within the SDK tree** and to **external
+documentation**.
+
+## Directory layout
+
+Each SDK gets one directory under `sdks/`, named by its **slug** (the `SDK slug` column in
+[`index.md`](./index.md) — lowercase, no `sentry-` prefix, no `-sdk` suffix, e.g. `nextjs`,
+`react-native`):
+
+    sdks/[sdk]/
+      index.md                  # required — overview, detect, install, init, feature catalog
+      error-monitoring.md       # required — every SDK supports it
+      tracing.md                # one file per SUPPORTED canonical signal
+      logging.md
+      profiling.md
+      metrics.md
+      crons.md
+      session-replay.md
+      user-feedback.md
+      ai-monitoring.md
+      <extension>.md            # optional — platform-specific topics (see below)
+
+Create a signal file **only if the SDK supports that signal.** Unsupported signals are not files —
+they are listed in `index.md`'s catalog table marked as not available (see below).
+
+## The WHAT vs HOW rule
+
+These references are the **HOW** — install commands, `init` options, and the code to wire up a
+signal on this platform. They are **not** the place for strategy.
+
+- Best practices, when-to-use, sampling philosophy, naming conventions, and pitfalls do **not** live
+  here, and the reference does **not** link out to them. Omit them — the skill that loads this
+  reference supplies that context. If you find yourself writing a paragraph that would be true on
+  every platform, cut it.
+- Genuinely platform-specific guidance (e.g. "Celery needs dual-process init", "ProGuard mappings
+  must be uploaded for readable native frames") *does* belong here — it is HOW, not generic strategy.
+
+## What does NOT live here
+
+Some setup is not owned by a platform tree at all — project/DSN provisioning, the verify/confirm
+loop, source maps / debug symbols, releases, data scrubbing, and volume tuning. Keep these out of the
+SDK references entirely; do not document or link them here. The one exception is the **SDK-side hook**
+for those topics — the `authToken` line, `beforeSend`, sample-rate options, the `release` /
+`environment` `init` options — which may appear as a normal config option, described in place without
+a pointer to any other doc.
+
+## Canonical signals
+
+This is the fixed, ordered set. Use these exact filenames and section titles. Order matters: it is
+the order the catalog table and any walkthrough should follow.
+
+| Order | Signal title | Filename | Notes |
+|---|---|---|---|
+| 1 | Error Monitoring | `error-monitoring.md` | Always supported. The baseline. |
+| 2 | Tracing & Performance | `tracing.md` | |
+| 3 | Logging | `logging.md` | |
+| 4 | Profiling | `profiling.md` | Requires tracing. |
+| 5 | Metrics | `metrics.md` | |
+| 6 | Cron Monitoring | `crons.md` | Check-in code only. |
+| 7 | Session Replay | `session-replay.md` | Browser and mobile only. |
+| 8 | User Feedback | `user-feedback.md` | |
+| 9 | AI / LLM Monitoring | `ai-monitoring.md` | Platforms with LLM-SDK auto-instrumentation. |
+
+Do not add a canonical signal without updating this table and the catalog in `index.md`.
+
+## Platform-extension files
+
+Topics that aren't one of the canonical signals but are specific to a platform get their own file
+with a descriptive slug, linked from `index.md`. Examples already in the tree:
+
+- `integrations.md` / `ecosystem-integrations.md` (Android, Flutter)
+- `laravel.md`, `symfony.md` (PHP)
+- `durable-objects.md` (Cloudflare)
+- `react-features.md`, `react-router-framework-features.md`, `tanstackstart-features.md`
+- `expo-config-plugin.md` (React Native)
+- `migration.md` (Ruby)
+
+Keep these focused. If an extension grows to cover a canonical signal, move that content into the
+signal file and cross-link.
+
+## `index.md` format
+
+The front door for an SDK — read first, every time. Sections, in order:
+
+1. **Title** — `# Sentry <Platform> SDK`
+
+2. **What this SDK applies to** — the scope of the SDK so a reader can confirm it is the right one:
+   the runtimes/languages it covers, the frameworks and libraries it supports, the package name(s)
+   it ships as, and when to pick a sibling SDK instead (e.g. "use `nextjs` for Next.js apps, not
+   this"). A link to the platform's docs (`https://docs.sentry.io/platforms/<...>/`) and a version
+   note belong here. **If the SDK has more than one target** (multiple runtimes, platforms, or
+   tooling variants — see "Multi-target SDKs"), enumerate them here by name; everything downstream
+   refers back to these names.
+
+3. **Confirm & inspect** — two jobs: (a) *confirm this is the right reference* — quick checks that
+   the project really matches this SDK, and a pointer to the sibling SDK's `index.md` if it doesn't
+   (e.g. "found `@nestjs/core` → use `../nestjs/index.md` instead"); and (b) *inspect the specifics*
+   that change the setup — framework/variant, task queue, AI libs, existing Sentry install,
+   companion frontend/backend — with the shell commands to find each and what the finding implies.
+
+4. **Recommend** — a concrete proposal, not open questions: a matrix mapping each feature to
+   "recommend when…" and its reference file. Write it so it is easy to skip — it must not be a
+   prerequisite for reading an individual signal file.
+
+5. **Installation** — how to add the SDK as a project dependency: package name(s), the
+   package-manager command(s) for that ecosystem, where the dependency is declared, and any
+   framework-specific extras. This covers *only* getting the package installed — wiring up `init` is
+   next.
+
+6. **Quick Start `init`** — the recommended initialization snippet with sensible defaults and where
+   it must be placed. A placeholder DSN (like `___DSN___`) is fine in the reference text. This is the
+   minimal-but-good starting point; deeper per-signal config lives in the signal files.
+
+7. **Where to initialize** — *where and when* `init` should run for this platform, and why placement
+   matters (e.g. "before any other import," "before the app/server is created," "in each worker
+   process"). Cover the common cases inline; defer deep framework-specific placement to that
+   framework's extension file and link out.
+
+8. **Feature catalog** — the table linking every canonical signal to its file or marking it
+   unsupported (see next section). The routing hub.
+
+9. **Configuration Reference** — key `init` options and environment variables in a table.
+
+10. **Platform considerations** — the things unique to this platform that must be handled for Sentry
+    to actually work well — the gotchas obvious to a platform expert but easy to miss. Most common
+    are the steps for a *readable* event:
+
+    - **JavaScript/TypeScript** — source maps must be configured or stack traces stay minified.
+    - **Native / mobile** (Apple, Android, NDK) — debug symbols must be uploaded (dSYM, ProGuard/R8
+      mappings, etc.) or frames stay unsymbolicated.
+
+    These are only examples — generalize to whatever this platform needs that others don't (build
+    steps, release/dist matching, runtime quirks, permissions, init ordering, packaging/deploy). List
+    each with what happens if skipped. Don't omit this section just because a platform "seems
+    straightforward" — if there is genuinely nothing, say so.
+
+11. **Cross-link** — companion projects to suggest (e.g. a backend SDK for a frontend install),
+    linking the sibling tree's `index.md`.
+
+12. **Troubleshooting** — a symptom → solution table.
+
+### The feature catalog table
+
+`index.md` lists **all** canonical signals so coverage is explicit. The `Status` column takes one of
+three forms:
+
+- **`Supported`** — available on every target this SDK covers; link the signal to its file.
+- **`Supported — <targets> only`** — available on *some* targets but not all; still link to the
+  file, and name the targets that have it.
+- **`Not available — <reason>`** — unsupported everywhere; do not link (there is no file).
+
+    ## Features
+
+    | Signal | Status |
+    |---|---|
+    | [Error Monitoring](./error-monitoring.md) | Supported |
+    | [Tracing & Performance](./tracing.md) | Supported |
+    | [Logging](./logging.md) | Supported |
+    | [Profiling](./profiling.md) | Supported — iOS, macOS only |
+    | [Metrics](./metrics.md) | Supported |
+    | [Session Replay](./session-replay.md) | Supported — iOS, Android only |
+    | User Feedback | Not available — no widget on this platform |
+    | Cron Monitoring | Not available — no scheduler runtime |
+    | AI / LLM Monitoring | Not available — no auto-instrumentation yet |
+
+Use the target names exactly as the SDK enumerates them, so the catalog, the signal files, and the
+per-target setup sections all speak the same vocabulary. List platform-extension files in a separate
+row group or a short list under the table.
+
+### Multi-target SDKs
+
+Some SDKs cover more than one **target** — multiple runtimes (`node`: Node/Bun/Deno), platforms
+(`cocoa`: iOS/macOS/tvOS/watchOS/visionOS), or tooling variants (`react-native`: Expo-managed / bare
+/ vanilla). One slug still maps to one `index.md`; the target axis is handled *inside* it. Two rules:
+
+- **Enumerate targets once**, in *What this SDK applies to*, and reuse those exact names everywhere.
+- **Tier by how much actually diverges:**
+  - *Minor divergence* — same `init`, differing only in install/build/packaging or a few placement
+    details. Keep everything in `index.md` and use labeled `### <target>` subsections inside the
+    sections that vary.
+  - *Major divergence* — a whole distinct setup flow for one target (e.g. React Native's Expo
+    config-plugin path). Give that target its own **platform-extension file** and route to it from
+    `index.md`; keep the shared path in `index.md` so the common case stays linear.
+
+Per-target *feature availability* is a separate axis covered by the catalog's
+`Supported — <targets> only` status and a signal file's target-scope line.
+
+## Signal-file format
+
+Every canonical signal file (`tracing.md`, `logging.md`, …) follows the same shape:
+
+1. **Title** — `# <Signal title> — <Platform>` (e.g. `# Tracing & Performance — Python`).
+2. **Target scope** — *only when the signal is not available on every target.* One line right after
+   the title naming where it applies, e.g. "Applies to: iOS, Android." Use the same target names as
+   the catalog. Omit when the signal works on all of the SDK's targets.
+3. **Setup** — the minimal config/code to turn the signal on, building on the `index.md` `init`.
+   - **Single path (the default):** one `## Basic setup` section.
+   - **Mutually-exclusive paths:** when a signal can be wired up in genuinely different,
+     non-combinable ways (e.g. native tracing vs an OpenTelemetry/OTLP path), drop the single
+     `## Basic setup` and lead with a short **"Which path"** selector (HOW-level routing only),
+     followed by one `## Setup: <Path>` section per path.
+   - When setup differs by target, note the per-target difference here (a short `### <target>`
+     subsection or inline note).
+4. **Additional sections as needed** — `## Custom spans`, `## Sampling`, framework specifics, etc.
+   Only what is platform-specific.
+5. **Verification** — `## Verification`. A copy-pasteable snippet that *produces this signal* (a span,
+   a log line, a metric, a forced replay) so a reader can confirm it lands: the trigger and what to
+   expect in Sentry. With multiple setup paths, share one Verification if the produced signal looks
+   the same, or give one per path when they differ.
+
+A signal file does **not** open with a cross-skill callout, and does **not** link to strategy/WHY
+docs. It starts with the title and gets straight to the HOW.
+
+## Relative links
+
+Reference files live at `sdks/[sdk]/`. The only links allowed are within the SDK tree and to external
+docs:
+
+- Sibling signal file in the same SDK → `./<other>.md`
+- Sibling SDK tree → `../<other-slug>/index.md`
+- External documentation → an absolute `https://…` URL
+
+Do **not** link to skills or to reference docs in another domain (e.g. `concepts/`). References are
+standalone; cross-domain navigation is the job of the skill that loads them.

--- a/skills-next/references/sdks/index.md
+++ b/skills-next/references/sdks/index.md
@@ -1,0 +1,109 @@
+# Sentry SDK references
+
+The per-platform HOW — the code for installing Sentry and wiring up each signal. There is one
+reference tree per SDK under `sdks/[sdk]/`: an `index.md` (detect, install, `init`, feature catalog)
+plus one file per supported signal. This is the mechanics layer: the actual install commands,
+`Sentry.init()` options, and the code to wire up each capability.
+
+## What Sentry can capture
+
+A quick orientation so you know which signal file to open.
+
+| Signal | What it is |
+|---|---|
+| **Error Monitoring** | Unhandled exceptions and crashes, grouped into issues with stack traces, breadcrumbs, and context. The baseline — always set up first. |
+| **Tracing & Performance** | Distributed traces and spans across services and requests, showing where time goes and how a request flows end to end. |
+| **Profiling** | Function-level CPU/wall-clock samples tied to traces — which lines are slow. Requires tracing. |
+| **Logging** | Structured application logs sent to Sentry and correlated with errors and traces. |
+| **Metrics** | Counters, gauges, and distributions for operational metrics — request rates, queue depths, cache hit ratios, and other system-health signals. |
+| **Cron Monitoring** | Check-in code for scheduled/recurring jobs. |
+| **Session Replay** | A video-like reproduction of a user's session (browser and mobile) leading up to an error. |
+| **User Feedback** | A widget or API to collect user-submitted reports, optionally attached to an event. |
+| **AI / LLM Monitoring** | Spans, token usage, and tool calls for LLM SDKs (OpenAI, Anthropic, Vercel AI, LangChain, Google GenAI). |
+
+## How the references are structured
+
+Each SDK has a reference tree:
+
+    sdks/[sdk]/index.md          # overview, detect, install, init, feature catalog
+    sdks/[sdk]/error-monitoring.md
+    sdks/[sdk]/tracing.md
+    sdks/[sdk]/<signal>.md        # one file per supported signal
+
+Read `sdks/[sdk]/index.md` **first** — it owns detection, install, the recommended `init`, and a
+feature catalog table that links to each signal's file (and marks unsupported ones). Then read only
+the signal files you need. The exact format both files follow is documented in
+[`STRUCTURE.md`](STRUCTURE.md).
+
+## Detect the platform first
+
+Detect the platform from project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`,
+`*.csproj`, `build.gradle`, `pubspec.yaml`, etc.) using the catalog below, then open that SDK's
+`index.md` and follow it. Each `index.md` carries its own detection logic, prerequisites, and
+step-by-step configuration.
+
+### SDK catalog
+
+| Platform | SDK slug | Reference |
+|---|---|---|
+| Android | `android` | `sdks/android/index.md` |
+| browser JavaScript | `browser` | `sdks/browser/index.md` |
+| Cloudflare Workers and Pages | `cloudflare` | `sdks/cloudflare/index.md` |
+| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | `cocoa` | `sdks/cocoa/index.md` |
+| .NET | `dotnet` | `sdks/dotnet/index.md` |
+| Elixir | `elixir` | `sdks/elixir/index.md` |
+| Go | `go` | `sdks/go/index.md` |
+| NestJS | `nestjs` | `sdks/nestjs/index.md` |
+| Next.js | `nextjs` | `sdks/nextjs/index.md` |
+| Node.js, Bun, and Deno | `node` | `sdks/node/index.md` |
+| PHP | `php` | `sdks/php/index.md` |
+| Python | `python` | `sdks/python/index.md` |
+| Flutter and Dart | `flutter` | `sdks/flutter/index.md` |
+| React Native and Expo | `react-native` | `sdks/react-native/index.md` |
+| React | `react` | `sdks/react/index.md` |
+| React Router Framework | `react-router-framework` | `sdks/react-router-framework/index.md` |
+| TanStack Start React | `tanstack-start` | `sdks/tanstack-start/index.md` |
+| Ruby | `ruby` | `sdks/ruby/index.md` |
+| Svelte and SvelteKit | `svelte` | `sdks/svelte/index.md` |
+
+### Platform detection priority
+
+When multiple SDKs could match, prefer the more specific one:
+
+- **Android** (`build.gradle` with android plugin) → `android`
+- **Cloudflare** (`wrangler.toml` or `wrangler.jsonc`) → `cloudflare` over `node`
+- **NestJS** (`@nestjs/core`) → `nestjs` over `node`
+- **Next.js** → `nextjs` over `react` or `node`
+- **React Router Framework** (`@sentry/react-router` or `@react-router/*`) → `react-router-framework` over `react`
+- **TanStack Start React** (`@tanstack/react-start`) → `tanstack-start` over `react`
+- **Flutter** (`pubspec.yaml` with `flutter:` dependency or `sentry_flutter`) → `flutter`
+- **React Native** → `react-native` over `react`
+- **PHP** with Laravel or Symfony → `php`
+- **Elixir** (`mix.exs` detected) → `elixir`
+- **Node.js / Bun / Deno** without a specific framework → `node`
+- **Browser JS** (vanilla, jQuery, static sites) → `browser`
+- **No match** → direct the user to [Sentry Docs](https://docs.sentry.io/platforms/)
+
+### Quick lookup
+
+| Keywords | SDK slug |
+|---|---|
+| android, kotlin, java, jetpack compose | `android` |
+| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | `browser` |
+| cloudflare, cloudflare workers, cloudflare pages, wrangler, durable objects, d1 | `cloudflare` |
+| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | `cocoa` |
+| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | `dotnet` |
+| go, golang, gin, echo, fiber | `go` |
+| elixir, phoenix, plug, oban | `elixir` |
+| nestjs, nest | `nestjs` |
+| nextjs, next.js, next | `nextjs` |
+| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | `node` |
+| php, laravel, symfony | `php` |
+| python, django, flask, fastapi, celery, starlette | `python` |
+| flutter, dart, pubspec | `flutter` |
+| react native, expo | `react-native` |
+| react, react router, tanstack, redux, vite | `react` |
+| react-router framework, @sentry/react-router, @react-router/dev | `react-router-framework` |
+| tanstack start, @tanstack/react-start | `tanstack-start` |
+| ruby, rails, sinatra, sidekiq | `ruby` |
+| svelte, sveltekit | `svelte` |


### PR DESCRIPTION
Adds the top-level `index.md` and `STRUCTURE.md` for the per-SDK reference tree under `skills-next/references/sdks/`. This is the organizational scaffold for the skills-next SDK references; the individual per-SDK reference sets land in their own PRs.