### PR TITLE
feat(skills-next): add node SDK references

### DIFF
--- a/skills-next/references/sdks/node/ai-monitoring.md
+++ b/skills-next/references/sdks/node/ai-monitoring.md
@@ -1,0 +1,282 @@
+# AI Monitoring - Sentry Node.js SDK
+
+> Minimum SDK: `@sentry/node` >=10.61.0 (Gen AI span streaming is on by default at this version). OpenAI, Anthropic, LangChain, LangGraph, Google GenAI, Vercel AI SDK auto-instrument and are available since 10.53.0.
+
+## Prerequisites
+
+Tracing must be enabled - AI spans require an active trace:
+
+```typescript
+Sentry.init({
+  dsn: "...",
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+});
+```
+
+## Integration Matrix
+
+| Integration | Min Library | Auto-Enabled | Status |
+|-------------|-------------|-------------|--------|
+| OpenAI (`openai`) | openai 4.0+ | Yes | Stable |
+| Anthropic (`@anthropic-ai/sdk`) | 0.19.2+ | Yes | Stable |
+| Vercel AI SDK (`ai`) | ai 3.0+ | Yes* | Stable |
+| LangChain (`@langchain/core`) | 0.1.0+ | Yes | Stable |
+| LangGraph (`@langchain/langgraph`) | 0.1.0+ | Yes | Stable |
+| Google GenAI (`@google/genai`) | 1.0+ | Yes | Stable |
+
+*Vercel AI SDK requires `experimental_telemetry: { isEnabled: true }` on every call.
+
+## PII Control
+
+| `dataCollection.genAI` | `recordInputs` | Prompts captured? |
+|-------------------|-----------------|-------------------|
+| default on | `true` (default) | Yes |
+| `{ inputs: false }` | `true` | No |
+| default on | `false` | No |
+
+With `dataCollection`, genAI input/output capture is **on by default**. Supported integrations default `recordInputs`/`recordOutputs` to `true` (governed by `dataCollection.genAI`). To disable it, set `dataCollection: { genAI: { inputs: false, outputs: false } }`. Use integration-level options to opt out or override specific integrations.
+
+## Configuration Examples
+
+### Auto-enabled integrations
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+});
+// OpenAI, Anthropic, LangChain, LangGraph, Google GenAI activate automatically
+```
+
+### Explicit configuration with recordInputs/recordOutputs override
+
+```typescript
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+  integrations: [
+    Sentry.openAIIntegration(),
+    Sentry.vercelAIIntegration(),
+  ],
+});
+```
+
+### Vercel AI SDK per-call telemetry (required)
+
+```typescript
+await generateText({
+  model: openai("gpt-4.1"),
+  prompt: "Hello",
+  experimental_telemetry: { isEnabled: true, recordInputs: true, recordOutputs: true },
+});
+```
+
+### Browser / Next.js client-side (manual wrapping required)
+
+```typescript
+import OpenAI from "openai";
+import * as Sentry from "@sentry/nextjs"; // or @sentry/browser
+
+const openai = Sentry.instrumentOpenAiClient(new OpenAI());
+```
+
+## Manual Instrumentation - `gen_ai.*` Spans
+
+Use when the library isn't supported, or for wrapping custom AI logic.
+
+### `gen_ai.request` - LLM call
+
+```typescript
+await Sentry.startSpan({
+  op: "gen_ai.request",
+  name: "chat claude-sonnet-4-6",
+  attributes: { "gen_ai.request.model": "claude-sonnet-4-6" },
+}, async (span) => {
+  span.setAttribute("gen_ai.request.messages", JSON.stringify(messages));
+  const result = await myClient.chat(messages);
+  span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
+  span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+  return result;
+});
+```
+
+### `gen_ai.invoke_agent` - Agent lifecycle
+
+```typescript
+await Sentry.startSpan({
+  op: "gen_ai.invoke_agent",
+  name: "invoke_agent Weather Agent",
+  attributes: { "gen_ai.agent.name": "Weather Agent", "gen_ai.request.model": "claude-sonnet-4-6" },
+}, async (span) => {
+  const result = await myAgent.run(task);
+  span.setAttribute("gen_ai.usage.input_tokens", result.totalInputTokens);
+  span.setAttribute("gen_ai.usage.output_tokens", result.totalOutputTokens);
+  return result;
+});
+```
+
+### `gen_ai.execute_tool` - Tool/function call
+
+```typescript
+await Sentry.startSpan({
+  op: "gen_ai.execute_tool",
+  name: "execute_tool get_weather",
+  attributes: {
+    "gen_ai.tool.name": "get_weather",
+    "gen_ai.tool.type": "function",
+    "gen_ai.tool.input": JSON.stringify({ location: "Paris" }),
+  },
+}, async (span) => {
+  const result = await getWeather("Paris");
+  span.setAttribute("gen_ai.tool.output", JSON.stringify(result));
+  return result;
+});
+```
+
+
+## Span Attribute Reference
+
+### Common attributes
+
+| Attribute | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `gen_ai.request.model` | string | Yes | Model identifier (e.g., `claude-sonnet-4-6`, `gemini-2.5-flash`) |
+| `gen_ai.operation.name` | string | No | Human-readable operation label |
+| `gen_ai.agent.name` | string | No | Agent name (for agent spans) |
+
+### Model config attributes
+
+| Attribute | Type |
+|-----------|------|
+| `gen_ai.request.reasoning_effort` | string |
+
+### Content attributes (captured by default; gated by `dataCollection.genAI` + `recordInputs/recordOutputs`)
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `gen_ai.request.messages` | string | **JSON-stringified** message array |
+| `gen_ai.request.available_tools` | string | **JSON-stringified** tool definitions |
+| `gen_ai.response.text` | string | **JSON-stringified** response array |
+| `gen_ai.response.tool_calls` | string | **JSON-stringified** tool call array |
+
+> Span attributes only accept primitives - arrays/objects must be JSON-stringified.
+
+### Token usage attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `gen_ai.usage.input_tokens` | int | Total input tokens (including cached) |
+| `gen_ai.usage.input_tokens.cached` | int | Subset served from cache |
+| `gen_ai.usage.input_tokens.cache_write` | int | Tokens written to cache (Anthropic) |
+| `gen_ai.usage.output_tokens` | int | Total output tokens (including reasoning) |
+| `gen_ai.usage.output_tokens.reasoning` | int | Subset for chain-of-thought (o3, etc.) |
+| `gen_ai.usage.total_tokens` | int | Sum of input + output |
+
+> Cached and reasoning tokens are **subsets** of totals, not additive. Incorrect reporting produces wrong cost calculations.
+
+## Agent Workflow Hierarchy
+
+```
+Transaction
+└── gen_ai.invoke_agent  "Weather Agent"
+    ├── gen_ai.request      "chat claude-sonnet-4-6"
+    ├── gen_ai.execute_tool "get_weather"
+    ├── gen_ai.request      "chat claude-sonnet-4-6"     ← follow-up
+    └── gen_ai.execute_tool "format_report"
+```
+
+## Streaming
+
+| Integration | Streaming | Token counts in streams |
+|-------------|-----------|------------------------|
+| OpenAI | Yes | Requires `stream_options: { include_usage: true }` |
+| Anthropic | Yes | Automatic |
+| Vercel AI SDK | Yes | Automatic (with `experimental_telemetry`) |
+| LangChain | Yes | Tracked |
+| Manual `gen_ai.*` | Yes | Set token counts after stream completes |
+
+## Unsupported Providers
+
+| Provider | Workaround |
+|----------|-----------|
+| Cohere | Manual `gen_ai.*` spans |
+| AWS Bedrock | Manual `gen_ai.*` spans |
+| Mistral | Manual `gen_ai.*` spans |
+| Groq | Manual `gen_ai.*` spans |
+
+## Sampling Strategy
+
+If `tracesSampleRate` < 1.0, use a `tracesSampler` that keeps 100% of gen_ai-related transactions while sampling other traffic at a lower rate.
+
+## Conversation Tracking
+
+Link AI spans across turns into a chat-style timeline at **Explore > Conversations**.
+
+**Prerequisites:** `streamGenAiSpans` defaults to `true` (SDK >=10.61.0, so AI spans stream as standalone items) and genAI input/output capture enabled (on by default via `dataCollection`) — Conversations reconstructs the chat from input/output attributes, so without input/output capture the view will be empty.
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+// Set at the start of a conversation
+Sentry.setConversationId("conv_abc123");
+
+// All subsequent AI calls carry gen_ai.conversation.id: "conv_abc123"
+await openai.chat.completions.create({
+  model: "gpt-5.5",
+  messages: [{ role: "user", content: "Hello" }],
+});
+
+// Later turns in the same conversation are linked automatically
+await openai.chat.completions.create({
+  model: "gpt-5.5",
+  messages: [
+    { role: "user", content: "Hello" },
+    { role: "assistant", content: "Hi there!" },
+    { role: "user", content: "What's the weather?" },
+  ],
+});
+```
+
+A single conversation can span multiple traces (e.g., page refresh), and a single trace can contain multiple conversations.
+
+### User Attribution
+
+To populate the **User** column in Conversations, call `setUser` once per request or session before any AI calls:
+
+```typescript
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No AI spans appearing | Verify `tracesSampleRate > 0`; check SDK >=10.61.0 |
+| Token counts missing in streams | Add `stream_options: { include_usage: true }` (OpenAI) |
+| Vercel AI spans not tracked | Add `experimental_telemetry: { isEnabled: true }` per call |
+| Browser OpenAI not traced | Use `Sentry.instrumentOpenAiClient()` - auto-instrumentation is server-only |
+| Prompts not captured | genAI capture is on by default; ensure you haven't set `dataCollection: { genAI: { inputs: false } }`, or pass `recordInputs: true` explicitly |
+| AI Agents Dashboard empty | Ensure traces are being sent; check DSN and `tracesSampleRate` |
+| Wrong cost calculations | Cached/reasoning tokens are subsets of totals, not additions |
+| Conversations view empty | Ensure `streamGenAiSpans` is enabled (default since SDK 10.61.0), genAI capture is on (default; not disabled via `dataCollection: { genAI: { inputs: false } }`), and a conversation ID is set via `Sentry.setConversationId()` |
+| User column shows "Unknown" | Call `Sentry.setUser()` once per request or session |

--- a/skills-next/references/sdks/node/crons.md
+++ b/skills-next/references/sdks/node/crons.md
@@ -1,0 +1,406 @@
+# Crons / Job Monitoring — Sentry Node.js SDK
+
+> Minimum SDK: `@sentry/node` ≥7.51.1 (`captureCheckIn`, `withMonitor`)  
+> `instrumentNodeCron` / `instrumentCron`: ≥7.92.0  
+> `instrumentNodeSchedule`: ≥7.93.0  
+> `failureIssueThreshold` / `recoveryThreshold`: ≥8.7.0  
+> `isolateTrace` in `MonitorConfig`: ≥10.28.0  
+> Status: ✅ **Generally Available**
+
+---
+
+## Overview
+
+Sentry Crons (job monitoring) tracks whether scheduled tasks run on time, succeed, and complete within expected durations. Sentry will alert when a job:
+- Misses its scheduled start time (checkin margin exceeded)
+- Takes too long to complete (maxRuntime exceeded)
+- Fails (status `"error"`)
+
+---
+
+## Core API
+
+### `Sentry.captureCheckIn(checkIn, monitorConfig?)` → `string`
+
+```typescript
+// Three check-in shapes:
+
+// 1. Heartbeat — single-shot, no duration tracking
+Sentry.captureCheckIn({ monitorSlug: "my-job", status: "ok" });
+Sentry.captureCheckIn({ monitorSlug: "my-job", status: "error" });
+
+// 2. In-progress — signals job started, returns ID for completion
+const checkInId = Sentry.captureCheckIn({
+  monitorSlug: "my-job",
+  status: "in_progress",
+});
+
+// 3. Finished — completes an in-progress check-in
+Sentry.captureCheckIn({
+  checkInId,
+  monitorSlug: "my-job",
+  status: "ok",          // or "error"
+  duration: 12.3,        // optional, in seconds
+});
+```
+
+### `Sentry.withMonitor(slug, callback, monitorConfig?)` → `T`
+
+Wraps a sync or async function. Automatically sends `in_progress`, then `ok` on success or `error` on throw. Records duration automatically.
+
+```typescript
+// Simple form
+await Sentry.withMonitor("my-job", async () => {
+  await runJob();
+});
+
+// With monitor config
+await Sentry.withMonitor("my-job", async () => {
+  await runJob();
+}, {
+  schedule: { type: "crontab", value: "0 * * * *" },
+  checkinMargin: 5,
+  maxRuntime: 30,
+  timezone: "America/New_York",
+});
+```
+
+---
+
+## Check-In Status Values
+
+| Status        | Meaning                                           |
+|---------------|---------------------------------------------------|
+| `"in_progress"` | Job has started; Sentry waiting for completion  |
+| `"ok"`          | Job completed successfully                      |
+| `"error"`       | Job failed; triggers incident in Sentry         |
+
+---
+
+## Usage Patterns
+
+### Heartbeat (simplest — detect missed runs only)
+
+```typescript
+try {
+  await runMyJob();
+  Sentry.captureCheckIn({ monitorSlug: "my-cron-job", status: "ok" });
+} catch (err) {
+  Sentry.captureCheckIn({ monitorSlug: "my-cron-job", status: "error" });
+  throw err;
+}
+```
+
+### Start/Finish (tracks in-progress state and duration)
+
+```typescript
+const checkInId = Sentry.captureCheckIn({
+  monitorSlug: "my-cron-job",
+  status: "in_progress",
+});
+
+const startTime = Date.now();
+
+try {
+  await runMyJob();
+  Sentry.captureCheckIn({
+    checkInId,
+    monitorSlug: "my-cron-job",
+    status: "ok",
+    duration: (Date.now() - startTime) / 1000,  // seconds
+  });
+} catch (err) {
+  Sentry.captureCheckIn({
+    checkInId,
+    monitorSlug: "my-cron-job",
+    status: "error",
+    duration: (Date.now() - startTime) / 1000,
+  });
+  throw err;
+}
+```
+
+### `withMonitor` (recommended — handles all status logic)
+
+```typescript
+await Sentry.withMonitor("my-cron-job", async () => {
+  await runMyJob();
+});
+```
+
+---
+
+## Monitor Configuration (Upsert)
+
+Pass a `MonitorConfig` to create or update the monitor from code — no manual setup in Sentry UI needed. On first check-in the monitor is created; subsequent calls update it.
+
+```typescript
+interface MonitorConfig {
+  schedule: CrontabSchedule | IntervalSchedule;  // REQUIRED
+  checkinMargin?: number;          // minutes: grace period before "missed" alert
+  maxRuntime?: number;             // minutes: max execution before timeout alert
+  timezone?: string;               // IANA timezone, e.g. "America/New_York"
+  failureIssueThreshold?: number;  // consecutive failures before creating issue (≥8.7.0)
+  recoveryThreshold?: number;      // consecutive OKs before resolving issue (≥8.7.0)
+  isolateTrace?: boolean;          // new trace per monitor run (≥10.28.0)
+}
+```
+
+Pass as the **second argument** to `captureCheckIn()` or **third argument** to `withMonitor()`.
+
+---
+
+## Schedule Types
+
+**Crontab schedule:**
+
+```typescript
+{ type: "crontab", value: "* * * * *" }          // every minute
+{ type: "crontab", value: "0 * * * *" }          // every hour
+{ type: "crontab", value: "0 4 * * *" }          // daily at 4:00am
+{ type: "crontab", value: "0 9 * * MON-FRI" }    // weekdays at 9am
+{ type: "crontab", value: "0 0 1 * *" }          // first of every month
+{ type: "crontab", value: "*/15 * * * *" }       // every 15 minutes
+```
+
+**Interval schedule:**
+
+```typescript
+{ type: "interval", value: 1,  unit: "hour" }
+{ type: "interval", value: 30, unit: "minute" }
+{ type: "interval", value: 7,  unit: "day" }
+{ type: "interval", value: 1,  unit: "week" }
+// unit: "year" | "month" | "week" | "day" | "hour" | "minute"
+```
+
+---
+
+## Full Upsert Example
+
+```typescript
+const monitorConfig: Sentry.MonitorConfig = {
+  schedule: {
+    type: "crontab",
+    value: "0 4 * * *",           // daily at 4am
+  },
+  checkinMargin: 5,               // alert if not started within 5 min
+  maxRuntime: 30,                 // alert if running > 30 min
+  timezone: "America/New_York",
+  failureIssueThreshold: 3,       // create issue after 3 consecutive failures
+  recoveryThreshold: 2,           // resolve issue after 2 consecutive successes
+  isolateTrace: true,             // SDK ≥10.28.0
+};
+
+await Sentry.withMonitor("daily-report-job", generateDailyReport, monitorConfig);
+```
+
+---
+
+## Scheduler Library Integrations
+
+### `node-cron` (SDK ≥7.92.0)
+
+```typescript
+import cron from "node-cron";
+import * as Sentry from "@sentry/node";
+
+const cronWithCheckIn = Sentry.cron.instrumentNodeCron(cron);
+
+// `name` option is REQUIRED — becomes the monitor slug
+cronWithCheckIn.schedule(
+  "* * * * *",
+  () => { /* task */ },
+  { name: "my-cron-job" },
+);
+```
+
+### `cron` package — `CronJob` (SDK ≥7.92.0)
+
+```typescript
+import { CronJob } from "cron";
+import * as Sentry from "@sentry/node";
+
+// Monitor slug is bound at instrumentation time
+const CronJobWithCheckIn = Sentry.cron.instrumentCron(CronJob, "my-cron-job");
+
+// Constructor form
+const job = new CronJobWithCheckIn("* * * * *", () => { /* task */ });
+
+// Static factory form
+const job2 = CronJobWithCheckIn.from({
+  cronTime: "* * * * *",
+  onTick: () => { /* task */ },
+});
+```
+
+### `node-schedule` (SDK ≥7.93.0)
+
+```typescript
+import * as schedule from "node-schedule";
+import * as Sentry from "@sentry/node";
+
+const scheduleWithCheckIn = Sentry.cron.instrumentNodeSchedule(schedule);
+
+// First argument must be the job name (monitor slug)
+scheduleWithCheckIn.scheduleJob(
+  "my-cron-job",      // monitor slug — REQUIRED as first arg
+  "* * * * *",        // cron expression
+  () => { /* task */ },
+);
+```
+
+### Agenda (no official helper — use `withMonitor`)
+
+```typescript
+import Agenda from "agenda";
+import * as Sentry from "@sentry/node";
+
+const agenda = new Agenda({ db: { address: "mongodb://localhost/agenda" } });
+
+agenda.define("send-newsletter", async (job) => {
+  await Sentry.withMonitor(
+    "send-newsletter",
+    async () => { await sendNewsletterEmails(); },
+    {
+      schedule: { type: "crontab", value: "0 8 * * MON" },
+      maxRuntime: 60,
+      timezone: "UTC",
+    },
+  );
+});
+```
+
+### Bull / BullMQ (no official helper — use `withMonitor`)
+
+```typescript
+import { Worker } from "bullmq";
+import * as Sentry from "@sentry/node";
+
+const worker = new Worker("report-queue", async (job) => {
+  await Sentry.withMonitor(
+    "report-queue-processor",
+    async () => { await processReportJob(job.data); },
+    {
+      schedule: { type: "interval", value: 5, unit: "minute" },
+      maxRuntime: 10,
+      checkinMargin: 2,
+    },
+  );
+});
+```
+
+---
+
+## Library Integration Signatures
+
+```typescript
+// node-cron
+function instrumentNodeCron<T>(
+  lib: Partial<NodeCron> & T,
+  monitorConfig?: Pick<MonitorConfig, "isolateTrace">,
+): T;
+
+// cron package
+function instrumentCron<T>(
+  lib: T & CronJobConstructor,
+  monitorSlug: string,    // REQUIRED — single slug for all jobs from this constructor
+): T;
+
+// node-schedule
+function instrumentNodeSchedule<T>(
+  lib: T & NodeSchedule,
+): T;
+```
+
+---
+
+## Serverless / Lambda
+
+Check-ins are lost if the process terminates before flush. Always flush explicitly:
+
+```typescript
+export const handler = async (event: any) => {
+  const checkInId = Sentry.captureCheckIn({
+    monitorSlug: "lambda-scheduled-job",
+    status: "in_progress",
+  });
+
+  try {
+    await doWork(event);
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: "lambda-scheduled-job",
+      status: "ok",
+    });
+  } catch (err) {
+    Sentry.captureCheckIn({
+      checkInId,
+      monitorSlug: "lambda-scheduled-job",
+      status: "error",
+    });
+    throw err;
+  } finally {
+    // CRITICAL — flush before Lambda container freezes
+    await Sentry.flush(2000);
+  }
+};
+```
+
+For AWS Lambda, prefer `@sentry/aws-serverless` — it handles flushing automatically.
+
+---
+
+## Deno: Native Cron Integration
+
+Deno provides a built-in `Deno.cron()` API. Use `denoCronIntegration` to automatically monitor all native Deno crons:
+
+```typescript
+import * as Sentry from "@sentry/deno";
+
+Sentry.init({
+  dsn: Deno.env.get("SENTRY_DSN"),
+  integrations: [
+    Sentry.denoCronIntegration(),
+  ],
+});
+
+// Automatically monitored — no manual check-ins needed
+Deno.cron("daily-cleanup", "0 0 * * *", async () => {
+  await cleanupOldRecords();
+});
+
+Deno.cron("hourly-sync", "0 * * * *", async () => {
+  await syncExternalData();
+});
+```
+
+The integration intercepts `Deno.cron()` calls and wraps them with automatic `in_progress` → `ok`/`error` check-ins. The monitor slug is the first argument to `Deno.cron()`.
+
+> **Deno Deploy:** `Deno.cron()` runs natively on Deno Deploy. The integration works in both local Deno and Deno Deploy environments.
+
+> **Node.js and Bun:** `denoCronIntegration` is only available in `@sentry/deno`. For Node.js, use the `node-cron`, `cron`, or `node-schedule` library helpers above.
+
+---
+
+## Rate Limits
+
+- Maximum **6 check-ins per minute** per monitor + environment combination
+- Each environment (production, staging, etc.) counts separately
+- Dropped check-ins appear in Sentry's Usage Stats page
+
+---
+
+## Troubleshooting
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| Monitor not created in Sentry | No `MonitorConfig` passed | Pass `schedule` in `monitorConfig` (upsert) |
+| Check-ins not arriving | Process exits before flush | Add `await Sentry.flush(2000)` before exit |
+| `withMonitor` status wrong | Callback doesn't throw on failure | Ensure your job throws on error |
+| `node-cron` job not tracked | Missing `name` option | Add `{ name: "slug" }` to `cron.schedule()` options |
+| `instrumentNodeSchedule` slug not set | First arg is cron expression | First arg to `scheduleJob()` must be the job name |
+| `instrumentCron` tracking wrong job | Multiple jobs from one constructor | Each constructor call is for one slug; create multiple if needed |
+| Duration always `undefined` | Using heartbeat pattern | Switch to start/finish or `withMonitor` for duration tracking |
+| Missing `failureIssueThreshold` | SDK < 8.7.0 | Upgrade to ≥8.7.0 |
+| `isolateTrace` not recognized | SDK < 10.28.0 | Upgrade to ≥10.28.0 |
+| Rate limit errors in logs | > 6 check-ins/min per monitor | Reduce check-in frequency or consolidate environments |

--- a/skills-next/references/sdks/node/error-monitoring.md
+++ b/skills-next/references/sdks/node/error-monitoring.md
@@ -1,0 +1,1110 @@
+# Error Monitoring — Sentry Node.js SDK
+
+> Minimum SDK: `@sentry/node` ≥8.0.0  
+> NestJS integration: `@sentry/nestjs` ≥8.0.0  
+> Bun integration: `@sentry/bun` ≥8.0.0 (thin wrapper over `@sentry/node`)  
+> Deno integration: `npm:@sentry/deno` (Deno 2+)
+
+---
+
+## The Instrument-First Rule
+
+`@sentry/node` patches modules at import time via OpenTelemetry. The instrument file **must be loaded before everything else** — before your framework, before your database driver, before any HTTP client.
+
+```javascript
+// instrument.js — loaded first
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  release: "my-app@1.2.3",
+  environment: process.env.NODE_ENV ?? "production",
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+});
+```
+
+```javascript
+// app.js
+require("./instrument");  // MUST be line 1
+const express = require("express");
+// ...
+```
+
+**ESM (Node 18.19+ / 19.9+):**
+
+```javascript
+// instrument.mjs
+import * as Sentry from "@sentry/node";
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+```
+
+```bash
+# Launch with --import
+node --import ./instrument.mjs app.mjs
+# or:
+NODE_OPTIONS="--import ./instrument.mjs" npm start
+```
+
+---
+
+## What Is Captured Automatically
+
+| Error Type | Captured? | Mechanism |
+|-----------|-----------|-----------|
+| Uncaught exceptions | ✅ Yes | `process.on("uncaughtException")` |
+| Unhandled promise rejections | ✅ Yes | `process.on("unhandledRejection")` |
+| Framework errors (Express, Fastify, Koa, Hapi, Connect) | ✅ Yes | Error handler middleware (see below) |
+| NestJS non-HttpExceptions | ✅ Yes | `SentryGlobalFilter` |
+| Caught + re-thrown errors | ✅ Yes | Bubbles to global handler |
+| Caught + swallowed errors | ❌ No | Must call `captureException` manually |
+| `HttpException` in NestJS (4xx) | ❌ No | Treated as control flow by design |
+
+### The Core Rule
+
+> **"If you catch an error and don't re-throw it, Sentry never sees it."**
+
+```javascript
+// ✅ Auto-captured — unhandled, bubbles up
+throw new Error("Unhandled");
+
+// ✅ Auto-captured — re-thrown
+try {
+  await doSomething();
+} catch (err) {
+  throw err;
+}
+
+// ❌ NOT captured — swallowed by graceful return
+try {
+  await doSomething();
+} catch (err) {
+  return res.status(500).json({ error: "Failed" }); // ← add captureException!
+}
+
+// ✅ Manually captured
+try {
+  await doSomething();
+} catch (err) {
+  Sentry.captureException(err);
+  return res.status(500).json({ error: "Failed" });
+}
+```
+
+---
+
+## Framework Error Handler Placement
+
+**Critical: placement rules differ per framework. Getting this wrong silently misses errors.**
+
+| Framework | Function | Placement | Async? |
+|-----------|----------|-----------|--------|
+| Express | `setupExpressErrorHandler(app)` | **AFTER routes** | No |
+| Fastify | `setupFastifyErrorHandler(app)` | **BEFORE routes** | No |
+| Koa | `setupKoaErrorHandler(app)` | **FIRST middleware** | No |
+| Hapi | `setupHapiErrorHandler(server)` | Before routes | **YES — must `await`** |
+| Connect | `setupConnectErrorHandler(app)` | **BEFORE routes** | No |
+| NestJS | `SentryGlobalFilter` + `SentryModule.forRoot()` | AppModule providers | No |
+
+---
+
+## Express
+
+Error handler goes **after all routes**, before your own error handler.
+
+```javascript
+require("./instrument");
+const express = require("express");
+const Sentry = require("@sentry/node");
+
+const app = express();
+app.use(express.json());
+
+// ── Routes ──────────────────────────────────────────────────────
+app.get("/", (req, res) => res.json({ ok: true }));
+app.post("/orders", async (req, res, next) => {
+  try {
+    const result = await processOrder(req.body.orderId);
+    res.json(result);
+  } catch (err) {
+    next(err); // pass to error handlers
+  }
+});
+
+// ↓ Sentry AFTER routes, BEFORE your error handler
+Sentry.setupExpressErrorHandler(app);
+
+// Optional: capture only specific status codes
+// Sentry.setupExpressErrorHandler(app, {
+//   shouldHandleError(error) {
+//     return !error.status || parseInt(String(error.status)) >= 500;
+//   },
+// });
+
+// ── Your error handler (runs after Sentry) ──────────────────────
+app.use((err, req, res, next) => {
+  res.status(err.status || 500).json({ error: "Internal Server Error" });
+});
+
+app.listen(3000);
+```
+
+---
+
+## Fastify
+
+Error handler goes **before routes**. Internally registers a Fastify plugin using `onError` lifecycle hook.
+
+```javascript
+require("./instrument");
+const Fastify = require("fastify");
+const Sentry = require("@sentry/node");
+
+const app = Fastify({ logger: true });
+
+// ↓ Sentry BEFORE routes
+Sentry.setupFastifyErrorHandler(app);
+
+// Optional: customize which errors are captured
+// Sentry.setupFastifyErrorHandler(app, {
+//   shouldHandleError(error, request, reply) {
+//     return reply.statusCode >= 500;
+//   },
+// });
+
+app.get("/", async (request, reply) => ({ hello: "world" }));
+app.get("/debug-sentry", async () => {
+  throw new Error("Test Fastify error!");
+});
+
+app.listen({ port: 3000 });
+```
+
+---
+
+## Koa
+
+Error handler goes as the **first `app.use()` call**, before any route.
+
+```javascript
+require("./instrument");
+const Koa = require("koa");
+const Router = require("@koa/router");
+const Sentry = require("@sentry/node");
+
+const app = new Koa();
+const router = new Router();
+
+// ↓ Sentry FIRST middleware
+Sentry.setupKoaErrorHandler(app);
+
+router.get("/", async (ctx) => { ctx.body = { ok: true }; });
+router.get("/debug-sentry", async () => { throw new Error("Test Koa error!"); });
+
+app.use(router.routes());
+app.use(router.allowedMethods());
+app.listen(3000);
+```
+
+> **Note:** `setupKoaErrorHandler` has no `shouldHandleError` option — it captures all errors.
+
+---
+
+## Hapi
+
+`setupHapiErrorHandler` is **async** — you must `await` it. Internally registers a Hapi lifecycle extension on `onPreResponse`.
+
+```javascript
+require("./instrument");
+const Sentry = require("@sentry/node");
+const Hapi = require("@hapi/hapi");
+
+const init = async () => {
+  const server = Hapi.server({ port: 3000, host: "localhost" });
+
+  // ↓ MUST be awaited!
+  await Sentry.setupHapiErrorHandler(server);
+
+  server.route({
+    method: "GET",
+    path: "/debug-sentry",
+    handler: () => { throw new Error("Test Hapi error!"); },
+  });
+
+  await server.start();
+  console.log("Server running on %s", server.info.uri);
+};
+
+init();
+```
+
+> **Caution:** Forgetting `await` silently skips Sentry registration. No error is thrown.
+
+---
+
+## Connect
+
+Error handler goes **before routes**.
+
+```javascript
+require("./instrument");
+const connect = require("connect");
+const Sentry = require("@sentry/node");
+
+const app = connect();
+
+// ↓ Sentry BEFORE routes
+Sentry.setupConnectErrorHandler(app);
+
+app.use("/", (req, res, next) => {
+  res.setHeader("Content-Type", "application/json");
+  res.end(JSON.stringify({ hello: "world" }));
+});
+
+app.use("/debug-sentry", (req, res, next) => {
+  throw new Error("Test Connect error!");
+});
+
+// Your own error handler (after Sentry)
+app.use((err, req, res, next) => {
+  res.statusCode = err.status || 500;
+  res.end("Internal Server Error");
+});
+
+require("http").createServer(app).listen(3000);
+```
+
+---
+
+## NestJS
+
+> **NestJS has a dedicated skill: [`nestjs`](../nestjs/index.md)**
+>
+> NestJS uses a separate package (`@sentry/nestjs`) with NestJS-native error handling
+> via `SentryGlobalFilter`, `SentryModule.forRoot()`, `@SentryExceptionCaptured` decorator,
+> and GraphQL/Microservices support. Load that skill for complete NestJS error monitoring
+> setup including `HttpException` filtering, custom filters, and background job isolation.
+
+---
+
+## Vanilla Node.js (`http` Module)
+
+No framework integration needed — rely on the global `uncaughtException` / `unhandledRejection` handlers plus manual `captureException` for caught errors.
+
+```javascript
+require("./instrument");
+const http = require("http");
+const Sentry = require("@sentry/node");
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const data = await handleRequest(req);
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(data));
+  } catch (err) {
+    Sentry.captureException(err, {
+      tags: { path: req.url, method: req.method },
+    });
+    res.writeHead(500, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "Internal Server Error" }));
+  }
+});
+
+server.listen(3000);
+```
+
+---
+
+## `captureException` — Full API
+
+```typescript
+function captureException(
+  exception: unknown,
+  captureContext?: CaptureContext | ((scope: Scope) => Scope)
+): string; // returns EventId
+
+type CaptureContext = Scope | Partial<ScopeContext> | ((scope: Scope) => Scope);
+
+interface ScopeContext {
+  user?: User;
+  level?: "fatal" | "error" | "warning" | "log" | "info" | "debug";
+  extra?: Record<string, unknown>;
+  tags?: Record<string, Primitive>;
+  contexts?: Record<string, Record<string, unknown>>;
+  fingerprint?: string[];
+}
+```
+
+```javascript
+// Basic
+Sentry.captureException(new Error("Something broke"));
+
+// With inline CaptureContext
+Sentry.captureException(error, {
+  level: "fatal",
+  tags: { order_id: orderId, payment_method: "stripe" },
+  user: { id: req.user.id, email: req.user.email },
+  extra: { requestBody: req.body, retryCount: 3 },
+  fingerprint: ["order-processing-failure", orderId],
+  contexts: {
+    order: { id: orderId, total: 99.99, currency: "USD" },
+  },
+});
+
+// Scope callback form — most flexible
+Sentry.captureException(error, (scope) => {
+  scope.setTag("component", "payment");
+  scope.setLevel("error");
+  scope.setTransactionName("POST /orders");
+  return scope; // must return scope
+});
+
+// Non-Error values are accepted (but stack traces may be synthetic)
+Sentry.captureException("something broke");
+Sentry.captureException({ code: "AUTH_FAILED", userId: 42 });
+
+// Capture and use the returned event ID
+const eventId = Sentry.captureException(err);
+res.status(500).json({ error: "Something went wrong", eventId });
+```
+
+---
+
+## `captureMessage`
+
+```typescript
+function captureMessage(
+  message: string,
+  captureContext?: CaptureContext | SeverityLevel
+): string; // returns EventId
+
+type SeverityLevel = "fatal" | "error" | "warning" | "log" | "info" | "debug";
+```
+
+```javascript
+// Basic
+Sentry.captureMessage("Payment gateway timeout");
+
+// With severity level shorthand
+Sentry.captureMessage("Disk usage above 90%", "warning");
+Sentry.captureMessage("Cache miss rate critical", "fatal");
+Sentry.captureMessage("User signed up", "info");
+
+// With full context
+Sentry.captureMessage("Rate limit exceeded", {
+  level: "warning",
+  tags: { service: "api-gateway", region: "us-east-1" },
+  user: { id: req.user.id },
+  extra: { requestsPerMinute: 1500, limit: 1000 },
+  fingerprint: ["rate-limit", req.headers["x-client-id"]],
+});
+```
+
+---
+
+## Scope Management (v8+ — Hub Removed)
+
+In SDK v8, `Hub` is removed. Use the three scope types directly.
+
+| Scope | Accessor | Lifetime | Use For |
+|-------|----------|----------|---------|
+| **Global** | `Sentry.getGlobalScope()` | Process lifetime | App version, region, build ID |
+| **Isolation** | `Sentry.getIsolationScope()` | Per HTTP request (auto-forked) | User identity, request metadata |
+| **Current** | `Sentry.getCurrentScope()` | Narrow/temporary | Per-operation context |
+
+**Priority (current wins):** Current > Isolation > Global
+
+```javascript
+// All Sentry.setXXX() top-level methods write to the ISOLATION scope
+Sentry.setTag("key", "value");
+// identical to:
+Sentry.getIsolationScope().setTag("key", "value");
+
+// Global scope — survives the lifetime of the process
+Sentry.getGlobalScope().setTag("server_region", "eu-west-1");
+Sentry.getGlobalScope().setContext("runtime", {
+  name: "node",
+  version: process.version,
+});
+```
+
+### `withScope` — Temporary Per-Capture Context
+
+Primary tool for adding context to a single capture without contaminating other events.
+
+```javascript
+Sentry.withScope((scope) => {
+  scope.setTag("payment_method", "stripe");
+  scope.setFingerprint(["stripe-payment-error"]);
+  scope.setLevel("error");
+  scope.setUser({ id: req.user.id });
+  scope.setContext("cart", { items: req.body.items.length });
+  scope.addBreadcrumb({ category: "payment", message: "Attempt #3", level: "info" });
+  Sentry.captureException(stripeError);
+  // All above ONLY applies to this one capture
+});
+```
+
+### `withIsolationScope` — Full Isolation (Background Jobs)
+
+Use for background jobs, workers, and queue processors where you need a completely clean scope.
+
+```javascript
+Sentry.withIsolationScope(async (scope) => {
+  scope.setUser({ id: job.userId });
+  scope.setTag("job_type", job.type);
+  scope.setTag("job_id", job.id);
+  await processJob(job); // all events inside are fully isolated from other jobs
+});
+```
+
+### Scope Decision Guide
+
+| Goal | API |
+|------|-----|
+| Data on ALL events (app version, build ID) | `Sentry.getGlobalScope().setTag(...)` |
+| Current request data | `Sentry.setTag(...)` (writes to isolation scope) |
+| One specific capture only | `Sentry.withScope((scope) => { ... })` |
+| Background job / worker | `Sentry.withIsolationScope(async (scope) => { ... })` |
+| Inline on a single event | Second arg to `captureException(err, { tags: {...} })` |
+
+---
+
+## Context Enrichment
+
+### `setTag` / `setTags` — Indexed, Searchable
+
+Tags are **indexed** — use them for filtering, grouping, and alerting. Key: max 32 chars, `[a-zA-Z0-9_.:−]`. Value: max 200 chars.
+
+```javascript
+Sentry.setTag("db_region", "us-east-1");
+Sentry.setTag("feature_flag_new_ui", true);
+Sentry.setTags({
+  service: "checkout",
+  version: "2.1.4",
+  region: "eu",
+});
+```
+
+### `setContext` — Structured, Non-Searchable
+
+Attaches structured data visible in the issue detail view. Not indexed. Normalized to 3 levels deep. The `type` key is reserved — don't use it.
+
+```javascript
+Sentry.setContext("order", {
+  id: orderId,
+  total: 99.99,
+  currency: "USD",
+  coupon: "SAVE20",
+});
+Sentry.setContext("database", {
+  host: "postgres.internal",
+  query_duration_ms: 4523,
+  active_connections: 19,
+});
+Sentry.setContext("order", null); // clear it
+```
+
+### `setUser` — User Identity
+
+```javascript
+// On login (writes to isolation scope — safe per-request)
+Sentry.setUser({
+  id: user.id,
+  email: user.email,
+  username: user.displayName,
+  subscription_tier: "pro", // custom fields accepted
+});
+
+// On logout
+Sentry.setUser(null);
+
+// Express middleware pattern — set per-request
+app.use((req, res, next) => {
+  if (req.user) {
+    Sentry.setUser({ id: req.user.id, email: req.user.email });
+  }
+  next();
+});
+```
+
+### `setExtra` / `setExtras` — Arbitrary Data
+
+Non-indexed supplementary data. Prefer `setContext` for structured objects.
+
+```javascript
+Sentry.setExtra("server_memory_mb", process.memoryUsage().heapUsed / 1024 / 1024);
+Sentry.setExtras({
+  uptime: process.uptime(),
+  node_version: process.version,
+});
+```
+
+### Tags vs Context vs Extra
+
+| Feature | Searchable? | Indexed? | Best For |
+|---------|-----------|---------|---------|
+| **Tags** | ✅ Yes | ✅ Yes | Filtering, grouping, alerting |
+| **Context** | ❌ No | ❌ No | Structured debug info (nested objects) |
+| **Extra** | ❌ No | ❌ No | Arbitrary debug values |
+| **User** | ✅ Partially | ✅ Yes | User attribution and filtering |
+
+---
+
+## Breadcrumbs
+
+### Automatic Breadcrumbs (Zero Config)
+
+| Type | What's Captured |
+|------|----------------|
+| `http` | Outgoing HTTP requests (URL, method, status code) |
+| `console` | `console.log`, `warn`, `error` calls |
+| `db` | Database queries (via OTel auto-instrumentation) |
+
+### Manual Breadcrumbs
+
+```javascript
+Sentry.addBreadcrumb({
+  category: "auth",
+  message: `User ${user.email} authenticated`,
+  level: "info",
+  data: { method: "oauth2", provider: "google" },
+});
+
+Sentry.addBreadcrumb({
+  type: "http",
+  category: "http",
+  data: {
+    method: "POST",
+    url: "https://api.stripe.com/v1/charges",
+    status_code: 402,
+  },
+  level: "warning",
+});
+
+Sentry.addBreadcrumb({
+  type: "query",
+  category: "db.query",
+  message: "SELECT * FROM orders WHERE user_id = ?",
+  data: { db: "postgres", duration_ms: 42 },
+});
+```
+
+### Breadcrumb Properties
+
+| Key | Type | Values |
+|-----|------|--------|
+| `type` | string | `"default"` \| `"debug"` \| `"error"` \| `"info"` \| `"http"` \| `"navigation"` \| `"query"` \| `"ui"` \| `"user"` |
+| `category` | string | Dot-notation: `"auth"`, `"db.query"`, `"job.start"` |
+| `message` | string | Human-readable description |
+| `level` | string | `"fatal"` \| `"error"` \| `"warning"` \| `"log"` \| `"info"` \| `"debug"` |
+| `timestamp` | number | Unix timestamp (auto-set if omitted) |
+| `data` | object | Arbitrary key/value data |
+
+---
+
+## `beforeSend` and Filtering Hooks
+
+### `beforeSend` — Modify or Drop Error Events
+
+Last chance to modify or drop events. Runs after all event processors. Return `null` to drop. **Only one `beforeSend` is allowed** — use `addEventProcessor` for multiple processors.
+
+```javascript
+Sentry.init({
+  beforeSend(event, hint) {
+    const err = hint.originalException;
+
+    // Drop in development
+    if (process.env.NODE_ENV === "development") return null;
+
+    // Drop specific error types
+    if (err instanceof ConnectionResetError) return null;
+    if (err?.message?.includes("ECONNRESET")) return null;
+
+    // Scrub PII from user object
+    if (event.user) {
+      delete event.user.email;
+      delete event.user.ip_address;
+    }
+
+    // Scrub sensitive keys from request body
+    if (event.request?.data) {
+      try {
+        const body = JSON.parse(event.request.data as string);
+        delete body.password;
+        delete body.token;
+        event.request.data = JSON.stringify(body);
+      } catch {}
+    }
+
+    // Custom fingerprint from error properties
+    if (err instanceof ApiError) {
+      event.fingerprint = ["api-error", String(err.statusCode), err.endpoint];
+    }
+
+    // Filter noisy breadcrumbs
+    if (event.breadcrumbs?.values) {
+      event.breadcrumbs.values = event.breadcrumbs.values.filter(
+        (bc) => !bc.data?.url?.includes("/health")
+      );
+    }
+
+    return event;
+  },
+
+  // Drop specific transaction/span events
+  beforeSendTransaction(event) {
+    if (event.transaction === "GET /health") return null;
+    if (event.transaction === "GET /ping") return null;
+    return event;
+  },
+});
+```
+
+### `beforeBreadcrumb` — Filter or Mutate Breadcrumbs
+
+```javascript
+Sentry.init({
+  beforeBreadcrumb(breadcrumb, hint) {
+    // Drop health-check HTTP requests
+    if (
+      breadcrumb.type === "http" &&
+      breadcrumb.data?.url?.includes("/health")
+    ) {
+      return null;
+    }
+
+    // Redact auth tokens from URLs
+    if (breadcrumb.type === "http" && breadcrumb.data?.url) {
+      try {
+        const url = new URL(breadcrumb.data.url);
+        url.searchParams.delete("token");
+        url.searchParams.delete("api_key");
+        breadcrumb.data.url = url.toString();
+      } catch {}
+    }
+
+    return breadcrumb;
+  },
+  maxBreadcrumbs: 50, // default: 100
+});
+```
+
+### `ignoreErrors` — Pattern-Based Filtering
+
+```javascript
+Sentry.init({
+  ignoreErrors: [
+    "Non-Error exception captured",
+    /^ECONNRESET/,
+    /^ETIMEDOUT/,
+    /^socket hang up/,
+  ],
+  ignoreTransactions: [
+    "GET /health",
+    "GET /ping",
+    "GET /metrics",
+    /^GET \/internal\//,
+  ],
+});
+```
+
+---
+
+## Fingerprinting and Custom Grouping
+
+All events have a `fingerprint` array. Events with the same fingerprint group into the same Sentry issue.
+
+### Per-Capture Fingerprinting
+
+```javascript
+Sentry.captureException(error, {
+  fingerprint: ["payment-declined", req.body.payment_method],
+});
+```
+
+### `withScope` Fingerprinting
+
+```javascript
+Sentry.withScope((scope) => {
+  scope.setFingerprint([req.method, req.path, String(err.statusCode)]);
+  Sentry.captureException(err);
+});
+```
+
+### `beforeSend` Fingerprinting (Global Rules)
+
+```javascript
+Sentry.init({
+  beforeSend(event, hint) {
+    const err = hint.originalException;
+
+    // All DB connection errors → one group
+    if (err instanceof DatabaseConnectionError) {
+      event.fingerprint = ["database-connection-error"];
+    }
+
+    // Group ApiErrors by status + endpoint
+    if (err instanceof ApiError) {
+      event.fingerprint = ["api-error", String(err.statusCode), err.endpoint];
+    }
+
+    // Extend Sentry's default algorithm (keep stack-trace hash + add dimension)
+    if (err?.code) {
+      event.fingerprint = ["{{ default }}", err.code];
+    }
+
+    return event;
+  },
+});
+```
+
+### Template Variables
+
+| Variable | Description |
+|----------|-------------|
+| `{{ default }}` | Sentry's normally computed hash — extend rather than replace |
+| `{{ transaction }}` | Current transaction name |
+| `{{ function }}` | Top function in stack trace |
+| `{{ type }}` | Exception type name |
+
+---
+
+## Event Processors
+
+Unlike `beforeSend` (one allowed), multiple event processors can be registered. Order is not guaranteed. `beforeSend` always runs last.
+
+```javascript
+// Runs on every event — enrich with deploy metadata
+Sentry.addEventProcessor((event, hint) => {
+  event.tags = {
+    ...event.tags,
+    git_sha: process.env.GIT_SHA ?? "unknown",
+    deployed_by: process.env.DEPLOY_USER ?? "unknown",
+  };
+  return event;
+});
+
+// Drop events with a custom ignore flag
+Sentry.addEventProcessor((event, hint) => {
+  if ((hint.originalException as any)?.ignore_in_sentry === true) return null;
+  return event;
+});
+
+// Scope-level processor (only inside withScope callback)
+Sentry.withScope((scope) => {
+  scope.addEventProcessor((event) => {
+    event.tags = { ...event.tags, batch_job: "true" };
+    return event;
+  });
+  Sentry.captureException(new Error("job failed"));
+});
+```
+
+**`addEventProcessor` vs `beforeSend`:**
+
+| | `addEventProcessor` | `beforeSend` |
+|---|---|---|
+| Count | Unlimited | One only |
+| Order | Undefined (before `beforeSend`) | Always last |
+| Async | ✅ Yes | ✅ Yes |
+| Drop events | Return `null` | Return `null` |
+
+---
+
+## `requestDataIntegration` — Per-Request Data
+
+Auto-enabled. Attaches HTTP request data to all events during a request. Each framework auto-forks an isolation scope per request via OpenTelemetry `AsyncLocalStorage` — concurrent requests stay separate.
+
+| Field | Captured | Notes |
+|-------|----------|-------|
+| `url` | ✅ Always | Full request URL |
+| `method` | ✅ Always | GET, POST, etc. |
+| `headers` | ✅ Always | Auth header scrubbed automatically |
+| `query_string` | ✅ Always | URL query params |
+| `data` (body) | ✅ Default on | Controlled by `dataCollection` (`httpBodies`); set to `[]` to opt out |
+| `cookies` | ✅ Default on | Controlled by `dataCollection` (`cookies`); set to `false` to opt out |
+| `ip_address` | ✅ Default on | Controlled by `dataCollection` (`userInfo`); set to `false` to opt out |
+
+```javascript
+Sentry.init({
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+  integrations: [
+    Sentry.requestDataIntegration({
+      include: {
+        cookies: true,
+        data: true,         // request body
+        headers: true,
+        ip: true,
+        query_string: true,
+        url: true,
+        user: { id: true, username: true, email: false },
+      },
+    }),
+  ],
+});
+```
+
+---
+
+## Error Chains
+
+`linkedErrorsIntegration` is auto-enabled and follows the standard `Error.cause` chain.
+
+```javascript
+// Standard Error.cause — captured automatically
+try {
+  await connectToDatabase();
+} catch (dbError) {
+  throw new Error("Failed to process order", { cause: dbError });
+  // Sentry captures BOTH errors as a chain
+}
+
+// Configure depth (default: 5)
+Sentry.init({
+  integrations: [
+    Sentry.linkedErrorsIntegration({ key: "cause", limit: 5 }),
+  ],
+});
+```
+
+### `extraErrorDataIntegration` — Custom Error Properties
+
+Captures non-standard properties on Error subclasses:
+
+```javascript
+Sentry.init({
+  integrations: [Sentry.extraErrorDataIntegration({ depth: 3 })],
+});
+
+class HttpError extends Error {
+  constructor(message, response) {
+    super(message);
+    this.statusCode = response.status;    // captured in extras
+    this.responseBody = response.body;    // captured in extras
+    this.endpoint = response.url;         // captured in extras
+  }
+}
+```
+
+---
+
+## Lifecycle: Flush Before Shutdown
+
+`@sentry/node` batches events and sends asynchronously. Always flush before process exit to avoid losing the last events.
+
+```javascript
+// Graceful shutdown — HTTP server
+process.on("SIGTERM", async () => {
+  server.close(async () => {
+    await Sentry.flush(2000); // wait up to 2s for queue to drain
+    process.exit(0);
+  });
+});
+
+// Serverless (Lambda, Cloud Functions) — close disables SDK after flush
+export const handler = async (event) => {
+  try {
+    return await processEvent(event);
+  } catch (err) {
+    Sentry.captureException(err);
+    await Sentry.close(2000); // flush + disable before function freezes
+    throw err;
+  }
+};
+```
+
+---
+
+## `Sentry.init()` — Error-Relevant Options
+
+```typescript
+Sentry.init({
+  // Identity
+  dsn?: string;                    // also: SENTRY_DSN env var
+  release?: string;                // "my-app@1.2.3+abc123"
+  environment?: string;            // default: "production"
+  serverName?: string;             // hostname
+  enabled?: boolean;               // default: true
+
+  // Sampling
+  sampleRate?: number;             // 0.0–1.0 error event sample rate
+  tracesSampleRate?: number;       // 0.0–1.0 transaction sample rate
+
+  // Data limits
+  maxBreadcrumbs?: number;         // default: 100
+  maxValueLength?: number;         // truncate long strings
+  normalizeDepth?: number;         // default: 3
+
+  // Privacy
+  dataCollection?: DataCollectionOptions; // omitted => falls back to sendDefaultPii (conservative); pass an object (even {}) to enable permissive collection, then opt out per category
+
+  // Filtering
+  ignoreErrors?: Array<string | RegExp>;
+  ignoreTransactions?: Array<string | RegExp>;
+
+  // Hooks
+  beforeSend?: (event: Event, hint: EventHint) => Event | null;
+  beforeSendTransaction?: (event: Event, hint: EventHint) => Event | null;
+  beforeBreadcrumb?: (breadcrumb: Breadcrumb, hint?: BreadcrumbHint) => Breadcrumb | null;
+
+  // Node-specific
+  enableLogs?: boolean;             // default: false — Sentry.logger.*
+  attachStacktrace?: boolean;       // add stack traces to captureMessage
+  includeLocalVariables?: boolean;  // include local vars in stack frames
+  onFatalError?: (error: Error) => void;
+  shutdownTimeout?: number;         // default: 2000ms
+});
+```
+
+---
+
+## Bun
+
+`@sentry/bun` is a thin wrapper over `@sentry/node`. The API is identical — use `--preload` instead of `require("./instrument")` first.
+
+```typescript
+// instrument.ts
+import * as Sentry from "@sentry/bun";
+
+Sentry.init({
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+});
+```
+
+```bash
+bun --preload ./instrument.ts server.ts
+```
+
+For `Bun.serve()`:
+
+```typescript
+import * as Sentry from "@sentry/bun";
+
+const server = Bun.serve({
+  port: 3000,
+  fetch(request) {
+    return new Response("Hello from Bun!");
+  },
+  error(error) {
+    Sentry.captureException(error); // manual — no setupErrorHandler for Bun.serve
+    return new Response("Internal Server Error", { status: 500 });
+  },
+});
+```
+
+> **Profiling:** `@sentry/profiling-node` uses a native addon — incompatible with Bun's runtime. Omit `nodeProfilingIntegration()` in Bun apps.
+
+---
+
+## Deno
+
+```typescript
+// instrument.ts
+import * as Sentry from "npm:@sentry/deno";
+
+Sentry.init({
+  dsn: "https://examplePublicKey@o0.ingest.sentry.io/0",
+  tracesSampleRate: 1.0,
+});
+```
+
+```typescript
+// server.ts
+import "../instrument.ts";
+import * as Sentry from "npm:@sentry/deno";
+
+Deno.serve({ port: 3000 }, async (request) => {
+  try {
+    return new Response("Hello from Deno!");
+  } catch (error) {
+    Sentry.captureException(error);
+    return new Response("Internal Server Error", { status: 500 });
+  }
+});
+```
+
+> **Requirements:** Deno 2+. Run with `--allow-net --allow-env --allow-read`. No `setupExpressErrorHandler` equivalent — use `try/catch` + `captureException`.
+
+---
+
+## Quick Reference
+
+```javascript
+// Init
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+
+// Capture
+Sentry.captureException(new Error("oops"));
+Sentry.captureException(err, { tags: { source: "api" }, level: "fatal" });
+Sentry.captureMessage("Something happened", "warning");
+
+// Context (→ isolation scope, auto-forked per request)
+Sentry.setUser({ id: 1, email: "user@example.com" });
+Sentry.setTag("region", "us-east");
+Sentry.setTags({ service: "checkout", version: "2.0" });
+Sentry.setContext("cart", { items: 3, total: 49.99 });
+Sentry.addBreadcrumb({ category: "auth", message: "login", level: "info" });
+
+// Scoped capture (temporary context, one event only)
+Sentry.withScope((scope) => {
+  scope.setTag("temp_tag", "only-this-event");
+  scope.setFingerprint(["my-custom-group"]);
+  scope.setLevel("warning");
+  Sentry.captureException(err);
+});
+
+// Background job isolation
+await Sentry.withIsolationScope(async (scope) => {
+  scope.setUser({ id: job.userId });
+  await processJob(job);
+});
+
+// Global (all events, process lifetime)
+Sentry.getGlobalScope().setTag("app", "my-api");
+
+// Framework error handlers — placement matters!
+Sentry.setupExpressErrorHandler(app);          // Express: AFTER routes
+Sentry.setupFastifyErrorHandler(app);          // Fastify: BEFORE routes
+Sentry.setupKoaErrorHandler(app);              // Koa: FIRST middleware
+await Sentry.setupHapiErrorHandler(server);    // Hapi: BEFORE routes, MUST await
+Sentry.setupConnectErrorHandler(app);          // Connect: BEFORE routes
+
+// Shutdown
+await Sentry.flush(2000);
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Errors not appearing in Sentry | `instrument.js` loaded too late | Ensure it's the first `require()` or loaded via `--import` / `--preload` before app code |
+| Express errors not captured | `setupExpressErrorHandler` placed before routes | Move it **after** all route definitions |
+| Fastify errors not captured | `setupFastifyErrorHandler` placed after routes | Move it **before** route definitions (opposite of Express) |
+| Hapi error handler silently fails | `setupHapiErrorHandler` not awaited | Must `await Sentry.setupHapiErrorHandler(server)` — it's the only async handler |
+| NestJS `HttpException` not captured | Intentional — `SentryGlobalFilter` skips control flow exceptions | Create a custom filter extending `SentryGlobalFilter` and override `catch()` to capture `HttpException` if desired |
+| `setUser()` leaks between requests | Using global scope for user data | Use `Sentry.setUser()` (isolation scope) — it's auto-forked per request by framework integrations |
+| `withScope` changes persisting | Wrong scope layer | `withScope` creates a temporary current scope — changes don't survive the callback. Use `setTag()` for request-lifetime data |
+| `beforeSend` returning wrong type | Not returning `event` or `null` | `beforeSend` must return the event object or `null` to drop — `undefined` causes silent failures |
+| Breadcrumbs not showing | `maxBreadcrumbs: 0` | Check init config — default is 100; set to desired max |
+| Duplicate error events | Multiple capture paths | Ensure only one handler captures each error — e.g., don't both re-throw and call `captureException` |
+| Stack traces show minified code | Source maps not uploaded | Configure `@sentry/cli` sourcemap upload in your build pipeline |

--- a/skills-next/references/sdks/node/index.md
+++ b/skills-next/references/sdks/node/index.md
@@ -1,0 +1,884 @@
+# Sentry Node.js / Bun / Deno SDK
+
+Opinionated wizard that scans your project and guides you through complete Sentry setup for server-side JavaScript and TypeScript runtimes: Node.js, Bun, and Deno.
+
+> **NestJS?** Use [[`nestjs`](../nestjs/index.md)](../nestjs/index.md) instead — it uses `@sentry/nestjs` with NestJS-native decorators and filters.
+> **Next.js?** Use [[`nextjs`](../nextjs/index.md)](../nextjs/index.md) instead — it handles the three-runtime architecture (browser, server, edge).
+
+> **Note:** SDK versions below reflect current Sentry docs at time of writing (`@sentry/node` ≥10.42.0, `@sentry/bun` ≥10.42.0, `@sentry/deno` ≥10.42.0).
+> Always verify against [docs.sentry.io/platforms/javascript/guides/node/](https://docs.sentry.io/platforms/javascript/guides/node/) before implementing.
+
+---
+
+## Phase 1: Detect
+
+Run these commands to identify the runtime, framework, and existing Sentry setup:
+
+```bash
+# Detect runtime
+bun --version 2>/dev/null && echo "Bun detected"
+deno --version 2>/dev/null && echo "Deno detected"
+node --version 2>/dev/null && echo "Node.js detected"
+
+# Detect existing Sentry packages
+cat package.json 2>/dev/null | grep -E '"@sentry/'
+cat deno.json deno.jsonc 2>/dev/null | grep -i sentry
+
+# Detect Node.js framework
+cat package.json 2>/dev/null | grep -E '"express"|"fastify"|"@hapi/hapi"|"koa"|"@nestjs/core"|"connect"'
+
+# Detect Bun-specific frameworks
+cat package.json 2>/dev/null | grep -E '"elysia"|"hono"'
+
+# Detect Deno frameworks (deno.json imports)
+cat deno.json deno.jsonc 2>/dev/null | grep -E '"oak"|"hono"|"fresh"'
+
+# Detect module system (Node.js)
+cat package.json 2>/dev/null | grep '"type"'
+ls *.mjs *.cjs 2>/dev/null | head -5
+
+# Detect existing instrument file
+ls instrument.js instrument.mjs instrument.ts instrument.cjs 2>/dev/null
+
+# Detect logging libraries
+cat package.json 2>/dev/null | grep -E '"winston"|"pino"|"bunyan"'
+
+# Detect cron / scheduling
+cat package.json 2>/dev/null | grep -E '"node-cron"|"cron"|"agenda"|"bull"|"bullmq"'
+
+# Detect AI / LLM usage
+cat package.json 2>/dev/null | grep -E '"openai"|"@anthropic-ai"|"@langchain"|"@vercel/ai"|"@google/generative-ai"'
+
+# Detect OpenTelemetry tracing
+cat package.json 2>/dev/null | grep -E '"@opentelemetry/sdk-node"|"@opentelemetry/sdk-trace-node"|"@opentelemetry/sdk-trace-base"'
+grep -rn "NodeTracerProvider\|trace\.getTracer\|startActiveSpan" \
+  --include="*.ts" --include="*.js" --include="*.mjs" 2>/dev/null | head -5
+
+# Check for companion frontend
+ls frontend/ web/ client/ ui/ 2>/dev/null
+cat package.json 2>/dev/null | grep -E '"react"|"vue"|"svelte"|"next"'
+```
+
+**What to determine:**
+
+| Question | Impact |
+|----------|--------|
+| Which runtime? (Node.js / Bun / Deno) | Determines package, init pattern, and preload flag |
+| Node.js: ESM or CJS? | ESM requires `--import ./instrument.mjs`; CJS uses `require("./instrument")` |
+| Framework detected? | Determines which error handler to register |
+| `@sentry/*` already installed? | Skip install, go straight to feature config |
+| `instrument.js` / `instrument.mjs` already exists? | Merge into it rather than overwrite |
+| Logging library detected? | Recommend Sentry Logs |
+| Cron / job scheduler detected? | Recommend Crons monitoring |
+| AI library detected? | Recommend AI Monitoring |
+| OpenTelemetry tracing detected? | Use OTLP path instead of native tracing |
+| Companion frontend found? | Trigger Phase 4 cross-link |
+
+---
+
+## Phase 2: Recommend
+
+Present a concrete recommendation based on what you found. Don't ask open-ended questions — lead with a proposal:
+
+**Route from OTel detection:**
+- **OTel tracing detected** (`@opentelemetry/sdk-node` or `@opentelemetry/sdk-trace-node` in `package.json`, or `NodeTracerProvider` in source) → use OTLP path: `otlpIntegration()` via `@sentry/node-core/light`; do **not** set `tracesSampleRate`; Sentry links errors to OTel traces automatically
+
+**Recommended (core coverage):**
+- ✅ **Error Monitoring** — always; captures unhandled exceptions, promise rejections, and framework errors
+- ✅ **Tracing** — automatic HTTP, DB, and queue instrumentation via OpenTelemetry
+
+**Optional (enhanced observability):**
+- ⚡ **Logging** — structured logs via `Sentry.logger.*`; recommend when `winston`/`pino`/`bunyan` or log search is needed
+- ⚡ **Profiling** — continuous CPU profiling (Node.js only; not available on Bun or Deno); **not available with OTLP path**
+- ⚡ **AI Monitoring** — OpenAI, Anthropic, LangChain, Vercel AI SDK; recommend when AI/LLM calls detected
+- ⚡ **Crons** — detect missed or failed scheduled jobs; recommend when node-cron, Bull, or Agenda is detected
+- ⚡ **Metrics** — custom counters, gauges, distributions; recommend when custom KPIs needed
+- ⚡ **Runtime Metrics** — automatic collection of memory, CPU, and event loop metrics; `nodeRuntimeMetricsIntegration()` (Node.js) / `bunRuntimeMetricsIntegration()` (Bun)
+
+**Recommendation logic:**
+
+| Feature | Recommend when... |
+|---------|------------------|
+| Error Monitoring | **Always** — non-negotiable baseline |
+| OTLP Integration | OTel tracing detected — **replaces** native Tracing |
+| Tracing | **Always for server apps** — HTTP spans + DB spans are high-value; **skip if OTel tracing detected** |
+| Logging | App uses winston, pino, bunyan, or needs log-to-trace correlation |
+| Profiling | **Node.js only** — performance-critical service; native addon compatible; **skip if OTel tracing detected** (requires `tracesSampleRate`, incompatible with OTLP) |
+| AI Monitoring | App calls OpenAI, Anthropic, LangChain, Vercel AI, or Google GenAI |
+| Crons | App uses node-cron, Bull, BullMQ, Agenda, or any scheduled task pattern |
+| Metrics | App needs custom counters, gauges, or histograms |
+| Runtime Metrics | Any Node.js or Bun service wanting automatic memory/CPU/event-loop visibility |
+
+**OTel tracing detected:** *"I see OpenTelemetry tracing in the project. I recommend Sentry's OTLP integration for tracing (via your existing OTel setup) + Error Monitoring + Sentry Logging [+ Metrics/Crons/AI Monitoring if applicable]. Shall I proceed?"*
+
+**No OTel:** *"I recommend setting up Error Monitoring + Tracing. Want me to also add Logging or Profiling?"*
+
+---
+
+## Phase 3: Guide
+
+### Runtime: Node.js
+
+#### Option 1: Wizard (Recommended for Node.js)
+
+> **You need to run this yourself** — the wizard opens a browser for login and requires interactive input that the agent can't handle. Copy-paste into your terminal:
+>
+> ```
+> npx @sentry/wizard@latest -i node
+> ```
+>
+> It handles login, org/project selection, SDK installation, `instrument.js` creation, and package.json script updates.
+>
+> **Once it finishes, come back and skip to [Verification](#verification).**
+
+If the user skips the wizard, proceed with Option 2 (Manual Setup) below.
+
+---
+
+#### Option 2: Manual Setup — Node.js
+
+##### Install
+
+```bash
+npm install @sentry/node --save
+# or
+yarn add @sentry/node
+# or
+pnpm add @sentry/node
+```
+
+##### Create the Instrument File
+
+**CommonJS (`instrument.js`):**
+
+```javascript
+// instrument.js — must be loaded before all other modules
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? "___DSN___",
+
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+
+  // 100% in dev, lower in production
+  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+
+  // Capture local variable values in stack frames
+  includeLocalVariables: true,
+
+  enableLogs: true,
+});
+```
+
+**ESM (`instrument.mjs`):**
+
+```javascript
+// instrument.mjs — loaded via --import flag before any other module
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? "___DSN___",
+
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  includeLocalVariables: true,
+  enableLogs: true,
+});
+```
+
+##### Start Your App with Sentry Loaded First
+
+**CommonJS** — add `require("./instrument")` as the very first line of your entry file:
+
+```javascript
+// app.js
+require("./instrument"); // must be first
+
+const express = require("express");
+// ... rest of your app
+```
+
+**ESM** — use the `--import` flag so Sentry loads before all other modules (Node.js 18.19.0+ required):
+
+```bash
+node --import ./instrument.mjs app.mjs
+```
+
+Add to `package.json` scripts:
+
+```json
+{
+  "scripts": {
+    "start": "node --import ./instrument.mjs server.mjs",
+    "dev": "node --import ./instrument.mjs --watch server.mjs"
+  }
+}
+```
+
+Or via environment variable (useful for wrapping existing start commands):
+
+```bash
+NODE_OPTIONS="--import ./instrument.mjs" npm start
+```
+
+##### Framework Error Handlers
+
+Register the Sentry error handler **after all routes** so it can capture framework errors:
+
+**Express:**
+
+```javascript
+const express = require("express");
+const Sentry = require("@sentry/node");
+
+const app = express();
+
+// ... your routes
+
+// Add AFTER all routes — captures 5xx errors by default
+Sentry.setupExpressErrorHandler(app);
+
+// Optional: capture 4xx errors too
+// Sentry.setupExpressErrorHandler(app, {
+//   shouldHandleError(error) { return error.status >= 400; },
+// });
+
+app.listen(3000);
+```
+
+**Fastify:**
+
+```javascript
+const Fastify = require("fastify");
+const Sentry = require("@sentry/node");
+
+const fastify = Fastify();
+
+// Add BEFORE routes (unlike Express!)
+Sentry.setupFastifyErrorHandler(fastify);
+
+// ... your routes
+
+await fastify.listen({ port: 3000 });
+```
+
+**Koa:**
+
+```javascript
+const Koa = require("koa");
+const Sentry = require("@sentry/node");
+
+const app = new Koa();
+
+// Add as FIRST middleware (catches errors thrown by later middleware)
+Sentry.setupKoaErrorHandler(app);
+
+// ... your other middleware and routes
+
+app.listen(3000);
+```
+
+**Hapi (async — must await):**
+
+```javascript
+const Hapi = require("@hapi/hapi");
+const Sentry = require("@sentry/node");
+
+const server = Hapi.server({ port: 3000 });
+
+// ... your routes
+
+// Must await — Hapi registration is async
+await Sentry.setupHapiErrorHandler(server);
+
+await server.start();
+```
+
+**Connect:**
+
+```javascript
+const connect = require("connect");
+const Sentry = require("@sentry/node");
+
+const app = connect();
+
+// Add BEFORE routes (like Fastify and Koa)
+Sentry.setupConnectErrorHandler(app);
+
+// ... your middleware and routes
+
+require("http").createServer(app).listen(3000);
+```
+
+**NestJS** — has its own dedicated skill with full coverage:
+
+> **Use the [[`nestjs`](../nestjs/index.md)](../nestjs/index.md) skill instead.**
+> NestJS uses a separate package (`@sentry/nestjs`) with NestJS-native constructs:
+> `SentryModule.forRoot()`, `SentryGlobalFilter`, `@SentryTraced`, `@SentryCron` decorators,
+> and GraphQL/Microservices support. Load that skill for complete NestJS setup.
+
+**Vanilla Node.js `http` module** — wrap request handler manually:
+
+```javascript
+const http = require("http");
+const Sentry = require("@sentry/node");
+
+const server = http.createServer((req, res) => {
+  Sentry.withIsolationScope(() => {
+    try {
+      // your handler
+      res.end("OK");
+    } catch (err) {
+      Sentry.captureException(err);
+      res.writeHead(500);
+      res.end("Internal Server Error");
+    }
+  });
+});
+
+server.listen(3000);
+```
+
+**Framework error handler summary:**
+
+| Framework | Function | Placement | Async? |
+|-----------|----------|-----------|--------|
+| Express | `setupExpressErrorHandler(app)` | **After** all routes | No |
+| Fastify | `setupFastifyErrorHandler(fastify)` | **Before** routes | No |
+| Koa | `setupKoaErrorHandler(app)` | **First** middleware | No |
+| Hapi | `setupHapiErrorHandler(server)` | Before `server.start()` | **Yes** |
+| Connect | `setupConnectErrorHandler(app)` | **Before** routes | No |
+| NestJS | → Use [[`nestjs`](../nestjs/index.md)](../nestjs/index.md) | Dedicated skill | — |
+
+---
+
+### Runtime: Bun
+
+> **No wizard available for Bun.** Manual setup only.
+
+#### Install
+
+```bash
+bun add @sentry/bun
+```
+
+#### Create `instrument.ts` (or `instrument.js`)
+
+```typescript
+// instrument.ts
+import * as Sentry from "@sentry/bun";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? "___DSN___",
+
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  enableLogs: true,
+});
+```
+
+#### Start Your App with `--preload`
+
+```bash
+bun --preload ./instrument.ts server.ts
+```
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "start": "bun --preload ./instrument.ts server.ts",
+    "dev": "bun --watch --preload ./instrument.ts server.ts"
+  }
+}
+```
+
+#### Bun.serve() — Auto-Instrumentation
+
+`@sentry/bun` automatically instruments `Bun.serve()` via JavaScript Proxy. No extra setup is required — just initialize with `--preload` and your `Bun.serve()` calls are traced:
+
+```typescript
+// server.ts
+const server = Bun.serve({
+  port: 3000,
+  fetch(req) {
+    return new Response("Hello from Bun!");
+  },
+});
+```
+
+#### Framework Error Handlers on Bun
+
+Bun can run Express, Fastify, Hono, and Elysia. Use the same `@sentry/bun` import and the `@sentry/node` error handler functions (re-exported by `@sentry/bun`):
+
+```typescript
+import * as Sentry from "@sentry/bun";
+import express from "express";
+
+const app = express();
+// ... routes
+Sentry.setupExpressErrorHandler(app);
+app.listen(3000);
+```
+
+#### Bun Feature Support
+
+| Feature | Bun Support | Notes |
+|---------|-------------|-------|
+| Error Monitoring | ✅ Full | Same API as Node |
+| Tracing | ✅ Via `@sentry/node` OTel | Most auto-instrumentations work |
+| Logging | ✅ Full | `enableLogs: true` + `Sentry.logger.*` |
+| Profiling | ❌ Not available | `@sentry/profiling-node` uses native addons incompatible with Bun |
+| Metrics | ✅ Full | `Sentry.metrics.*` |
+| Runtime Metrics | ✅ Full | `bunRuntimeMetricsIntegration()` — memory, CPU, event loop (no event loop delay percentiles) |
+| Crons | ✅ Full | `Sentry.withMonitor()` |
+| AI Monitoring | ✅ Full | OpenAI, Anthropic integrations work |
+
+---
+
+### Runtime: Deno
+
+> **No wizard available for Deno.** Manual setup only.
+> **Requires Deno 2.0+.** Deno 1.x is not supported.
+> **Use `npm:` specifier.** The `deno.land/x/sentry` registry is deprecated.
+
+#### Install via `deno.json` (Recommended)
+
+```json
+{
+  "imports": {
+    "@sentry/deno": "npm:@sentry/deno@10.42.0"
+  }
+}
+```
+
+Or import directly with the `npm:` specifier:
+
+```typescript
+import * as Sentry from "npm:@sentry/deno";
+```
+
+#### Initialize — Add to Entry File
+
+```typescript
+// main.ts — Sentry.init() must be called before any other code
+import * as Sentry from "@sentry/deno";
+
+Sentry.init({
+  dsn: Deno.env.get("SENTRY_DSN") ?? "___DSN___",
+
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+  tracesSampleRate: Deno.env.get("DENO_ENV") === "development" ? 1.0 : 0.1,
+  enableLogs: true,
+});
+
+// Your application code follows
+Deno.serve({ port: 8000 }, (req) => {
+  return new Response("Hello from Deno!");
+});
+```
+
+> Unlike Node.js and Bun, Deno does not have a `--preload` or `--import` flag. Sentry must be the first `import` in your entry file.
+
+#### Required Deno Permissions
+
+The SDK requires network access to reach your Sentry ingest domain:
+
+```bash
+deno run \
+  --allow-net=o<ORG_ID>.ingest.sentry.io \
+  --allow-read=./src \
+  --allow-env=SENTRY_DSN,SENTRY_RELEASE \
+  main.ts
+```
+
+For development, `--allow-all` works but is not recommended for production.
+
+#### Deno Cron Integration
+
+Deno provides native cron scheduling. Use `denoCronIntegration` for automatic monitoring:
+
+```typescript
+import * as Sentry from "@sentry/deno";
+import { denoCronIntegration } from "@sentry/deno";
+
+Sentry.init({
+  dsn: Deno.env.get("SENTRY_DSN") ?? "___DSN___",
+  integrations: [denoCronIntegration()],
+});
+
+// Cron is automatically monitored
+Deno.cron("daily-cleanup", "0 0 * * *", () => {
+  // cleanup logic
+});
+```
+
+#### Deno Feature Support
+
+| Feature | Deno Support | Notes |
+|---------|-------------|-------|
+| Error Monitoring | ✅ Full | Unhandled exceptions + `captureException` |
+| Tracing | ✅ Custom OTel | Automatic spans for `Deno.serve()` and `fetch` |
+| Logging | ✅ Full | `enableLogs: true` + `Sentry.logger.*` |
+| Profiling | ❌ Not available | No profiling addon for Deno |
+| Metrics | ✅ Full | `Sentry.metrics.*` |
+| Runtime Metrics | ❌ Not available | No runtime metrics integration for Deno |
+| Crons | ✅ Full | `denoCronIntegration()` + `Sentry.withMonitor()` |
+| AI Monitoring | ✅ Partial | Vercel AI SDK integration works; OpenAI/Anthropic via `npm:` |
+
+---
+
+### OTLP Integration (OTel-First Projects — Node.js Only)
+
+> Use this path **only when OpenTelemetry tracing was detected** in Phase 1
+> (e.g., `@opentelemetry/sdk-node` or `@opentelemetry/sdk-trace-node` in `package.json`).
+> For projects without an existing OTel setup, use the standard `@sentry/node` path above.
+
+The OTLP integration uses `@sentry/node-core/light` — a lightweight Sentry SDK that does not bundle its own OpenTelemetry. Instead, it hooks into the user's existing OTel `TracerProvider` and exports spans to Sentry via OTLP.
+
+#### When to Use
+
+| Scenario | Recommended path |
+|----------|-----------------|
+| New project, no existing OTel | Standard `@sentry/node` (above) — includes built-in OTel |
+| Existing OTel setup, want Sentry tracing | `@sentry/node-core/light` + `otlpIntegration()` |
+| Existing OTel setup, sending to own Collector | `@sentry/node-core/light` + `otlpIntegration({ collectorUrl })` |
+
+#### Install
+
+```bash
+npm install @sentry/node-core @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/sdk-trace-base
+# or
+yarn add @sentry/node-core @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/sdk-trace-base
+# or
+pnpm add @sentry/node-core @opentelemetry/api @opentelemetry/sdk-trace-node @opentelemetry/sdk-trace-base
+```
+
+> The `@opentelemetry/*` packages are peer dependencies. If the project already has them installed, skip duplicates.
+
+#### Initialize
+
+```javascript
+// instrument.mjs — load via --import flag before any other module
+import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+import * as Sentry from '@sentry/node-core/light';
+import { otlpIntegration } from '@sentry/node-core/light/otlp';
+
+// Register the user's OTel TracerProvider first
+const provider = new NodeTracerProvider();
+provider.register();
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? '___DSN___',
+
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/node/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+  enableLogs: true,
+
+  // Do NOT set tracesSampleRate — OTel controls sampling
+  integrations: [
+    otlpIntegration({
+      // Export OTel spans to Sentry via OTLP (default: true)
+      setupOtlpTracesExporter: true,
+    }),
+  ],
+});
+```
+
+**With a custom Collector endpoint:**
+
+```javascript
+Sentry.init({
+  dsn: process.env.SENTRY_DSN ?? '___DSN___',
+  integrations: [
+    otlpIntegration({
+      collectorUrl: 'http://localhost:4318/v1/traces',
+    }),
+  ],
+});
+```
+
+#### Start Your App
+
+Same `--import` pattern as the standard Node.js setup:
+
+```bash
+node --import ./instrument.mjs app.mjs
+```
+
+#### Key Differences from Standard `@sentry/node`
+
+| Aspect | `@sentry/node` (standard) | `@sentry/node-core/light` (OTLP) |
+|--------|--------------------------|----------------------------------|
+| OTel bundled | ✅ Yes — built-in TracerProvider | ❌ No — uses your existing provider |
+| Tracing control | `tracesSampleRate` in `Sentry.init()` | OTel SDK controls sampling |
+| Auto-instrumentation | ✅ Built-in (HTTP, DB, etc.) | ❌ You manage OTel instrumentations |
+| Profiling | ✅ Available | ❌ Not compatible |
+| Error ↔ trace linking | ✅ Automatic | ✅ Automatic (via `otlpIntegration`) |
+| Package size | Larger (includes OTel) | Smaller (light mode) |
+
+---
+
+### For Each Agreed Feature
+
+Load the corresponding reference file and follow its steps:
+
+| Feature | Reference file | Load when... |
+|---------|---------------|-------------|
+| Error Monitoring | `./error-monitoring.md` | Always (baseline) — captures, scopes, enrichment, beforeSend |
+| OTLP Integration | See [OTLP Integration](#otlp-integration-otel-first-projects--nodejs-only) above | OTel tracing detected — **replaces** native Tracing |
+| Tracing | `./tracing.md` | OTel auto-instrumentation, custom spans, distributed tracing, sampling; **skip if OTel tracing detected** |
+| Logging | `./logging.md` | Structured logs, `Sentry.logger.*`, log-to-trace correlation |
+| Profiling | `./profiling.md` | Node.js only — CPU profiling, Bun/Deno gaps documented; **skip if OTel tracing detected** |
+| Metrics | `./metrics.md` | Custom counters, gauges, distributions |
+| Runtime Metrics | See inline below | Automatic memory, CPU, and event loop metrics for Node.js and Bun |
+| Crons | `./crons.md` | Scheduled job monitoring, node-cron, Bull, Agenda, Deno.cron |
+| AI Monitoring | `./ai-monitoring.md` | OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI |
+
+For each feature: read the reference file, follow its steps exactly, and verify before moving on.
+
+### Runtime Metrics
+
+Automatically collect Node.js and Bun runtime health metrics (memory, CPU utilization, event loop delay/utilization, uptime) at a configurable interval. Metrics appear in Sentry's Metrics product under the `node.runtime.*` / `bun.runtime.*` namespace.
+
+**Node.js** — add `nodeRuntimeMetricsIntegration()` to your `instrument.js`:
+
+```javascript
+const Sentry = require("@sentry/node");
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [
+    Sentry.nodeRuntimeMetricsIntegration(),
+    // Optional: change collection interval (default 30 000 ms)
+    // Sentry.nodeRuntimeMetricsIntegration({ collectionIntervalMs: 60_000 }),
+  ],
+});
+```
+
+Metrics collected by default: `node.runtime.mem.rss`, `node.runtime.mem.heap_used`, `node.runtime.mem.heap_total`, `node.runtime.cpu.utilization`, `node.runtime.event_loop.delay.p50`, `node.runtime.event_loop.delay.p99`, `node.runtime.event_loop.utilization`, `node.runtime.process.uptime`.
+
+**Bun** — add `bunRuntimeMetricsIntegration()` to your `instrument.ts`:
+
+```typescript
+import * as Sentry from "@sentry/bun";
+import { bunRuntimeMetricsIntegration } from "@sentry/bun";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [
+    bunRuntimeMetricsIntegration(),
+    // Optional: change collection interval (default 30 000 ms)
+    // bunRuntimeMetricsIntegration({ collectionIntervalMs: 60_000 }),
+  ],
+});
+```
+
+Metrics collected: same as Node.js except no event loop delay percentiles (unavailable in Bun). Prefixed with `bun.runtime.*`.
+
+---
+
+## Configuration Reference
+
+### `Sentry.init()` Core Options
+
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `dsn` | `string` | — | Required. Also from `SENTRY_DSN` env var |
+| `tracesSampleRate` | `number` | — | 0–1; required to enable tracing; **do not set when using OTLP path** |
+| `dataCollection` | `object` | conservative unless set | Fine-grained control over auto-collected categories (`userInfo`, `cookies`, `httpHeaders`, `httpBodies`, `queryParams`, `genAI`). When omitted, the SDK falls back to `sendDefaultPii` (default `false`). Passing the object — even `{}` — flips unset categories to their permissive defaults; opt out per category. |
+| `includeLocalVariables` | `boolean` | `false` | Add local variable values to stack frames (Node.js) |
+| `enableLogs` | `boolean` | `false` | Enable Sentry Logs product (v9.41.0+) |
+| `environment` | `string` | `"production"` | Also from `SENTRY_ENVIRONMENT` env var |
+| `release` | `string` | — | Also from `SENTRY_RELEASE` env var |
+| `debug` | `boolean` | `false` | Log SDK activity to console |
+| `enabled` | `boolean` | `true` | Set `false` in tests to disable sending |
+| `sampleRate` | `number` | `1.0` | Fraction of error events to send (0–1) |
+| `shutdownTimeout` | `number` | `2000` | Milliseconds to flush events before process exit |
+
+### `nativeNodeFetchIntegration()` Options
+
+Configures outgoing `fetch`/`undici` span capture. Since `@opentelemetry/instrumentation-undici@0.22.0`, response headers like `content-length` are no longer captured automatically — use `headersToSpanAttributes` to opt in:
+
+```javascript
+Sentry.init({
+  integrations: [
+    Sentry.nativeNodeFetchIntegration({
+      headersToSpanAttributes: {
+        requestHeaders: ["x-request-id"],
+        responseHeaders: ["content-length", "content-type"],
+      },
+    }),
+  ],
+});
+```
+
+| Option | Type | Default | Notes |
+|--------|------|---------|-------|
+| `breadcrumbs` | `boolean` | `true` | Record breadcrumbs for outgoing fetch requests |
+| `headersToSpanAttributes.requestHeaders` | `string[]` | — | Request header names to capture as span attributes |
+| `headersToSpanAttributes.responseHeaders` | `string[]` | — | Response header names to capture as span attributes |
+
+### `otlpIntegration()` Options (`@sentry/node-core/light/otlp`)
+
+For OTel-first projects using `@sentry/node-core/light`. Import: `import { otlpIntegration } from '@sentry/node-core/light/otlp'`.
+
+| Option | Type | Default | Purpose |
+|--------|------|---------|---------|
+| `setupOtlpTracesExporter` | `boolean` | `true` | Auto-configure OTLP exporter to send spans to Sentry; set `false` if you already export to your own Collector |
+| `collectorUrl` | `string` | `undefined` | OTLP HTTP endpoint of an OTel Collector (e.g., `http://localhost:4318/v1/traces`); when set, spans are sent to the collector instead of the DSN-derived Sentry endpoint |
+
+### Graceful Shutdown
+
+Flush buffered events before process exit — important for short-lived scripts and serverless:
+
+```javascript
+process.on("SIGTERM", async () => {
+  await Sentry.close(2000); // flush with 2s timeout
+  process.exit(0);
+});
+```
+
+### Environment Variables
+
+| Variable | Purpose | Runtime |
+|----------|---------|---------|
+| `SENTRY_DSN` | DSN (alternative to hardcoding in `init()`) | All |
+| `SENTRY_ENVIRONMENT` | Deployment environment | All |
+| `SENTRY_RELEASE` | Release version string (auto-detected from git) | All |
+| `SENTRY_AUTH_TOKEN` | Source map upload token | Build time |
+| `SENTRY_ORG` | Org slug for source map upload | Build time |
+| `SENTRY_PROJECT` | Project slug for source map upload | Build time |
+| `NODE_OPTIONS` | Set `--import ./instrument.mjs` for ESM | Node.js |
+
+### Source Maps (Node.js)
+
+Readable stack traces in production require uploading source maps with `@sentry/cli` or the webpack/esbuild/rollup plugins — for example, an inject + upload step in your build:
+
+```json
+{
+  "scripts": {
+    "build": "tsc && sentry-cli sourcemaps inject ./dist && sentry-cli sourcemaps upload ./dist"
+  }
+}
+```
+
+Upload needs a `SENTRY_AUTH_TOKEN` (a build-time secret).
+
+---
+
+## Verification
+
+After setup, verify Sentry is receiving events:
+
+```javascript
+// Add temporarily to your entry file or a test route, then remove
+import * as Sentry from "@sentry/node"; // or @sentry/bun / @sentry/deno
+
+Sentry.captureException(new Error("Sentry test error — delete me"));
+```
+
+Or trigger an unhandled exception:
+
+```javascript
+// In a route handler or startup — will be captured automatically
+throw new Error("Sentry test error — delete me");
+```
+
+Then check your [Sentry Issues dashboard](https://sentry.io/issues/) — the error should appear within ~30 seconds.
+
+**Verification checklist:**
+
+| Check | How |
+|-------|-----|
+| Error captured | Throw in a handler, verify in Sentry Issues |
+| Tracing working | Check Performance tab — should show HTTP spans |
+| `includeLocalVariables` working | Stack frame in Sentry should show variable values |
+| Source maps working | Stack trace shows readable file names, not minified |
+
+---
+
+## Phase 4: Cross-Link
+
+After completing backend setup, check for companion services:
+
+```bash
+# Frontend companion
+ls frontend/ web/ client/ ui/ 2>/dev/null
+cat package.json 2>/dev/null | grep -E '"react"|"vue"|"svelte"|"next"'
+
+# Other backend services
+ls ../go.mod ../requirements.txt ../Gemfile 2>/dev/null
+```
+
+If a frontend, framework-specific SDK, or other backend is found, suggest the matching skill:
+
+**Dedicated JavaScript framework skills (prefer these over generic node-sdk):**
+
+| Detected | Prefer skill | Why |
+|----------|-------------|-----|
+| NestJS (`@nestjs/core` in `package.json`) | [[`nestjs`](../nestjs/index.md)](../nestjs/index.md) | Uses `@sentry/nestjs` with NestJS-native decorators, filters, and GraphQL support |
+| Next.js (`next` in `package.json`) | [[`nextjs`](../nextjs/index.md)](../nextjs/index.md) | Three-runtime architecture (browser, server, edge), `withSentryConfig`, source map upload |
+
+**Frontend companions:**
+
+| Detected | Suggest |
+|---------|---------|
+| React app (`react` in `package.json`) | [[`react`](../react/index.md)](../react/index.md) |
+| Svelte/SvelteKit | [[`svelte`](../svelte/index.md)](../svelte/index.md) |
+
+**Other backend companions:**
+
+| Detected | Suggest |
+|---------|---------|
+| Go backend (`go.mod`) | [[`go`](../go/index.md)](../go/index.md) |
+| Python backend (`requirements.txt`, `pyproject.toml`) | [[`python`](../python/index.md)](../python/index.md) |
+| Ruby backend (`Gemfile`) | [[`ruby`](../ruby/index.md)](../ruby/index.md) |
+
+Connecting frontend and backend with the same DSN or linked projects enables **distributed tracing** — stack traces that span your browser, API server, and database in a single trace view.
+
+---
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| Events not appearing | `instrument.js` loaded too late | Ensure it's the first `require()` / loaded via `--import` or `--preload` |
+| Tracing spans missing | `tracesSampleRate` not set | Add `tracesSampleRate: 1.0` to `Sentry.init()` |
+| ESM instrumentation not working | Missing `--import` flag | Run with `node --import ./instrument.mjs`; `import "./instrument.mjs"` inside app is not sufficient |
+| `@sentry/profiling-node` install fails on Bun | Native addon incompatible | Profiling is not supported on Bun — remove `@sentry/profiling-node` |
+| Deno: events not sent | Missing `--allow-net` permission | Run with `--allow-net=o<ORG_ID>.ingest.sentry.io` |
+| Deno: `deno.land/x/sentry` not working | Deprecated and frozen at v8.55.0 | Switch to `npm:@sentry/deno` specifier |
+| `includeLocalVariables` not showing values | Integration not activated or minified code | Ensure `includeLocalVariables: true` in init; check source maps |
+| NestJS: errors not captured | Wrong SDK or missing filter | Use [[`nestjs`](../nestjs/index.md)](../nestjs/index.md) — NestJS needs `@sentry/nestjs`, not `@sentry/node` |
+| Hapi: `setupHapiErrorHandler` timing issue | Not awaited | Must `await Sentry.setupHapiErrorHandler(server)` before `server.start()` |
+| Shutdown: events lost | Process exits before flush | Add `await Sentry.close(2000)` in SIGTERM/SIGINT handler |
+| Stack traces show minified code | Source maps not uploaded | Configure `@sentry/cli` source map upload in build step |
+| No traces appearing (OTLP) | Missing `@opentelemetry/*` packages or `otlpIntegration` not added | Verify `@opentelemetry/sdk-trace-node` is installed; add `otlpIntegration()` to `integrations`; do **not** set `tracesSampleRate` |
+| OTLP: errors not linked to traces | `otlpIntegration` not registered | Ensure `otlpIntegration()` is in the `integrations` array — it registers the propagation context that links errors to OTel traces |
+| Profiling not starting (OTLP) | Profiling requires `tracesSampleRate` | Profiling is **not compatible** with the OTLP path; use the standard `@sentry/node` setup instead |

--- a/skills-next/references/sdks/node/logging.md
+++ b/skills-next/references/sdks/node/logging.md
@@ -1,0 +1,357 @@
+# Logging — Sentry Node.js SDK
+
+> Minimum SDK: `@sentry/node` ≥9.41.0 (stable GA)  
+> First experimental: ≥9.10.0 (via `_experiments.enableLogs`)  
+> Console multi-arg parsing: ≥10.13.0  
+> Consola reporter: ≥10.12.0  
+> Scope attributes on logs: ≥10.32.0  
+> Status: ✅ **Generally Available**
+
+---
+
+## Overview
+
+Sentry Logs are high-cardinality structured log entries that link directly to traces and errors. They let you answer *why* something broke, not just *what* broke.
+
+Key characteristics:
+- Sent as structured data — each attribute is individually searchable in Sentry UI
+- Automatically linked to the active trace (if tracing is enabled)
+- Buffered and batched (max 100 per buffer) — no per-log network overhead
+- NOT a replacement for a logging library; designed to complement one
+
+---
+
+## Initialization
+
+`enableLogs: true` is **required**. Logging is disabled by default.
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  enableLogs: true,                   // REQUIRED — default: false
+
+  beforeSendLog: (log) => {           // optional filter/transform
+    if (log.level === "debug") return null;  // null = drop this log
+    return log;
+  },
+});
+```
+
+---
+
+## Logger API
+
+All six methods live at `Sentry.logger.*`:
+
+```typescript
+Sentry.logger.trace(message, attributes?, options?)
+Sentry.logger.debug(message, attributes?, options?)
+Sentry.logger.info(message, attributes?, options?)
+Sentry.logger.warn(message, attributes?, options?)
+Sentry.logger.error(message, attributes?, options?)
+Sentry.logger.fatal(message, attributes?, options?)
+```
+
+| Method  | Severity # | When to Use                             |
+|---------|------------|-----------------------------------------|
+| `trace` | 1          | Fine-grained debugging, hot paths       |
+| `debug` | 5          | Development diagnostics, variable dumps |
+| `info`  | 9          | Normal operations, milestones, events   |
+| `warn`  | 13         | Potential issues, degraded state        |
+| `error` | 17         | Failures that need attention            |
+| `fatal` | 21         | Critical failures, service down         |
+
+**Full TypeScript signature** (same shape for all six methods):
+
+```typescript
+function info(
+  message: ParameterizedString,          // string or fmt`` tagged template
+  attributes?: Record<string, unknown>,  // string | number | boolean values
+  options?: { scope?: Scope },           // optional scope override
+): void;
+```
+
+---
+
+## Basic Usage
+
+```typescript
+Sentry.logger.trace("Entering function", { fn: "processOrder" });
+Sentry.logger.debug("Cache lookup", { key: "user:123", hit: false });
+Sentry.logger.info("Order created", { orderId: "order_456", total: 99.99 });
+Sentry.logger.warn("Rate limit approaching", { current: 95, max: 100 });
+Sentry.logger.error("Payment failed", { reason: "card_declined", userId: 42 });
+Sentry.logger.fatal("Database unavailable", { host: "primary-db", port: 5432 });
+```
+
+---
+
+## Parameterized Messages — `Sentry.logger.fmt`
+
+Use the `fmt` tagged template literal to create parameterized messages. Interpolated values are extracted as **individually searchable attributes** in Sentry.
+
+```typescript
+const userId = "user_123";
+const productName = "Widget Pro";
+
+Sentry.logger.info(
+  Sentry.logger.fmt`User ${userId} purchased ${productName}`,
+);
+
+// Stored in Sentry as:
+// sentry.message.template  → "User '%s' purchased '%s'"
+// sentry.message.parameter.0 → "user_123"
+// sentry.message.parameter.1 → "Widget Pro"
+```
+
+You can combine `fmt` with additional attributes:
+
+```typescript
+Sentry.logger.info(
+  Sentry.logger.fmt`Order ${orderId} placed by ${userId}`,
+  { total: 149.99, itemCount: 3, region: "us-west-2" },
+);
+```
+
+`fmt` is an alias for `Sentry.parameterize()` internally. The returned string carries hidden `__sentry_template_string__` and `__sentry_template_values__` properties used by the SDK for serialization.
+
+---
+
+## Structured Attributes
+
+The second argument is a plain object. Values must be `string`, `number`, or `boolean`.
+
+```typescript
+Sentry.logger.info("API request completed", {
+  userId: user.id,
+  userTier: user.plan,          // "free" | "pro" | "enterprise"
+  endpoint: "/api/orders",
+  method: "POST",
+  statusCode: 200,
+  durationMs: 234,
+  orderValue: 149.99,
+  isBeta: true,
+  retryCount: 0,
+});
+```
+
+Attributes become filterable columns in the Sentry Logs view.
+
+---
+
+## Scope-Based Attributes (SDK ≥10.32.0)
+
+Set attributes on a scope once and they are automatically attached to every log emitted within that scope.
+
+```typescript
+// Global scope — applies to all logs for the app's lifetime
+Sentry.getGlobalScope().setAttributes({
+  service: "checkout-service",
+  version: "2.1.0",
+  region: "us-west-2",
+});
+
+// Isolation scope — unique per HTTP request (auto-created by HTTP integrations)
+Sentry.getIsolationScope().setAttributes({
+  org_id: user.orgId,
+  user_tier: user.tier,
+  request_id: req.id,
+});
+
+// Current scope — single operation block
+Sentry.withScope((scope) => {
+  scope.setAttribute("operation", "payment-processing");
+  scope.setAttribute("payment_method", "stripe");
+
+  Sentry.logger.info("Processing payment", { amount: 99.99 });
+  // → includes all scope attributes + the explicit { amount }
+});
+```
+
+---
+
+## Auto-Attached Attributes
+
+The SDK automatically attaches these to every log:
+
+| Attribute Key                | Value                                  |
+|------------------------------|----------------------------------------|
+| `sentry.environment`         | `environment` from `Sentry.init()`     |
+| `sentry.release`             | `release` from `Sentry.init()`         |
+| `sentry.sdk.name`            | e.g., `"sentry.javascript.node"`       |
+| `sentry.sdk.version`         | e.g., `"10.42.0"`                      |
+| `server.address`             | Server hostname / `server_name`        |
+| `user.id`                    | Current scope user ID (if set)         |
+| `user.name`                  | Current scope username (if set)        |
+| `user.email`                 | Current scope user email (if set)      |
+| `sentry.message.template`    | Parameterized template (when using `fmt`) |
+| `sentry.message.parameter.N` | Positional interpolated values         |
+
+---
+
+## Console Integration
+
+Capture `console.*` calls as Sentry logs using the built-in integration (SDK ≥9.41.0):
+
+```typescript
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  enableLogs: true,
+  integrations: [
+    Sentry.consoleLoggingIntegration({
+      levels: ["log", "warn", "error"],
+      // Default levels: ['debug','info','warn','error','log','trace','assert']
+    }),
+  ],
+});
+
+// These now send to Sentry Logs automatically:
+console.log("User action:", "checkout");   // → severity: info
+console.warn("Memory pressure");           // → severity: warn
+console.error("Unhandled rejection");      // → severity: error
+```
+
+Multi-argument parsing (args become `message.parameter.N` attributes) requires SDK ≥10.13.0.
+
+---
+
+## Consola Integration (SDK ≥10.12.0)
+
+```typescript
+import { createConsola } from "consola";
+import * as Sentry from "@sentry/node";
+
+const logger = createConsola();
+logger.addReporter(Sentry.createConsolaReporter());
+
+logger.info("This goes to Sentry Logs");
+logger.error("This too");
+```
+
+---
+
+## `beforeSendLog` Hook
+
+Filter or transform logs before they are sent. Return `null` to drop:
+
+```typescript
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  enableLogs: true,
+  beforeSendLog: (log) => {
+    // Drop debug logs in production
+    if (process.env.NODE_ENV === "production" && log.level === "debug") {
+      return null;
+    }
+
+    // Scrub sensitive fields
+    if (log.attributes?.credit_card) {
+      log.attributes.credit_card = "[REDACTED]";
+    }
+
+    // Add computed attributes
+    log.attributes = {
+      ...log.attributes,
+      processed_at: Date.now(),
+    };
+
+    return log;
+  },
+});
+```
+
+The `log` object shape: `{ level, message, attributes, severityNumber }`.
+
+---
+
+## Third-Party Logger Bridges
+
+Sentry does **not** provide official first-party transports for Winston, Pino, Bunyan, or Morgan. Use the patterns below to forward logs to `Sentry.logger.*`.
+
+**Winston:**
+
+```typescript
+import winston from "winston";
+import * as Sentry from "@sentry/node";
+
+const levelMap: Record<string, keyof typeof Sentry.logger> = {
+  silly: "trace", verbose: "debug", debug: "debug",
+  http: "info", info: "info", warn: "warn", error: "error",
+};
+
+const sentryTransport = new winston.transports.Stream({
+  stream: {
+    write: (message: string) => {
+      const parsed = JSON.parse(message);
+      const fn = levelMap[parsed.level] ?? "info";
+      (Sentry.logger[fn] as Function)(parsed.message, parsed.meta ?? {});
+    },
+  },
+});
+
+const logger = winston.createLogger({
+  format: winston.format.json(),
+  transports: [new winston.transports.Console(), sentryTransport],
+});
+```
+
+**Pino:**
+
+```typescript
+import pino from "pino";
+import * as Sentry from "@sentry/node";
+
+const PINO_TO_SENTRY: Record<number, keyof typeof Sentry.logger> = {
+  10: "trace", 20: "debug", 30: "info",
+  40: "warn", 50: "error", 60: "fatal",
+};
+
+const dest = pino.destination({
+  write(chunk: string) {
+    const log = JSON.parse(chunk);
+    const fn = PINO_TO_SENTRY[log.level] ?? "info";
+    const { msg, level, time, pid, hostname, ...attrs } = log;
+    (Sentry.logger[fn] as Function)(msg, attrs);
+  },
+});
+
+const logger = pino({ level: "trace" }, dest);
+```
+
+---
+
+## Trace Linking
+
+Logs emitted during an active span automatically include `sentry.trace.parent_span_id`, linking them to the active trace. From a log in Sentry you can navigate to its parent trace; from a trace you can see all logs emitted during that request.
+
+---
+
+## Log Buffering and Flushing
+
+Logs are buffered in memory (max 100 per buffer: `MAX_LOG_BUFFER_SIZE = 100`). The buffer flushes automatically when full or on `client.close()`.
+
+For **serverless or short-lived processes**, flush explicitly before exit:
+
+```typescript
+await Sentry.flush(2000);  // flush with 2s timeout
+await Sentry.close(2000);  // flush + close all transports
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| Logs not appearing in Sentry | `enableLogs` not set | Add `enableLogs: true` to `Sentry.init()` |
+| `Sentry.logger` is undefined | SDK < 9.41.0 | Upgrade to ≥9.41.0 |
+| Attributes not searchable | Using complex objects | Use only `string`, `number`, `boolean` values |
+| Console logs not captured | Missing integration | Add `consoleLoggingIntegration()` to `integrations` |
+| Logs cut off in serverless | Buffer not flushed | Call `await Sentry.flush(2000)` before function returns |
+| `fmt` values not parameterized | Using string interpolation | Use tagged template: `` fmt`msg ${val}` `` not `"msg " + val` |
+| Logs missing trace link | No active span | Enable tracing with `tracesSampleRate` |
+| `beforeSendLog` not firing | `enableLogs: false` | Logs are dropped before the hook if logging is disabled |
+| Scope attributes missing from logs | SDK < 10.32.0 | Upgrade to ≥10.32.0 for scope attribute inheritance |
+| Consola reporter not working | SDK < 10.12.0 | Upgrade to ≥10.12.0 |

--- a/skills-next/references/sdks/node/metrics.md
+++ b/skills-next/references/sdks/node/metrics.md
@@ -1,0 +1,267 @@
+# Metrics — Sentry Node.js SDK
+
+> Minimum SDK: `@sentry/node` ≥10.25.0 (stable `Sentry.metrics.*` API)  
+> `enableMetrics` top-level option: ≥10.24.0 (default: `true`)  
+> `beforeSendMetric` hook: ≥10.24.0  
+> Scope attributes on metrics: ≥10.33.0
+
+---
+
+## Overview
+
+Sentry Metrics let you track counters, current values, and value distributions. They appear in Sentry alongside related errors and can be correlated with traces.
+
+Key characteristics:
+- Metrics are **enabled by default** — no configuration required for basic use
+- Buffered in memory (max 1000 entries) and sent periodically
+- High-cardinality attributes **degrade backend performance** — keep attribute cardinality low
+- Use `Sentry.logger.*` (not metrics) when you need per-user or per-request detail
+
+---
+
+## Initialization
+
+Metrics are on by default. Opt out if needed:
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  // Metrics are enabled by default — no config needed
+
+  // To disable entirely:
+  // enableMetrics: false,
+
+  beforeSendMetric: (metric) => {   // optional filter/transform
+    if (metric.name === "debug_metric") return null;
+    return metric;
+  },
+});
+```
+
+---
+
+## Metrics API
+
+Three methods. No `increment()` or `set()` — those do not exist in v10:
+
+```typescript
+Sentry.metrics.count(name, value?, options?)
+Sentry.metrics.gauge(name, value, options?)
+Sentry.metrics.distribution(name, value, options?)
+```
+
+**Full TypeScript signatures:**
+
+```typescript
+interface MetricOptions {
+  unit?: string;                           // see unit table below
+  attributes?: Record<string, unknown>;    // filterable dimensions
+  scope?: Scope;                           // optional scope override
+}
+
+function count(name: string, value?: number, options?: MetricOptions): void;
+       // value defaults to 1
+
+function gauge(name: string, value: number, options?: MetricOptions): void;
+
+function distribution(name: string, value: number, options?: MetricOptions): void;
+```
+
+---
+
+## Metric Types
+
+| Method         | Underlying Type | Use For                                          |
+|----------------|-----------------|--------------------------------------------------|
+| `count`        | counter         | Event frequency — requests, errors, signups      |
+| `gauge`        | gauge           | Current snapshot value — queue depth, CPU %      |
+| `distribution` | distribution    | Value histograms/ranges — latencies, file sizes  |
+
+```typescript
+// count — how many times something happened
+Sentry.metrics.count("user.signups", 1);
+Sentry.metrics.count("api.errors", 1, { attributes: { endpoint: "/checkout" } });
+
+// gauge — what the current state is
+Sentry.metrics.gauge("queue.depth", 42);
+Sentry.metrics.gauge("memory.usage", 512, { unit: "megabyte" });
+
+// distribution — spread of a measured value
+Sentry.metrics.distribution("api.latency", 187.5, { unit: "millisecond" });
+Sentry.metrics.distribution("payload.size", 1024, { unit: "byte" });
+```
+
+---
+
+## Units
+
+Pass a `unit` string in `MetricOptions`. Used for display formatting in Sentry.
+
+| Category  | Unit Values                                                        |
+|-----------|--------------------------------------------------------------------|
+| Time      | `millisecond`, `second`, `minute`, `hour`, `day`, `week`           |
+| Storage   | `bit`, `byte`, `kilobyte`, `megabyte`, `gigabyte`, `terabyte`, `petabyte` |
+| Fractions | `ratio`, `percent`                                                 |
+| None      | `none` (or omit `unit`)                                            |
+
+```typescript
+Sentry.metrics.distribution("api.latency", 187.5, { unit: "millisecond" });
+Sentry.metrics.distribution("job.duration", 3.2,   { unit: "second" });
+Sentry.metrics.gauge("memory.usage", 512,          { unit: "megabyte" });
+Sentry.metrics.gauge("cache.hit_rate", 0.87,       { unit: "ratio" });
+Sentry.metrics.gauge("disk.usage_pct", 72.4,       { unit: "percent" });
+Sentry.metrics.count("user.logins");               // omit unit for plain counts
+```
+
+---
+
+## Attributes (Tags)
+
+Use `attributes` in `MetricOptions` to add filterable/groupable dimensions.
+
+**Size limit:** 2 KB per metric envelope. Metrics exceeding this are **dropped**.
+
+```typescript
+Sentry.metrics.count("api.requests", 1, {
+  attributes: {
+    endpoint: "/api/orders",
+    method: "POST",
+    status_code: 200,
+    user_tier: "pro",
+    region: "us-west-2",
+    version: "v2",
+  },
+});
+
+Sentry.metrics.distribution("db.query_time", 45.3, {
+  unit: "millisecond",
+  attributes: {
+    table: "orders",
+    operation: "SELECT",
+    index_used: true,
+    rows_scanned: 1240,
+  },
+});
+```
+
+---
+
+## Cardinality
+
+Keep attribute values bounded. High-cardinality attributes (per-user IDs, request UUIDs) cause performance issues in Sentry's metrics backend.
+
+```typescript
+// ❌ HIGH CARDINALITY — avoid as metric attributes
+Sentry.metrics.count("page.view", 1, {
+  attributes: { user_id: "uuid-abc-123" },   // millions of unique values
+});
+
+// ✅ LOW CARDINALITY — bounded enums and sets
+Sentry.metrics.count("page.view", 1, {
+  attributes: {
+    page: "/dashboard",
+    user_tier: "pro",        // bounded enum
+    ab_variant: "control",   // bounded enum
+    region: "us-east-1",     // bounded set
+  },
+});
+```
+
+Use `Sentry.logger.*` for per-user or per-request data — logs handle high cardinality gracefully.
+
+---
+
+## Scope-Based Attributes (SDK ≥10.33.0)
+
+Set attributes on a scope and they auto-attach to all metrics emitted within it:
+
+```typescript
+// Global scope — applies to all metrics app-wide
+Sentry.getGlobalScope().setAttributes({
+  service: "payments",
+  deploy_env: "production",
+});
+
+// Per-request scope
+Sentry.withScope((scope) => {
+  scope.setAttribute("step", "checkout");
+  scope.setAttribute("user_tier", "enterprise");
+
+  // Both metrics inherit the scope attributes above
+  Sentry.metrics.count("checkout.attempts", 1);
+  Sentry.metrics.gauge("cart.value", 249.99);
+});
+```
+
+---
+
+## Auto-Attached Default Attributes
+
+| Attribute                            | Value                               | Context     |
+|--------------------------------------|-------------------------------------|-------------|
+| `sentry.environment`                 | From `Sentry.init({ environment })` | Always      |
+| `sentry.release`                     | From `Sentry.init({ release })`     | Always      |
+| `sentry.sdk.name`                    | SDK identifier                      | Always      |
+| `sentry.sdk.version`                 | e.g., `"10.42.0"`                   | Always      |
+| `user.id`, `user.name`, `user.email` | If user is set in scope             | When set    |
+| `server.address`                     | Server hostname                     | Server-side |
+
+---
+
+## `beforeSendMetric` Hook
+
+Filter or modify metrics before transmission. Return `null` to drop:
+
+```typescript
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  beforeSendMetric: (metric) => {
+    // metric: { name, value, type, unit?, attributes? }
+
+    // Drop internal debug metrics
+    if (metric.name.startsWith("_internal.")) {
+      return null;
+    }
+
+    // Normalize metric names
+    metric.name = metric.name.toLowerCase().replace(/[^a-z0-9_.]/g, "_");
+
+    // Add global context
+    metric.attributes = {
+      ...metric.attributes,
+      host: process.env.HOSTNAME,
+      deploy_id: process.env.DEPLOY_ID,
+    };
+
+    return metric;
+  },
+});
+```
+
+---
+
+## Flushing
+
+Metrics are buffered (max `MAX_METRIC_BUFFER_SIZE = 1000`) and flushed periodically. For serverless or short-lived scripts, flush explicitly:
+
+```typescript
+await Sentry.flush(2000);  // flush + 2s timeout
+await Sentry.close(2000);  // flush + close all transports
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Likely Cause | Fix |
+|---------|-------------|-----|
+| Metrics not appearing | SDK < 10.24.0 | Upgrade to ≥10.24.0 |
+| `Sentry.metrics` is undefined | SDK < 10.25.0 | Upgrade to ≥10.25.0 |
+| Metrics silently dropped | Attribute envelope > 2 KB | Reduce number or size of `attributes` |
+| `increment()` not found | Renamed in v10 | Use `count()` instead |
+| `set()` not found | Removed in v10 | No equivalent; use `count()` with bounded attributes |
+| Scope attributes missing | SDK < 10.33.0 | Upgrade to ≥10.33.0 |
+| Metrics lost in serverless | Buffer not flushed | Call `await Sentry.flush(2000)` before function returns |
+| High-cardinality issues | Unbounded attribute values | Keep attributes to bounded enums/sets |

--- a/skills-next/references/sdks/node/profiling.md
+++ b/skills-next/references/sdks/node/profiling.md
@@ -1,0 +1,359 @@
+# Profiling — Sentry Node.js SDK
+
+> Node.js profiling: `@sentry/profiling-node` — must match your `@sentry/node` version exactly  
+> **Bun and Deno are NOT supported.** The profiler is a native C++ addon (`node-gyp`) that only runs in Node.js.
+
+---
+
+## Overview
+
+Profiling captures V8 CPU call stacks at ~100 samples/second alongside your traces. Profiles attach to spans, giving you flame graphs to identify hot paths directly from a slow trace.
+
+Profiling is **Node.js only**:
+
+| Runtime | Profiling | Notes |
+|---------|-----------|-------|
+| Node.js ≥18 | ✅ | Full support via `@sentry/profiling-node` |
+| Bun | ❌ | Native addon not supported |
+| Deno | ❌ | Native addon not supported |
+
+---
+
+## How Profiling Relates to Tracing
+
+Profiles attach to **spans** — they require tracing to be enabled:
+
+1. `tracesSampleRate` / `tracesSampler` decides whether a request is traced at all
+2. `profileSessionSampleRate` decides whether the session opts into profiling
+3. A profile is only collected when **both** sampling decisions are "yes"
+
+```
+tracesSampleRate: 0.1   +  profileSessionSampleRate: 0.5
+→ ~5% of requests will have both a trace AND a profile attached
+```
+
+In `trace` lifecycle mode, you can drill from a slow span in the Performance UI directly into a flame graph:
+
+```
+Trace: "POST /api/checkout" (850ms)
+  ├── "validateCart" (45ms)   → [Profile attached] → shows DB driver hot paths
+  ├── "processPayment" (620ms)
+  └── "updateInventory" (185ms) → [Profile attached] → shows ORM overhead
+```
+
+---
+
+## Installation
+
+```bash
+npm install @sentry/profiling-node --save
+```
+
+> ⚠️ **Version pinning is required.** `@sentry/profiling-node` must exactly match your `@sentry/node` version. Mismatched versions cause silent failures or startup crashes.
+
+```bash
+# Both must be the same version
+npm install @sentry/node@latest @sentry/profiling-node@latest
+```
+
+---
+
+## SDK Configuration
+
+### Trace Mode (Recommended)
+
+Profiles auto-attach to all sampled spans with no additional code:
+
+```typescript
+import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  tracesSampleRate: 1.0,
+
+  // Session-level sampling: decision made once at process startup
+  profileSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+
+  // "trace" = profiles auto-attach to every sampled span
+  profileLifecycle: "trace",
+});
+```
+
+### Manual Mode
+
+Start and stop profiling around specific code paths:
+
+```typescript
+import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [nodeProfilingIntegration()],
+  tracesSampleRate: 1.0,
+  profileSessionSampleRate: 1.0,
+  profileLifecycle: "manual",
+});
+
+// Explicit start/stop around critical code:
+Sentry.profiler.startProfiler();
+await heavyComputation();
+Sentry.profiler.stopProfiler();
+```
+
+---
+
+## Continuous Profiling
+
+For long-running processes, batch jobs, or background workers that don't map cleanly to request spans, use the profiler API directly:
+
+```typescript
+import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  integrations: [nodeProfilingIntegration()],
+});
+
+// Start profiling at process startup
+Sentry.profiler.startProfiler();
+
+// Profile is chunked automatically into ~60-second intervals and uploaded
+// All spans created during this window have profile data attached
+
+// Stop when done (e.g. graceful shutdown)
+process.on("SIGTERM", () => {
+  Sentry.profiler.stopProfiler();
+  process.exit(0);
+});
+```
+
+### Profile Chunk Architecture
+
+The V2 profiler divides data into 60-second chunks that upload automatically:
+
+```
+Process lifetime:
+┌─── 60 seconds ───┬─── 60 seconds ───┬─── 60 seconds ───┐
+│   Chunk 1        │   Chunk 2        │   Chunk 3        │
+│   Spans: [...]   │   Spans: [...]   │   Spans: [...]   │
+│   Sent at 60s    │   Sent at 120s   │   Sent at 180s   │
+└──────────────────┴──────────────────┴──────────────────┘
+```
+
+This means there's no 30-second max like in the legacy V1 API — the profiler runs as long as your process does.
+
+---
+
+## Profiler API Reference
+
+### `Sentry.profiler.startProfiler()`
+
+Starts the V8 CpuProfiler. Call this once at process startup or before the code you want to profile.
+
+```typescript
+Sentry.profiler.startProfiler();
+```
+
+- No-ops gracefully if already running
+- Takes effect immediately
+- Overhead is low; safe to call at startup in production
+
+### `Sentry.profiler.stopProfiler()`
+
+Stops the profiler and flushes remaining profile data to Sentry.
+
+```typescript
+Sentry.profiler.stopProfiler();
+```
+
+- Flushes the current in-progress chunk
+- Call on graceful shutdown to avoid losing the last partial chunk
+
+### Manual Start/Stop Pattern
+
+```typescript
+// Profile a specific batch job, not the entire process
+async function runNightlyBatch() {
+  Sentry.profiler.startProfiler();
+  try {
+    await Sentry.startSpan({ op: "batch", name: "nightly-sync" }, async () => {
+      await syncUsers();
+      await syncOrders();
+      await syncInventory();
+    });
+  } finally {
+    Sentry.profiler.stopProfiler();
+  }
+}
+```
+
+---
+
+## Configuration Reference
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `profileSessionSampleRate` | `0.0–1.0` | Session-level sampling. Decision made once at process startup. |
+| `profileLifecycle` | `"trace" \| "manual"` | `"trace"` = auto-attach to spans; `"manual"` = explicit `startProfiler()`/`stopProfiler()` |
+| `nodeProfilingIntegration()` | integration | Enables V8 CpuProfiler. Must be in `integrations` array. |
+
+### `profileSessionSampleRate` Semantics
+
+The profiling sampling decision is made **once per process startup** — not per request.
+
+A "profiling session" either opts in or opts out for its entire lifetime. Within a profiling session, every traced span gets a profile attached (in `trace` mode).
+
+```typescript
+// 10% of Node.js processes will profile all their requests
+profileSessionSampleRate: 0.1
+```
+
+### `profileLifecycle` Modes
+
+| Mode | Trigger | Best for |
+|------|---------|----------|
+| `"trace"` | Auto-attached to every sampled span | Broad production coverage, web servers |
+| `"manual"` | `startProfiler()` / `stopProfiler()` | Batch jobs, specific hot paths, CLI tools |
+
+---
+
+## Supported Platforms
+
+Precompiled native binaries are available for:
+
+| OS | Architecture | Node.js |
+|----|--------------|---------|
+| macOS | x64 (Intel) | 18–24 |
+| macOS | ARM64 (Apple Silicon) | 18–24 |
+| Linux (glibc) | x64 | 18–24 |
+| Linux (glibc) | ARM64 | 18–24 |
+| Linux (musl/Alpine) | x64 | 18–24 |
+| Linux (musl/Alpine) | ARM64 | 18–24 |
+| Windows | x64 | 18–24 |
+
+> ❌ **FreeBSD, 32-bit systems, Bun, and Deno are not supported.**  
+> The native addon requires Node.js — it cannot run in other runtimes.
+
+### Alpine Linux / Docker
+
+The musl libc variant is included automatically. If you see missing binary errors on Alpine:
+
+```dockerfile
+# Ensure you're installing native dependencies
+RUN npm install --include=optional
+```
+
+Or rebuild from source:
+```dockerfile
+RUN apk add --no-cache python3 make g++ && npm rebuild @sentry/profiling-node
+```
+
+---
+
+## Environment Variables
+
+```bash
+# Override profiler binary path (for custom builds or non-standard environments)
+SENTRY_PROFILER_BINARY_PATH=/custom/path/sentry_cpu_profiler.node
+
+# Override binary directory
+SENTRY_PROFILER_BINARY_DIR=/path/to/dir
+
+# Profiler logging mode:
+# "eager" (default) — faster startProfiler calls, slightly more CPU overhead
+# "lazy"            — lower CPU overhead, slightly slower startProfiler
+SENTRY_PROFILER_LOGGING_MODE=lazy node server.js
+```
+
+---
+
+## Production Recommendations
+
+```typescript
+Sentry.init({
+  integrations: [nodeProfilingIntegration()],
+  tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  profileSessionSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1.0,
+  profileLifecycle: "trace",
+});
+```
+
+**Performance impact notes:**
+
+- **Sampling rate (~100Hz):** The V8 CpuProfiler adds CPU overhead. Test with realistic load before deploying `profileSessionSampleRate: 1.0` to high-traffic production.
+- **Memory:** Each 60-second chunk uses ~10–20 MB of buffer. Capped at 50 chunks (~100 MB max).
+- **Network:** One profiling upload per 60-second window per process.
+
+> "For high-throughput environments, we recommend testing prior to deployment to ensure that your service's performance characteristics maintain expectations." — Sentry docs
+
+For high-traffic servers, start conservative:
+
+```typescript
+// Start at 1–5% and increase after measuring overhead
+profileSessionSampleRate: 0.01
+```
+
+---
+
+## Complete Setup Example
+
+```typescript
+// instrument.ts (loaded before app code)
+import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+
+  integrations: [
+    nodeProfilingIntegration(),
+  ],
+
+  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  profileSessionSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+  profileLifecycle: "trace",
+});
+```
+
+```typescript
+// app.ts
+import "./instrument"; // Must be first import
+import express from "express";
+import * as Sentry from "@sentry/node";
+
+const app = express();
+
+app.get("/api/users", async (req, res) => {
+  // Automatically traced + profiled (in profiling sessions)
+  const users = await db.query("SELECT * FROM users");
+  res.json(users);
+});
+
+Sentry.setupExpressErrorHandler(app);
+app.listen(3000);
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No profiles appearing in Sentry | Verify `@sentry/profiling-node` version exactly matches `@sentry/node` version (`npm ls @sentry/profiling-node`) |
+| `Cannot find module '@sentry/profiling-node'` | Run `npm install @sentry/profiling-node` and confirm it's in `dependencies` (not `devDependencies`) |
+| Native addon fails to load | Check you're on Node.js ≥18; check OS/arch is in the supported platforms table |
+| Profiles not linked to spans | Confirm `profileLifecycle: "trace"` is set and `tracesSampleRate` > 0; both are required |
+| High CPU usage | Lower `profileSessionSampleRate`; use `SENTRY_PROFILER_LOGGING_MODE=lazy` |
+| Alpine/musl Linux binary error | Run `npm rebuild @sentry/profiling-node` after installing build tools (`apk add python3 make g++`) |
+| Profiling works locally but not in Docker | Ensure `npm install --include=optional` runs in the Docker build; musl variant must be present |
+| Flame graphs show minified names | Upload source maps via `authToken` in Sentry config; use `NODE_OPTIONS=--enable-source-maps` |
+| Last ~60s of data lost on shutdown | Call `Sentry.profiler.stopProfiler()` in your SIGTERM/SIGINT handler before `process.exit()` |
+| Bun or Deno profiling doesn't work | Native addon only supports Node.js — profiling is not available in Bun or Deno |

--- a/skills-next/references/sdks/node/tracing.md
+++ b/skills-next/references/sdks/node/tracing.md
@@ -1,0 +1,845 @@
+# Tracing — Sentry Node.js SDK
+
+> Minimum SDK: `@sentry/node` ≥8.0.0 (Node.js, Bun)  
+> `@sentry/deno` for Deno runtime  
+> `ignoreSpans`: ≥8.x  
+> `inheritOrSampleWith`: ≥9.x
+
+---
+
+## How Tracing Works in v8+
+
+`@sentry/node` v8 is **built on OpenTelemetry natively**. When you call `Sentry.init()`, it registers:
+
+- **`SentrySpanProcessor`** — captures OTel spans and sends them to Sentry
+- **`SentryPropagator`** — injects/extracts `sentry-trace` and `baggage` headers
+- **`SentrySampler`** — applies `tracesSampleRate` / `tracesSampler` decisions
+- **`SentryContextManager`** — manages active span context via AsyncLocalStorage
+
+This means **any OTel-compatible library** (custom or third-party) automatically produces spans visible in Sentry — no Sentry-specific code needed in those libraries.
+
+---
+
+## Activating Tracing
+
+Set **either** `tracesSampleRate` **or** `tracesSampler` in `Sentry.init()`. Without one of these, no spans are created.
+
+```typescript
+// instrument.ts (must run before your app)
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0, // 100% in development, lower in production
+});
+```
+
+> **To disable tracing entirely:** omit both `tracesSampleRate` and `tracesSampler`. Setting `tracesSampleRate: 0` activates the OTel machinery but drops all traces — not the same as disabled.
+
+---
+
+## `tracesSampleRate` — Uniform Sampling
+
+A number between `0.0` and `1.0`:
+
+```typescript
+Sentry.init({
+  tracesSampleRate: process.env.NODE_ENV === "development" ? 1.0 : 0.1,
+});
+```
+
+| Value | Effect |
+|-------|--------|
+| `1.0` | Capture 100% of traces |
+| `0.1` | Capture 10% of traces |
+| `0.0` | Initialize tracing but send nothing |
+| omitted | Tracing disabled entirely |
+
+---
+
+## `tracesSampler` — Dynamic Per-Request Sampling
+
+When defined, `tracesSampler` **takes precedence** over `tracesSampleRate`. Receives a `SamplingContext` and returns a number `0`–`1` (or boolean).
+
+```typescript
+// TypeScript: SamplingContext shape
+interface SamplingContext {
+  name: string;                                   // e.g. "GET /api/users"
+  attributes: SpanAttributes | undefined;
+  parentSampled: boolean | undefined;             // parent's sampling decision
+  parentSampleRate: number | undefined;
+  inheritOrSampleWith: (fallbackRate: number) => number; // ≥9.x
+}
+```
+
+### Route-Based Sampling
+
+```typescript
+Sentry.init({
+  tracesSampler: ({ name, inheritOrSampleWith }) => {
+    // Always drop health checks
+    if (name.includes("/health") || name.includes("/ping")) return 0;
+
+    // Always sample critical flows
+    if (name.includes("/checkout") || name.includes("/payment")) return 1.0;
+
+    // Honor parent's decision, fall back to 10%
+    return inheritOrSampleWith(0.1);
+  },
+});
+```
+
+### `inheritOrSampleWith()` (≥9.x)
+
+Respects the upstream trace's sampling decision. If no parent decision exists, applies your fallback rate. Always prefer this over checking `parentSampled` directly — it propagates rates accurately through distributed traces and sets the correct `sentry-sampled` value in `baggage`.
+
+```typescript
+// Without inheritOrSampleWith (manual check)
+tracesSampler: ({ parentSampled }) => {
+  if (parentSampled !== undefined) return parentSampled ? 1 : 0;
+  return 0.1;
+},
+
+// With inheritOrSampleWith (cleaner, accurate metric extrapolation)
+tracesSampler: ({ inheritOrSampleWith }) => inheritOrSampleWith(0.1),
+```
+
+### Sampling Precedence
+
+1. `tracesSampler` function (if defined) — evaluated first
+2. Parent's sampling decision (propagated via `sentry-trace` header)
+3. `tracesSampleRate` (uniform fallback)
+
+---
+
+## Auto-Instrumented Libraries
+
+`@sentry/node` v8 ships with **28+ auto-instrumented packages** via bundled OTel instrumentations. No additional configuration needed — they activate automatically on `Sentry.init()`.
+
+### HTTP & Web
+
+| Library | `op` | What's captured |
+|---------|------|-----------------|
+| `node:http` / `node:https` (incoming) | `http.server` | Method, URL, status code, duration |
+| `node:http` / `node:https` (outgoing) | `http.client` | Method, URL, status code, duration |
+| `fetch` / `undici` | `http.client` | Method, URL, status code (headers opt-in via `headersToSpanAttributes`) |
+| `axios` | `http.client` | Method, URL, status code |
+
+#### Capturing HTTP Headers on Fetch Spans
+
+Since `@opentelemetry/instrumentation-undici@0.22.0`, response headers like `content-length` are **no longer captured automatically** on outgoing `fetch`/`undici` spans. To restore header capture or add custom headers, use `headersToSpanAttributes` on `nativeNodeFetchIntegration()`:
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+  integrations: [
+    Sentry.nativeNodeFetchIntegration({
+      headersToSpanAttributes: {
+        requestHeaders: ["x-request-id", "x-custom-header"],
+        responseHeaders: ["content-length", "content-type"],
+      },
+    }),
+  ],
+});
+```
+
+Matched headers appear as span attributes: `http.request.header.<name>` and `http.response.header.<name>`.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `headersToSpanAttributes.requestHeaders` | `string[]` | `undefined` | Request header names to capture as span attributes |
+| `headersToSpanAttributes.responseHeaders` | `string[]` | `undefined` | Response header names to capture as span attributes |
+
+### Databases
+
+| Library | `op` | What's captured |
+|---------|------|-----------------|
+| `pg` (PostgreSQL) | `db.query` | SQL query text, duration |
+| `mysql2` | `db.query` | SQL query text, duration |
+| `mysql` | `db.query` | SQL query text, duration |
+| `mongodb` | `db` | Collection, operation name |
+| `redis` | `db.redis` | Command, key |
+| `ioredis` | `db.redis` | Command, key |
+| `prisma` (v5+) | `db.query` | SQL query, model |
+| `sequelize` | `db.query` | SQL query text |
+| `typeorm` | `db.query` | SQL query text |
+| `knex` | `db.query` | SQL query text |
+
+### Message Queues & Async
+
+| Library | `op` | What's captured |
+|---------|------|-----------------|
+| `kafkajs` | `queue.publish` / `queue.process` | Topic, partition |
+| `amqplib` | `queue.publish` / `queue.process` | Exchange, routing key |
+| `@google-cloud/pubsub` | `queue.publish` / `queue.process` | Topic, subscription |
+| `@aws-sdk/*` (SNS/SQS) | `queue.publish` / `queue.process` | Queue URL, message ID |
+| `bull` | `queue.process` | Job name, queue name |
+| `bullmq` | `queue.process` | Job name, queue name |
+
+### GraphQL & RPC
+
+| Library | `op` | What's captured |
+|---------|------|-----------------|
+| `graphql` / `apollo-server` | `graphql.resolve` | Operation name, field path |
+
+### AI/LLM
+
+| Library | `op` | What's captured |
+|---------|------|-----------------|
+| `@openai/sdk` | `ai.pipeline.*` | Model, tokens, prompt/completion |
+| `@anthropic-ai/sdk` | `ai.pipeline.*` | Model, tokens |
+| `langchain` | `ai.pipeline.*` | Chain, retriever, LLM operation |
+| `ai` (Vercel AI SDK) | `ai.pipeline.*` | Model, tokens |
+| `@google/generative-ai` | `ai.pipeline.*` | Model name |
+
+> **Note:** AI library instrumentation may require `Sentry.init()` with `skipOpenTelemetrySetup: false` (the default). See the AI Monitoring reference for full configuration.
+
+---
+
+## Custom Spans
+
+### `Sentry.startSpan()` — Active, Auto-Ending (Recommended)
+
+Creates an active span (children nest under it automatically) that ends when the callback returns or resolves:
+
+```typescript
+// Async
+const data = await Sentry.startSpan(
+  {
+    name: "fetchUserProfile",
+    op: "http.client",
+    attributes: { "user.id": userId, "cache.hit": false },
+  },
+  async () => {
+    const res = await fetch(`/api/users/${userId}`);
+    return res.json();
+  },
+);
+
+// Sync
+const result = Sentry.startSpan(
+  { name: "computeScore", op: "function" },
+  () => expensiveComputation(),
+);
+```
+
+### Nested Spans (Parent–Child Hierarchy)
+
+```typescript
+await Sentry.startSpan({ name: "checkout-flow", op: "function" }, async () => {
+  // Automatically children of "checkout-flow"
+  const cart = await Sentry.startSpan(
+    { name: "fetchCart", op: "db.query" },
+    () => db.cart.findUnique({ where: { userId } }),
+  );
+
+  const payment = await Sentry.startSpan(
+    { name: "processPayment", op: "http.client" },
+    () => stripe.paymentIntents.create({ amount: cart.total }),
+  );
+
+  return { cart, payment };
+});
+```
+
+### `Sentry.startSpanManual()` — Active, Manual End
+
+Use when the span lifetime cannot be enclosed in a callback (e.g., middleware with async continuations):
+
+```typescript
+function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  return Sentry.startSpanManual({ name: "auth.verify", op: "middleware" }, (span) => {
+    res.once("finish", () => {
+      span.setStatus({ code: res.statusCode < 400 ? 1 : 2 });
+      span.end(); // ← required; leaks if omitted
+    });
+    return next();
+  });
+}
+```
+
+### `Sentry.startInactiveSpan()` — Not Active, Manual End
+
+Creates a span that is **never** automatically made active. Use for parallel work or spans that don't fit the call stack:
+
+```typescript
+// Parallel independent operations
+const spanA = Sentry.startInactiveSpan({ name: "operation-a" });
+const spanB = Sentry.startInactiveSpan({ name: "operation-b" });
+
+await Promise.all([doA(), doB()]);
+
+spanA.end();
+spanB.end();
+
+// Explicit parent assignment
+const parent = Sentry.startInactiveSpan({ name: "parent" });
+const child = Sentry.startInactiveSpan({ name: "child", parentSpan: parent });
+child.end();
+parent.end();
+```
+
+### `Sentry.withActiveSpan()` — Temporarily Activate a Span
+
+Makes an inactive span active for the duration of a callback. Does **not** end the span:
+
+```typescript
+const backgroundSpan = Sentry.startInactiveSpan({ name: "background-task", op: "task" });
+
+await Sentry.withActiveSpan(backgroundSpan, async () => {
+  // Any nested startSpan() calls are children of backgroundSpan
+  await sendEmails();
+  await db.save(results);
+});
+
+backgroundSpan.end();
+```
+
+---
+
+## Span Options Reference
+
+```typescript
+interface StartSpanOptions {
+  name: string;               // Required: label shown in the UI
+  op?: string;                // Operation category (see table below)
+  attributes?: Record<string, string | number | boolean>;
+  parentSpan?: Span;          // Override automatic parent
+  onlyIfParent?: boolean;     // Skip span if no active parent exists
+  forceTransaction?: boolean; // Force display as root transaction in UI
+  startTime?: number;         // Unix timestamp in seconds
+}
+```
+
+**Common `op` values:**
+
+| `op` | Use for |
+|------|---------|
+| `http.client` | Outgoing HTTP requests |
+| `http.server` | Incoming HTTP requests |
+| `db` / `db.query` | Database queries |
+| `db.redis` | Redis operations |
+| `function` | General function calls |
+| `queue.publish` | Publishing to message queues |
+| `queue.process` | Consuming from message queues |
+| `cache.get` / `cache.put` | Cache reads/writes |
+| `task` | Background / scheduled work |
+| `ai.pipeline.*` | AI/LLM inference calls |
+
+---
+
+## Span Enrichment
+
+```typescript
+// Set attributes on the currently active span
+const span = Sentry.getActiveSpan();
+if (span) {
+  span.setAttribute("db.table", "users");
+  span.setAttributes({
+    "http.method": "POST",
+    "order.total": 99.99,
+    "user.tier": "premium",
+  });
+
+  // Status: 0=unset, 1=ok, 2=error
+  span.setStatus({ code: 1 });
+  span.setStatus({ code: 2, message: "Payment declined" });
+}
+
+// Record an exception on the active span
+const span = Sentry.getActiveSpan();
+if (span) span.recordException(error);
+
+// Rename a span at runtime
+Sentry.updateSpanName(span, "GET /users/:id");
+
+// Modify all spans globally before sending
+Sentry.init({
+  beforeSendSpan(span) {
+    // Add deployment metadata to every span
+    span.data = { ...span.data, "deployment.region": process.env.AWS_REGION };
+    return span; // return null to drop (prefer ignoreSpans for filtering)
+  },
+});
+```
+
+---
+
+## Advanced Span APIs
+
+### `continueTrace()` — Continue an Incoming Trace
+
+For message queues, cron triggers, and other non-HTTP channels that carry trace headers:
+
+```typescript
+Sentry.continueTrace(
+  {
+    sentryTrace: message.headers["sentry-trace"],
+    baggage: message.headers["baggage"],
+  },
+  () => {
+    return Sentry.startSpan({ name: "processJob", op: "queue.process" }, () =>
+      doWork(),
+    );
+  },
+);
+```
+
+> HTTP servers handled by framework integrations (Express, Fastify, etc.) call `continueTrace()` automatically. You only need it for non-HTTP channels.
+
+### `startNewTrace()` — Force a New Trace
+
+Breaks the distributed chain — creates an independent trace with a new `traceId`:
+
+```typescript
+Sentry.startNewTrace(() => {
+  return Sentry.startSpan({ name: "isolated-background-job" }, () => doWork());
+});
+```
+
+### `suppressTracing()` — Prevent Span Capture
+
+Suppresses span creation inside the callback, even for auto-instrumented code:
+
+```typescript
+// Health check polling — don't create spans
+const result = await Sentry.suppressTracing(() => {
+  return fetch("/internal/health");
+});
+```
+
+### `getActiveSpan()`, `getRootSpan()`
+
+```typescript
+const span = Sentry.getActiveSpan();
+if (span) {
+  const root = Sentry.getRootSpan(span);
+  console.log(Sentry.spanToJSON(root).name);
+}
+```
+
+### `forceTransaction` and `onlyIfParent`
+
+```typescript
+// Force span to appear as root transaction in Sentry UI
+Sentry.startSpan(
+  { name: "background-job", op: "function", forceTransaction: true },
+  () => runBackgroundJob(),
+);
+
+// Only create span when an active parent exists (drop orphan spans)
+Sentry.startSpan(
+  { name: "optional-metric", onlyIfParent: true },
+  () => measureSomething(),
+);
+```
+
+---
+
+## `ignoreSpans` — Filtering Spans
+
+Drop specific spans before they are sent. Accepts strings (substring match), RegExp, functions, or objects with an optional `attributes` field for attribute-based matching:
+
+```typescript
+Sentry.init({
+  ignoreSpans: [
+    // Drop health check spans (string substring match)
+    "health",
+    // Drop spans by name pattern (RegExp)
+    /health|heartbeat|ping/,
+    // Drop internal DB keepalive queries (function)
+    (span) => span.op === "db.query" && span.description?.includes("SELECT 1"),
+    // Drop spans matching specific attributes (object form, SDK ≥9.x)
+    {
+      name: /health/,             // optional: name/op substring or RegExp
+      attributes: {
+        "http.url": "/health",    // string = substring match
+        "http.status_code": 200,  // non-string = strict equality
+      },
+    },
+  ],
+});
+```
+
+The `attributes` field on an object entry matches span attributes: string values use substring/RegExp matching, non-string values (numbers, booleans, arrays) use strict equality.
+
+---
+
+## Distributed Tracing
+
+### How It Works
+
+Sentry injects two headers into outgoing HTTP requests:
+
+| Header | Format | Purpose |
+|--------|--------|---------|
+| `sentry-trace` | `{traceId}-{spanId}-{sampled}` | Carries trace context |
+| `baggage` | W3C Baggage with `sentry-*` keys | Carries sampling decision + metadata |
+
+Backends must allowlist these for CORS:
+```
+Access-Control-Allow-Headers: sentry-trace, baggage
+```
+
+### `tracePropagationTargets`
+
+Controls which outgoing requests get trace headers. Accepts strings (substring match) and/or RegExp:
+
+```typescript
+Sentry.init({
+  tracePropagationTargets: [
+    "localhost",                           // any URL containing "localhost"
+    /^https:\/\/api\.yourapp\.com/,        // your API
+    /^https:\/\/auth\.yourapp\.com/,       // auth service
+  ],
+});
+```
+
+**Default:** `['localhost', /^\//]` — only localhost and relative paths.  
+**Disable entirely:** `tracePropagationTargets: []`
+
+> ⚠️ If your API is at `http://localhost:3001`, use `"localhost:3001"` or a regex matching the port — `"localhost"` alone won't match.
+
+### Manual Trace Propagation (Non-HTTP Channels)
+
+For Kafka, AMQP, WebSockets, and other protocols:
+
+```typescript
+// Publisher — extract current trace context
+import * as Sentry from "@sentry/node";
+
+await Sentry.startSpan({ name: "Publish order event", op: "queue.publish" }, async () => {
+  const traceData = Sentry.getTraceData();
+  // Returns: { "sentry-trace": "...", "baggage": "..." }
+
+  await kafka.send({
+    topic: "orders",
+    messages: [{
+      value: JSON.stringify({ orderId: 123 }),
+      headers: {
+        "sentry-trace": traceData["sentry-trace"],
+        "baggage": traceData["baggage"],
+      },
+    }],
+  });
+});
+
+// Consumer — continue the trace
+consumer.run({
+  eachMessage: async ({ message }) => {
+    Sentry.continueTrace(
+      {
+        sentryTrace: message.headers["sentry-trace"]?.toString(),
+        baggage: message.headers["baggage"]?.toString(),
+      },
+      () => Sentry.startSpan({ name: "Process order", op: "queue.process" }, () =>
+        processOrder(message),
+      ),
+    );
+  },
+});
+```
+
+### Head-Based Sampling
+
+The originating (head) service makes the sampling decision and propagates it via `sentry-trace`. All downstream services either all sample or all drop — ensuring complete traces, never partial ones.
+
+---
+
+## Framework Auto-Instrumentation
+
+Framework integrations are included in `@sentry/node` and activated automatically. You don't add them via `integrations: []` — they are registered when you call `Sentry.init()` and `setupXxxErrorHandler()`.
+
+### Express
+
+```typescript
+import express from "express";
+import * as Sentry from "@sentry/node";
+
+// instrument.ts must load FIRST — before express is required
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+
+const app = express();
+
+app.get("/api/users/:id", async (req, res) => {
+  // DB queries are automatically child spans of this HTTP transaction
+  const user = await db.users.findUnique({ where: { id: req.params.id } });
+  res.json(user);
+});
+
+// Error handler AFTER all routes
+Sentry.setupExpressErrorHandler(app);
+app.listen(3000);
+```
+
+Sentry automatically traces all incoming requests. Each `GET /api/users/:id` becomes an `http.server` transaction with DB query spans as children.
+
+### Fastify
+
+```typescript
+import Fastify from "fastify";
+import * as Sentry from "@sentry/node";
+
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+
+const fastify = Fastify();
+
+// Error handler BEFORE routes (Fastify-specific — not async, unlike Hapi)
+Sentry.setupFastifyErrorHandler(fastify);
+
+fastify.get("/api/data", async (request, reply) => {
+  return fetchData();
+});
+
+await fastify.listen({ port: 3000 });
+```
+
+### Koa
+
+```typescript
+import Koa from "koa";
+import * as Sentry from "@sentry/node";
+
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+
+const app = new Koa();
+Sentry.setupKoaErrorHandler(app); // FIRST middleware
+
+app.use(async (ctx) => {
+  ctx.body = await fetchData();
+});
+
+app.listen(3000);
+```
+
+### Hapi
+
+```typescript
+import Hapi from "@hapi/hapi";
+import * as Sentry from "@sentry/node";
+
+Sentry.init({ dsn: "...", tracesSampleRate: 1.0 });
+
+const server = Hapi.server({ port: 3000 });
+await Sentry.setupHapiErrorHandler(server); // must await
+
+server.route({
+  method: "GET",
+  path: "/api/data",
+  handler: async (request) => fetchData(),
+});
+
+await server.start();
+```
+
+### NestJS
+
+> **NestJS has a dedicated skill: [[`nestjs`](../nestjs/index.md)](../nestjs/index.md)**
+> It covers `SentryModule.forRoot()`, `@SentryTraced` decorator for custom spans,
+> `SentryTracingInterceptor`, and GraphQL resolver tracing.
+
+---
+
+## Configuration Reference
+
+```typescript
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+
+  // Sampling
+  tracesSampleRate: 0.1,
+  // OR:
+  tracesSampler: ({ name, inheritOrSampleWith }) => {
+    if (name.includes("/health")) return 0;
+    if (name.includes("/checkout")) return 1.0;
+    return inheritOrSampleWith(0.1);
+  },
+
+  // Propagation — which outgoing requests get trace headers
+  tracePropagationTargets: [
+    "localhost",
+    /^https:\/\/api\.yourapp\.com/,
+  ],
+
+  // Drop specific spans before sending
+  ignoreSpans: [
+    /health|ping/,
+    (span) => span.op === "db.query" && span.description?.includes("SELECT 1"),
+  ],
+
+  // Modify all spans before sending (or return null to drop)
+  beforeSendSpan(span) {
+    if (span.op === "http.client" && span.data?.url?.includes("/internal")) {
+      return null; // drop internal health check spans
+    }
+    return span;
+  },
+
+  // Capture HTTP headers on outgoing fetch/undici spans
+  integrations: [
+    Sentry.nativeNodeFetchIntegration({
+      headersToSpanAttributes: {
+        requestHeaders: ["x-request-id"],
+        responseHeaders: ["content-length", "content-type"],
+      },
+    }),
+  ],
+});
+```
+
+**Environment variables:**
+
+| Variable | Effect |
+|----------|--------|
+| `SENTRY_TRACES_SAMPLE_RATE` | Sets `tracesSampleRate` |
+| `SENTRY_ENVIRONMENT` | Sets `environment` |
+
+---
+
+## Runtime Differences
+
+### Node.js
+
+Full tracing support via `@sentry/node`. All 28+ auto-instrumentations available. Profiling available via `@sentry/profiling-node`.
+
+```typescript
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: "...",
+  tracesSampleRate: 1.0,
+});
+```
+
+### Bun
+
+`@sentry/bun` wraps `@sentry/node` — tracing is 99% identical to Node.js. The same auto-instrumentation table applies. Profiling is **not** available (native addon incompatible with Bun).
+
+```typescript
+// bun-instrument.ts — loaded via --preload
+import * as Sentry from "@sentry/bun";
+
+Sentry.init({
+  dsn: "...",
+  tracesSampleRate: 1.0,
+});
+```
+
+```bash
+bun --preload ./bun-instrument.ts run app.ts
+```
+
+`Bun.serve()` is automatically instrumented — each request becomes an `http.server` transaction.
+
+### Deno
+
+`@sentry/deno` uses `npm:@sentry/deno`. Auto-instrumented libraries are limited — Deno doesn't load Node.js OTel instrumentations. Custom spans work identically.
+
+```typescript
+import * as Sentry from "npm:@sentry/deno";
+
+Sentry.init({
+  dsn: "...",
+  tracesSampleRate: 1.0,
+});
+
+// Deno.serve — wrap handlers manually (not auto-instrumented)
+Deno.serve(async (req) => {
+  return Sentry.startSpan(
+    { name: `${req.method} ${new URL(req.url).pathname}`, op: "http.server" },
+    async () => {
+      const data = await handleRequest(req);
+      return new Response(JSON.stringify(data));
+    },
+  );
+});
+```
+
+**Runtime comparison:**
+
+| Feature | Node.js | Bun | Deno |
+|---------|---------|-----|------|
+| Tracing (OTel) | ✅ Full | ✅ Via Node | ✅ Custom OTel |
+| HTTP auto-instrumentation | ✅ | ✅ | ⚠️ Manual |
+| Database auto-instrumentation | ✅ 10+ drivers | ✅ | ❌ |
+| Message queue auto-instrumentation | ✅ | ✅ | ❌ |
+| Profiling | ✅ | ❌ | ❌ |
+| Custom spans | ✅ | ✅ | ✅ |
+| Distributed tracing | ✅ | ✅ | ✅ |
+
+---
+
+## Complete Example
+
+```typescript
+// instrument.ts — loaded first via --require or --import
+import * as Sentry from "@sentry/node";
+
+Sentry.init({
+  dsn: process.env.SENTRY_DSN,
+  environment: process.env.NODE_ENV,
+
+  tracesSampler: ({ name, inheritOrSampleWith }) => {
+    if (name.includes("/health") || name.includes("/ping")) return 0;
+    if (name.includes("/checkout") || name.includes("/payment")) return 1.0;
+    return inheritOrSampleWith(0.1);
+  },
+
+  tracePropagationTargets: [
+    "localhost",
+    /^https:\/\/api\.myapp\.com/,
+    /^https:\/\/auth\.myapp\.com/,
+  ],
+
+  ignoreSpans: [/health|heartbeat/],
+});
+```
+
+```typescript
+// orders.service.ts
+import * as Sentry from "@sentry/node";
+
+export async function createOrder(userId: string, items: Item[]) {
+  return Sentry.startSpan({ name: "createOrder", op: "function" }, async () => {
+    // DB queries are automatically child spans
+    const user = await db.users.findUnique({ where: { id: userId } });
+
+    const total = await Sentry.startSpan(
+      { name: "calculateTotal", op: "function" },
+      () => computeTotal(items),
+    );
+
+    // Enrich the active span
+    const span = Sentry.getActiveSpan();
+    if (span) {
+      span.setAttributes({ "order.total": total, "order.item_count": items.length });
+    }
+
+    // Outgoing HTTP — automatically traced
+    const payment = await stripe.paymentIntents.create({ amount: total });
+
+    return db.orders.create({ data: { userId, items, total, paymentId: payment.id } });
+  });
+}
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| No transactions in Performance dashboard | Verify `tracesSampleRate` or `tracesSampler` is set; `Sentry.init()` must run before any imports |
+| Spans missing for DB queries | Confirm the driver is in the auto-instrumentation table above; `Sentry.init()` must run first |
+| Distributed trace not linking services | Add the target URL to `tracePropagationTargets`; verify `Access-Control-Allow-Headers: sentry-trace, baggage` |
+| `tracePropagationTargets` port not matching | `"localhost"` won't match `localhost:3001` — use `"localhost:3001"` or a regex |
+| `continueTrace()` not linking to parent | Confirm incoming headers are `"sentry-trace"` and `"baggage"` (not `traceparent`) |
+| High transaction volume | Use `tracesSampler` to return `0` for health checks; lower default rate |
+| `tracesSampler` not working | When both `tracesSampler` and `tracesSampleRate` are set, `tracesSampler` wins — expected |
+| Spans show generic names (raw URLs) | Use `beforeSendSpan` or framework route parameterization to normalize names |
+| Bun profiling not working | Profiling requires `@sentry/profiling-node` native addon — incompatible with Bun |
+| Deno DB spans missing | Deno doesn't load Node.js OTel instrumentations; use `startSpan()` manually |


### PR DESCRIPTION
Direct LLM port of the existing `node` SDK skill into the skills-next per-SDK reference layout under `skills-next/references/sdks/node/`. This content has NOT been reviewed at all — it is a machine-generated port of the existing SDK skill, and every file should be treated as unverified.