### PR TITLE
feat(skills): Remove "Invoke This Skill When" & improve skill frontmatter descriptions 

### DIFF
--- a/.github/agents/skill-creator.agent.md
+++ b/.github/agents/skill-creator.agent.md
@@ -5,7 +5,7 @@ description: >
   any platform or framework. Researches official docs, clones the SDK repo to
   verify APIs against source code, studies existing skills for patterns, and
   produces a full skill bundle (SKILL.md + reference files) with a PR.
-  Use when asked to "create a skill for <platform>" or "add SDK support for <framework>".
+  Use when asked to "create a skill for [platform]" or "add SDK support for [framework]".
 tools:
   - read
   - edit
@@ -44,8 +44,7 @@ Before writing anything, read 2 existing SDK skills to internalize the patterns:
 - **One frontend skill**: read `skills/sentry-nextjs-sdk/SKILL.md` and 2-3 of its `references/*.md` files
 
 Study them for:
-- Frontmatter fields and format
-- "Invoke This Skill When" trigger phrase style
+- Frontmatter fields and format — the `description` carries the "Use when …" trigger phrases (single line, no XML tags); there is no separate "when to use" section in the body
 - Phase 1 detection commands (real bash, not pseudo-code)
 - Phase 2 recommendation matrix (opinionated: always/when detected/optional)
 - Phase 3 guide structure (wizard option, manual setup, reference dispatch table)

--- a/.github/agents/skill-creator.agent.md
+++ b/.github/agents/skill-creator.agent.md
@@ -44,7 +44,7 @@ Before writing anything, read 2 existing SDK skills to internalize the patterns:
 - **One frontend skill**: read `skills/sentry-nextjs-sdk/SKILL.md` and 2-3 of its `references/*.md` files
 
 Study them for:
-- Frontmatter fields and format — the `description` carries the "Use when …" trigger phrases (single line, no XML tags); there is no separate "when to use" section in the body
+- Frontmatter fields and format — the `description` carries the "Use when …" trigger phrases (single line, max. 1024 characters, no XML tags); there is no separate "when to use" section in the body
 - Phase 1 detection commands (real bash, not pseudo-code)
 - Phase 2 recommendation matrix (opinionated: always/when detected/optional)
 - Phase 3 guide structure (wizard option, manual setup, reference dispatch table)

--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -97,10 +97,10 @@ Debug production issues and maintain code quality with Sentry context.
 
 | Use when | Skill | Path |
 |---|---|---|
-| Analyze and resolve Sentry comments on GitHub Pull Requests | [`sentry-code-review`](skills/sentry-code-review/SKILL.md) | `sentry-code-review/SKILL.md` |
-| Find and fix issues from Sentry using MCP | [`sentry-fix-issues`](skills/sentry-fix-issues/SKILL.md) | `sentry-fix-issues/SKILL.md` |
-| Review a project's PRs to check for issues detected in code review by Seer Bug Prediction | [`sentry-pr-code-review`](skills/sentry-pr-code-review/SKILL.md) | `sentry-pr-code-review/SKILL.md` |
-| Upgrade the Sentry JavaScript SDK across major versions | [`sentry-sdk-upgrade`](skills/sentry-sdk-upgrade/SKILL.md) | `sentry-sdk-upgrade/SKILL.md` |
+| Analyze and resolve comments from sentry[bot] on GitHub pull requests | [`sentry-code-review`](skills/sentry-code-review/SKILL.md) | `sentry-code-review/SKILL.md` |
+| Find and fix production issues from Sentry using the Sentry MCP server | [`sentry-fix-issues`](skills/sentry-fix-issues/SKILL.md) | `sentry-fix-issues/SKILL.md` |
+| Review and fix issues flagged by Seer Bug Prediction in GitHub PR comments | [`sentry-pr-code-review`](skills/sentry-pr-code-review/SKILL.md) | `sentry-pr-code-review/SKILL.md` |
+| Upgrade the Sentry JavaScript SDK across major versions with guided migration | [`sentry-sdk-upgrade`](skills/sentry-sdk-upgrade/SKILL.md) | `sentry-sdk-upgrade/SKILL.md` |
 
 ## Feature Setup
 
@@ -108,14 +108,14 @@ Configure specific Sentry capabilities beyond basic SDK setup.
 
 | Feature | Skill | Path |
 |---|---|---|
-| Create Sentry alerts using the workflow engine API | [`sentry-create-alert`](skills/sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
-| Decide which Sentry signal to reach for when instrumenting code — error, span, span attribute, log, or metric | [`sentry-instrumentation-guide`](skills/sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
-| Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
-| Setup Sentry AI Agent Monitoring in any project | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
+| Create Sentry alerts using the workflow engine API (currently beta) | [`sentry-create-alert`](skills/sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
+| Decision framework for choosing the right Sentry signal when instrumenting code — error, span, span attribute, log, or metric | [`sentry-instrumentation-guide`](skills/sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
+| Configure the OpenTelemetry Collector with the Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
+| Set up Sentry AI Agent Monitoring to track LLM calls, agent executions, tool usage, and token consumption | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
 | Full Sentry Snapshots setup for Apple/Cocoa projects | [`sentry-snapshots-cocoa`](skills/sentry-snapshots-cocoa/SKILL.md) | `sentry-snapshots-cocoa/SKILL.md` |
-| Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-dart`](skills/sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
-| Migrate JavaScript SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-js`](skills/sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
-| Migrate Python SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-python`](skills/sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |
+| Migrate the Dart and Flutter Sentry SDK from transaction-based to streamed span delivery (span-first trace lifecycle) | [`sentry-span-streaming-dart`](skills/sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
+| Migrate the JavaScript Sentry SDK from transaction-based to streamed span delivery (span-first trace lifecycle) | [`sentry-span-streaming-js`](skills/sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
+| Migrate the Python Sentry SDK from transaction-based to streamed span delivery (span-first trace lifecycle) | [`sentry-span-streaming-python`](skills/sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |
 
 ## Quick Lookup
 

--- a/skills/sentry-android-sdk/SKILL.md
+++ b/skills/sentry-android-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-android-sdk
-description: Full Sentry SDK setup for Android. Use when asked to "add Sentry to Android", "install sentry-android", "setup Sentry in Android", or configure error monitoring, tracing, profiling, session replay, or logging for Android applications. Supports Kotlin and Java codebases.
+description: Full Sentry SDK setup for Android. Use when asked to "add Sentry to Android", "install sentry-android", or set up crash reporting, ANR detection, error monitoring, tracing, profiling, session replay, or logging in a Kotlin or Java Android app. Covers native (NDK) crashes, app startup performance, io.sentry:sentry-android, and Jetpack Compose. Supports Kotlin and Java codebases.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Android SDK
 
 Opinionated wizard that scans your Android project and guides you through complete Sentry setup — error monitoring, tracing, profiling, session replay, logging, and more.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Android" or "set up Sentry" in an Android app
-- User wants error monitoring, crash reporting, ANR detection, tracing, profiling, session replay, or logging in Android
-- User mentions `sentry-android`, `io.sentry:sentry-android`, mobile crash tracking, or Sentry for Kotlin/Java Android
-- User wants to monitor native (NDK) crashes, application not responding (ANR) events, or app startup performance
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`io.sentry:sentry-android:8.33.0`, Gradle plugin `6.1.0`).
 > Always verify against [docs.sentry.io/platforms/android/](https://docs.sentry.io/platforms/android/) before implementing.

--- a/skills/sentry-browser-sdk/SKILL.md
+++ b/skills/sentry-browser-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-browser-sdk
-description: Full Sentry SDK setup for browser JavaScript. Use when asked to "add Sentry to a website", "install @sentry/browser", or configure error monitoring, tracing, session replay, or logging for vanilla JavaScript, jQuery, static sites, or WordPress.
+description: Full Sentry SDK setup for browser JavaScript. Use when asked to "add Sentry to a website", "install @sentry/browser", set up the Loader Script or CDN snippet, or configure error monitoring, tracing, session replay, or logging for plain JavaScript with no framework-specific SDK. Covers vanilla JS, jQuery, WordPress, Shopify, Squarespace, and static HTML sites.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry Browser SDK
 
 Opinionated wizard that scans your project and guides you through complete Sentry setup for browser JavaScript — vanilla JS, jQuery, static sites, WordPress, and any JS project without a framework-specific SDK.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to a website" or set up Sentry for plain JavaScript
-- User wants to install `@sentry/browser` or configure the Loader Script
-- User has a WordPress, Shopify, Squarespace, or static HTML site
-- User wants error monitoring, tracing, session replay, or logging without a framework
-- No framework-specific SDK applies
 
 > **Note:** SDK versions and APIs below reflect `@sentry/browser` ≥10.0.0.
 > Always verify against [docs.sentry.io/platforms/javascript/](https://docs.sentry.io/platforms/javascript/) before implementing.

--- a/skills/sentry-cloudflare-sdk/SKILL.md
+++ b/skills/sentry-cloudflare-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cloudflare-sdk
-description: Full Sentry SDK setup for Cloudflare Workers and Pages. Use when asked to "add Sentry to Cloudflare Workers", "install @sentry/cloudflare", or configure error monitoring, tracing, logging, crons, or AI monitoring on Cloudflare. Covers withSentry, sentryPagesPlugin, instrumentDurableObjectWithSentry, instrumentD1WithSentry, and monitoring Durable Objects, D1, Queues, Workflows, Scheduled handlers, Email handlers, and Hono.
+description: Full Sentry SDK setup for Cloudflare Workers and Pages. Use when asked to "add Sentry to Cloudflare Workers", "install @sentry/cloudflare", or configure error monitoring, tracing, logging, crons, or AI monitoring on Cloudflare. Covers withSentry, sentryPagesPlugin, instrumentDurableObjectWithSentry, and monitoring Durable Objects, D1, Queues, Workflows, Scheduled handlers, Email handlers, and Hono.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup

--- a/skills/sentry-cloudflare-sdk/SKILL.md
+++ b/skills/sentry-cloudflare-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cloudflare-sdk
-description: Full Sentry SDK setup for Cloudflare Workers and Pages. Use when asked to "add Sentry to Cloudflare Workers", "install @sentry/cloudflare", or configure error monitoring, tracing, logging, crons, or AI monitoring for Cloudflare Workers, Pages, Durable Objects, Queues, Workflows, or Hono on Cloudflare.
+description: Full Sentry SDK setup for Cloudflare Workers and Pages. Use when asked to "add Sentry to Cloudflare Workers", "install @sentry/cloudflare", or configure error monitoring, tracing, logging, crons, or AI monitoring on Cloudflare. Covers withSentry, sentryPagesPlugin, instrumentDurableObjectWithSentry, instrumentD1WithSentry, and monitoring Durable Objects, D1, Queues, Workflows, Scheduled handlers, Email handlers, and Hono.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry Cloudflare SDK
 
 Opinionated wizard that scans your Cloudflare project and guides you through complete Sentry setup for Workers, Pages, Durable Objects, Queues, Workflows, and Hono.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Cloudflare Workers" or "set up Sentry" in a Cloudflare project
-- User wants to install or configure `@sentry/cloudflare`
-- User wants error monitoring, tracing, logging, crons, or AI monitoring for Cloudflare Workers or Pages
-- User asks about `withSentry`, `sentryPagesPlugin`, `instrumentDurableObjectWithSentry`, or `instrumentD1WithSentry`
-- User wants to monitor Durable Objects, Queues, Workflows, Scheduled handlers, or Email handlers on Cloudflare
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/cloudflare` v10.61.0).
 > Always verify against [docs.sentry.io/platforms/javascript/guides/cloudflare/](https://docs.sentry.io/platforms/javascript/guides/cloudflare/) before implementing.

--- a/skills/sentry-cocoa-sdk/SKILL.md
+++ b/skills/sentry-cocoa-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-cocoa-sdk
-description: Full Sentry SDK setup for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS). Use when asked to "add Sentry to iOS", "add Sentry to Swift", "install sentry-cocoa", or configure error monitoring, tracing, profiling, session replay, logging, or metrics for Apple applications. Supports SwiftUI and UIKit.
+description: Full Sentry SDK setup for Apple platforms (iOS, macOS, tvOS, watchOS, visionOS). Use when asked to "add Sentry to iOS/macOS", "add Sentry to Swift", "install sentry-cocoa", or set up crash reporting, error monitoring, tracing, profiling, session replay, logging, or metrics for Apple apps. Covers SentrySDK setup, app hangs, watchdog terminations, and performance in Swift or Objective-C. Supports SwiftUI and UIKit.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Cocoa SDK
 
 Opinionated wizard that scans your Apple project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to iOS/macOS/tvOS" or "set up Sentry" in an Apple app
-- User wants error monitoring, tracing, profiling, session replay, or logging in Swift/ObjC, or metrics in Swift
-- User mentions `sentry-cocoa`, `SentrySDK`, or the Apple/iOS Sentry SDK
-- User wants to monitor crashes, app hangs, watchdog terminations, or performance
 
 > **Note:** SDK versions and APIs below reflect Sentry docs at time of writing (sentry-cocoa 9.15.0).
 > Always verify against [docs.sentry.io/platforms/apple/](https://docs.sentry.io/platforms/apple/) before implementing.

--- a/skills/sentry-code-review/SKILL.md
+++ b/skills/sentry-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-code-review
-description: Analyze and resolve Sentry comments on GitHub Pull Requests. Use this when asked to review or fix issues identified by Sentry in PR comments. Can review specific PRs by number or automatically find recent PRs with Sentry feedback.
+description: Analyze and resolve comments from sentry[bot] on GitHub pull requests. Use when asked to "review Sentry comments", "fix Sentry bot feedback", or resolve issues flagged by Sentry in PR review comments. Reviews a specific PR by number or automatically finds recent PRs with Sentry feedback, and processes only sentry[bot] comments while ignoring other bots. Requires the gh CLI.
 allowed-tools: Read, Edit, Write, Bash, Grep, Glob, WebFetch, AskUserQuestion
 category: workflow
 parent: sentry-workflow

--- a/skills/sentry-create-alert/SKILL.md
+++ b/skills/sentry-create-alert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-create-alert
-description: Create Sentry alerts using the workflow engine API. Use when asked to create alerts, set up notifications, configure issue priority alerts, or build workflow automations. Supports email, Slack, PagerDuty, Discord, and other notification actions.
+description: Create Sentry alerts using the workflow engine API (currently beta). Use when asked to "create a Sentry alert", "set up notifications", configure issue priority or de-escalation alerts, get notified when issues match conditions, or build workflow automations. Supports email, Slack, PagerDuty, Discord, and other notification actions. Requires curl and an org auth token with alerts:write scope.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup
@@ -14,13 +14,6 @@ disable-model-invocation: true
 Create alerts via Sentry's workflow engine API.
 
 **Note:** This API is currently in **beta** and may be subject to change. It is part of New Monitors and Alerts and may not be viewable in the legacy Alerts UI.
-
-## Invoke This Skill When
-
-- User asks to "create a Sentry alert" or "set up notifications"
-- User wants to be emailed or notified when issues match certain conditions
-- User mentions priority alerts, de-escalation alerts, or workflow automations
-- User wants to configure Slack, PagerDuty, or email notifications for Sentry issues
 
 ## Prerequisites
 

--- a/skills/sentry-dotnet-sdk/SKILL.md
+++ b/skills/sentry-dotnet-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-dotnet-sdk
-description: Full Sentry SDK setup for .NET. Use when asked to "add Sentry to .NET", "install Sentry for C#", or configure error monitoring, tracing, profiling, logging, or crons for ASP.NET Core, MAUI, WPF, WinForms, Blazor, Azure Functions, or any other .NET application.
+description: Full Sentry SDK setup for .NET. Use when asked to "add Sentry to .NET", "install Sentry for C#", "set up Sentry in ASP.NET Core", or configure error monitoring, tracing, profiling, logging, or crons for a .NET app. Covers SentrySdk.Init, UseSentry, SentryOptions, BeforeSend, TracesSampleRate, and symbol upload across ASP.NET Core, MAUI, WPF, WinForms, Blazor, and Azure Functions.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry .NET SDK
 
 Opinionated wizard that scans your .NET project and guides you through complete Sentry setup: error monitoring, distributed tracing, profiling, structured logging, and cron monitoring across all major .NET frameworks.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to .NET", "set up Sentry in C#", or "install Sentry for ASP.NET Core"
-- User wants error monitoring, tracing, profiling, logging, or crons for a .NET app
-- User mentions `SentrySdk.Init`, `UseSentry`, `Sentry.AspNetCore`, or `Sentry.Maui`
-- User wants to capture unhandled exceptions in WPF, WinForms, MAUI, or Azure Functions
-- User asks about `SentryOptions`, `BeforeSend`, `TracesSampleRate`, or symbol upload
 
 > **Note:** SDK version and APIs below reflect `Sentry` NuGet packages ≥6.1.0 (OTLP export requires ≥6.5.0).
 > Always verify against [docs.sentry.io/platforms/dotnet/](https://docs.sentry.io/platforms/dotnet/) before implementing.

--- a/skills/sentry-elixir-sdk/SKILL.md
+++ b/skills/sentry-elixir-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-elixir-sdk
-description: Full Sentry SDK setup for Elixir. Use when asked to "add Sentry to Elixir", "install sentry for Elixir", or configure error monitoring, tracing, logging, or crons for Elixir, Phoenix, or Plug applications. Supports Phoenix, Plug, LiveView, Oban, and Quantum.
+description: Full Sentry SDK setup for Elixir. Use when asked to "add Sentry to Elixir", "install the sentry hex package" (getsentry/sentry-elixir), or configure error monitoring, tracing, logging, or crons for Elixir or Phoenix apps. Covers capturing exceptions, Plug errors, LiveView errors, and scheduled jobs. Supports Phoenix, Plug, LiveView, Oban, and Quantum.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Elixir SDK
 
 Opinionated wizard that scans your Elixir project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Elixir" or "set up Sentry" in an Elixir or Phoenix app
-- User wants error monitoring, tracing, logging, or crons in Elixir or Phoenix
-- User mentions `sentry` hex package, `getsentry/sentry-elixir`, or Elixir Sentry SDK
-- User wants to monitor exceptions, Plug errors, LiveView errors, or scheduled jobs
 
 > **Note:** SDK versions and APIs below reflect Sentry docs at time of writing (sentry v13.2.0, requires Elixir ~> 1.13).
 > Always verify against [docs.sentry.io/platforms/elixir/](https://docs.sentry.io/platforms/elixir/) before implementing.

--- a/skills/sentry-fix-issues/SKILL.md
+++ b/skills/sentry-fix-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-fix-issues
-description: Find and fix issues from Sentry using MCP. Use when asked to fix Sentry errors, debug production issues, investigate exceptions, or resolve bugs reported in Sentry. Methodically analyzes stack traces, breadcrumbs, traces, and context to identify root causes.
+description: Find and fix production issues from Sentry using the Sentry MCP server. Use when asked to "fix Sentry issues", "resolve Sentry errors", "debug production bugs", or "investigate exceptions", when triaging the Sentry backlog, or when given a Sentry issue ID or error message. Methodically analyzes stack traces, breadcrumbs, traces, and context to identify root causes.
 license: Apache-2.0
 category: workflow
 parent: sentry-workflow
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Fix Sentry Issues
 
 Discover, analyze, and fix production issues using Sentry's full debugging capabilities.
-
-## Invoke This Skill When
-
-- User asks to "fix Sentry issues" or "resolve Sentry errors"
-- User wants to "debug production bugs" or "investigate exceptions"
-- User mentions issue IDs, error messages, or asks about recent failures
-- User wants to triage or work through their Sentry backlog
 
 ## Prerequisites
 

--- a/skills/sentry-flutter-sdk/SKILL.md
+++ b/skills/sentry-flutter-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-flutter-sdk
-description: Full Sentry SDK setup for Flutter and Dart. Use when asked to "add Sentry to Flutter", "install sentry_flutter", "setup Sentry in Dart", or configure error monitoring, tracing, profiling, session replay, or logging for Flutter applications. Supports Android, iOS, macOS, Linux, Windows, and Web.
+description: Full Sentry SDK setup for Flutter and Dart. Use when asked to "add Sentry to Flutter", "install sentry_flutter", "set up Sentry in Dart", or configure error monitoring, tracing, profiling, session replay, or logging. Covers native crashes, ANRs, and app hangs on iOS/Android, plus ecosystem integrations (Dio, sqflite, Hive, Isar, Drift). Supports Android, iOS, macOS, Linux, Windows, and Web.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Flutter SDK
 
 Opinionated wizard that scans your Flutter or Dart project and guides you through complete Sentry setup — error monitoring, tracing, session replay, logging, profiling, and ecosystem integrations.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Flutter" or "set up Sentry" in a Flutter or Dart app
-- User wants error monitoring, tracing, profiling, session replay, or logging in Flutter
-- User mentions `sentry_flutter`, `sentry_dart`, mobile error tracking, or Sentry for Flutter
-- User wants to monitor native crashes, ANRs, or app hangs on iOS/Android
 
 > **Note:** SDK versions and APIs below reflect `sentry_flutter` ≥9.14.0 (current stable, February 2026).
 > Always verify against [docs.sentry.io/platforms/flutter/](https://docs.sentry.io/platforms/flutter/) before implementing.

--- a/skills/sentry-go-sdk/SKILL.md
+++ b/skills/sentry-go-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-go-sdk
-description: Full Sentry SDK setup for Go. Use when asked to "add Sentry to Go", "install sentry-go", "setup Sentry in Go", or configure error monitoring, tracing, logging, metrics, or crons for Go applications. Supports net/http, Gin, Echo, Fiber, FastHTTP, Iris, Negroni, and gRPC.
+description: Full Sentry SDK setup for Go. Use when asked to "add Sentry to Go", "install sentry-go" (github.com/getsentry/sentry-go), or configure error monitoring, tracing, logging, metrics, or crons for a Go app. Covers capturing panics, HTTP handlers, and scheduled jobs. Supports net/http, Gin, Echo, Fiber, FastHTTP, Iris, Negroni, and gRPC.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Go SDK
 
 Opinionated wizard that scans your Go project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Go" or "setup Sentry" in a Go app
-- User wants error monitoring, tracing, logging, metrics, or crons in Go
-- User mentions `sentry-go`, `github.com/getsentry/sentry-go`, or Go Sentry SDK
-- User wants to monitor panics, HTTP handlers, or scheduled jobs in Go
 
 > **Note:** SDK versions and APIs below reflect Sentry docs at time of writing (sentry-go v0.43.0+).
 > As of v0.33.0+, the SDK requires **Go 1.25 or later** (supports the two most recent Go major versions).

--- a/skills/sentry-instrumentation-guide/SKILL.md
+++ b/skills/sentry-instrumentation-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-instrumentation-guide
-description: Decide which Sentry signal to reach for when instrumenting code — error, span, span attribute, log, or metric. Use when adding instrumentation and unsure whether something should be a log vs a span vs a metric, when deciding "what to instrument where", when reviewing instrumentation for gaps, or when a coding agent needs a rule for choosing between errors, traces, logs, and metrics. This skill decides WHAT to emit; the sentry-*-sdk skills handle HOW to set each pillar up.
+description: Decision framework for choosing the right Sentry signal when instrumenting code — error, span, span attribute, log, or metric. Use when adding instrumentation and unsure whether something should be a log vs a span vs a metric, deciding "what to instrument where", auditing existing instrumentation for gaps (for example an empty error feed while users report problems), or when a coding agent needs a consistent rule for choosing between errors, traces, logs, and metrics. Decides WHAT to emit; the sentry-*-sdk skills and sentry-setup-ai-monitoring handle HOW to set each pillar up.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup
@@ -24,15 +24,6 @@ or an event in front of you, which signal should carry it, and why.
 
 It decides **what** to emit. For **how** to turn each pillar on for a given stack, hand off to the
 `sentry-*-sdk` skills and `sentry-setup-ai-monitoring`.
-
-## Invoke This Skill When
-
-- You're instrumenting a piece of code and unsure whether something should be a log, a span, a
-  span attribute, or a metric
-- You're deciding "what to instrument where" across a service or request handler
-- You're reviewing existing instrumentation for gaps (e.g. an error feed that's empty while users
-  report problems)
-- A coding agent needs a consistent rule for choosing between errors, traces, logs, and metrics
 
 **Important:** The SDK APIs and code samples here are illustrative. Verify exact signatures and
 minimum versions against [docs.sentry.io](https://docs.sentry.io) and the relevant `sentry-*-sdk`

--- a/skills/sentry-nestjs-sdk/SKILL.md
+++ b/skills/sentry-nestjs-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-nestjs-sdk
-description: Full Sentry SDK setup for NestJS. Use when asked to "add Sentry to NestJS", "install @sentry/nestjs", "setup Sentry in NestJS", or configure error monitoring, tracing, profiling, logging, metrics, crons, or AI monitoring for NestJS applications. Supports Express and Fastify adapters, GraphQL, microservices, WebSockets, and background jobs.
+description: Full Sentry SDK setup for NestJS. Use when asked to "add Sentry to NestJS", "install @sentry/nestjs", or configure error monitoring, tracing, profiling, logging, metrics, crons, or AI monitoring for a NestJS app. Covers monitoring controllers, services, guards, microservices, WebSockets, and background jobs. Supports Express and Fastify adapters and GraphQL.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry NestJS SDK
 
 Opinionated wizard that scans your NestJS project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to NestJS" or "setup Sentry" in a NestJS app
-- User wants error monitoring, tracing, profiling, logging, metrics, or crons in NestJS
-- User mentions `@sentry/nestjs` or Sentry + NestJS
-- User wants to monitor NestJS controllers, services, guards, microservices, or background jobs
 
 > **Note:** SDK versions and APIs below reflect `@sentry/nestjs` 10.x (NestJS 8–11 supported).
 > Always verify against [docs.sentry.io/platforms/node/guides/nestjs/](https://docs.sentry.io/platforms/node/guides/nestjs/) before implementing.

--- a/skills/sentry-nextjs-sdk/SKILL.md
+++ b/skills/sentry-nextjs-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-nextjs-sdk
-description: Full Sentry SDK setup for Next.js. Use when asked to "add Sentry to Next.js", "install @sentry/nextjs", or configure error monitoring, tracing, session replay, logging, profiling, AI monitoring, or crons for Next.js applications. Supports Next.js 13+ with App Router and Pages Router.
+description: Full Sentry SDK setup for Next.js. Use when asked to "add Sentry to Next.js", "install @sentry/nextjs", or configure error monitoring, tracing, session replay, logging, profiling, AI monitoring, or crons. Covers instrumentation.ts, withSentryConfig(), global-error.tsx, and capturing server actions, server component errors, and edge runtime errors across the browser, Node.js server, and Edge runtimes. Supports Next.js 13+ with App Router and Pages Router.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry Next.js SDK
 
 Opinionated wizard that scans your Next.js project and guides you through complete Sentry setup across all three runtimes: browser, Node.js server, and Edge.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Next.js" or "set up Sentry" in a Next.js app
-- User wants to install or configure `@sentry/nextjs`
-- User wants error monitoring, tracing, session replay, logging, or profiling for Next.js
-- User asks about `instrumentation.ts`, `withSentryConfig()`, or `global-error.tsx`
-- User wants to capture server actions, server component errors, or edge runtime errors
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/nextjs` ≥8.28.0).
 > Always verify against [docs.sentry.io/platforms/javascript/guides/nextjs/](https://docs.sentry.io/platforms/javascript/guides/nextjs/) before implementing.

--- a/skills/sentry-node-sdk/SKILL.md
+++ b/skills/sentry-node-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-node-sdk
-description: Full Sentry SDK setup for Node.js, Bun, and Deno. Use when asked to "add Sentry to Node.js", "add Sentry to Bun", "add Sentry to Deno", "install @sentry/node", "@sentry/bun", or "@sentry/deno", or configure error monitoring, tracing, logging, profiling, metrics, crons, or AI monitoring for server-side JavaScript/TypeScript runtimes.
+description: Full Sentry SDK setup for Node.js, Bun, and Deno. Use when asked to "add Sentry to Node.js/Bun/Deno", install @sentry/node, @sentry/bun, or @sentry/deno, or configure error monitoring, tracing, logging, profiling, metrics, crons, or AI monitoring for a backend JavaScript or TypeScript app. Covers instrument.js, --import ./instrument.mjs, bun --preload, and monitoring Express, Fastify, Koa, Hapi, Connect, Bun.serve(), and Deno.serve(). For NestJS use sentry-nestjs-sdk; for Next.js use sentry-nextjs-sdk.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry Node.js / Bun / Deno SDK
 
 Opinionated wizard that scans your project and guides you through complete Sentry setup for server-side JavaScript and TypeScript runtimes: Node.js, Bun, and Deno.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Node.js", "Bun", or "Deno"
-- User wants to install or configure `@sentry/node`, `@sentry/bun`, or `@sentry/deno`
-- User wants error monitoring, tracing, logging, profiling, crons, metrics, or AI monitoring for a backend JS/TS app
-- User asks about `instrument.js`, `--import ./instrument.mjs`, `bun --preload`, or `npm:@sentry/deno`
-- User wants to monitor Express, Fastify, Koa, Hapi, Connect, Bun.serve(), or Deno.serve()
 
 > **NestJS?** Use [`sentry-nestjs-sdk`](../sentry-nestjs-sdk/SKILL.md) instead — it uses `@sentry/nestjs` with NestJS-native decorators and filters.
 > **Next.js?** Use [`sentry-nextjs-sdk`](../sentry-nextjs-sdk/SKILL.md) instead — it handles the three-runtime architecture (browser, server, edge).

--- a/skills/sentry-otel-exporter-setup/SKILL.md
+++ b/skills/sentry-otel-exporter-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-otel-exporter-setup
-description: Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation. Use when setting up OTel with Sentry, configuring collector pipelines for traces and logs, or routing telemetry from multiple services to Sentry projects.
+description: Configure the OpenTelemetry Collector with the Sentry Exporter for multi-project routing and automatic project creation. Use when asked to "set up OTel with Sentry", "add the Sentry Exporter", build collector pipelines for traces and logs, edit otel-collector-config.yaml, or route telemetry from multiple services into separate Sentry projects.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup

--- a/skills/sentry-php-sdk/SKILL.md
+++ b/skills/sentry-php-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-php-sdk
-description: Full Sentry SDK setup for PHP. Use when asked to "add Sentry to PHP", "install sentry/sentry", "setup Sentry in PHP", or configure error monitoring, tracing, profiling, logging, metrics, or crons for PHP applications. Supports plain PHP, Laravel, and Symfony.
+description: Full Sentry SDK setup for PHP. Use when asked to "add Sentry to PHP", install sentry/sentry, sentry/sentry-laravel, or sentry/sentry-symfony, or configure error monitoring, tracing, profiling, logging, metrics, or crons for a PHP app. Covers monitoring Laravel routes, Symfony controllers, queues, scheduled tasks, and plain PHP scripts. Supports plain PHP, Laravel, and Symfony.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry PHP SDK
 
 Opinionated wizard that scans your PHP project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to PHP" or "setup Sentry" in a PHP app
-- User wants error monitoring, tracing, profiling, logging, metrics, or crons in PHP
-- User mentions `sentry/sentry`, `sentry/sentry-laravel`, `sentry/sentry-symfony`, or Sentry + any PHP framework
-- User wants to monitor Laravel routes, Symfony controllers, queues, scheduled tasks, or plain PHP scripts
 
 > **Note:** SDK versions and APIs below reflect Sentry docs at time of writing (sentry/sentry 4.x, sentry/sentry-laravel 4.x, sentry/sentry-symfony 5.x).
 > Always verify against [docs.sentry.io/platforms/php/](https://docs.sentry.io/platforms/php/) before implementing.

--- a/skills/sentry-pr-code-review/SKILL.md
+++ b/skills/sentry-pr-code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-pr-code-review
-description: Review a project's PRs to check for issues detected in code review by Seer Bug Prediction. Use when asked to review or fix issues identified by Sentry in PR comments, or to find recent PRs with Sentry feedback.
+description: Review and fix issues flagged by Seer Bug Prediction in GitHub PR comments. Use when asked to "review Sentry comments", "fix Sentry issues" on a PR, "address Sentry review", or "resolve Sentry findings", when given a PR URL or number with Seer feedback, or to find recent PRs with unresolved Sentry comments. Requires the gh CLI and the Seer by Sentry GitHub App.
 license: Apache-2.0
 category: workflow
 parent: sentry-workflow
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Code Review
 
 Review and fix issues identified by Seer (by Sentry) in GitHub PR comments.
-
-## Invoke This Skill When
-
-- User asks to "review Sentry comments" or "fix Sentry issues" on a PR
-- User shares a PR URL/number and mentions Sentry or Seer feedback
-- User asks to "address Sentry review" or "resolve Sentry findings"
-- User wants to find PRs with unresolved Sentry comments
 
 ## Prerequisites
 

--- a/skills/sentry-python-sdk/SKILL.md
+++ b/skills/sentry-python-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-python-sdk
-description: Full Sentry SDK setup for Python. Use when asked to "add Sentry to Python", "install sentry-sdk", "setup Sentry in Python", or configure error monitoring, tracing, profiling, logging, metrics, crons, or AI monitoring for Python applications. Supports Django, Flask, FastAPI, Celery, Starlette, AIOHTTP, Tornado, and more.
+description: Full Sentry SDK setup for Python. Use when asked to "add Sentry to Python", "install sentry-sdk", or configure error monitoring, tracing, profiling, logging, metrics, crons, or AI monitoring for a Python app. Covers monitoring Django views, Flask routes, FastAPI endpoints, Celery tasks, and scheduled jobs. Supports Django, Flask, FastAPI, Celery, Starlette, AIOHTTP, Tornado, and more.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry Python SDK
 
 Opinionated wizard that scans your Python project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Python" or "setup Sentry" in a Python app
-- User wants error monitoring, tracing, profiling, logging, metrics, or crons in Python
-- User mentions `sentry-sdk`, `sentry_sdk`, or Sentry + any Python framework
-- User wants to monitor Django views, Flask routes, FastAPI endpoints, Celery tasks, or scheduled jobs
 
 > **Note:** SDK versions and APIs below reflect Sentry docs at time of writing (sentry-sdk 2.x).
 > Always verify against [docs.sentry.io/platforms/python/](https://docs.sentry.io/platforms/python/) before implementing.

--- a/skills/sentry-react-native-sdk/SKILL.md
+++ b/skills/sentry-react-native-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-react-native-sdk
-description: Full Sentry SDK setup for React Native and Expo. Use when asked to "add Sentry to React Native", "install @sentry/react-native", "setup Sentry in Expo", or configure error monitoring, tracing, profiling, session replay, or logging for React Native applications. Supports Expo managed, Expo bare, and vanilla React Native.
+description: Full Sentry SDK setup for React Native and Expo. Use when asked to "add Sentry to React Native", "install @sentry/react-native", "set up Sentry in Expo", or configure error monitoring, tracing, profiling, session replay, or logging. Covers native crashes, ANRs, and app hangs on iOS/Android. Supports Expo managed, Expo bare, and vanilla React Native.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry React Native SDK
 
 Opinionated wizard that scans your React Native or Expo project and guides you through complete Sentry setup — error monitoring, tracing, profiling, session replay, logging, and more.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to React Native" or "set up Sentry" in an RN or Expo app
-- User wants error monitoring, tracing, profiling, session replay, or logging in React Native
-- User mentions `@sentry/react-native`, mobile error tracking, or Sentry for Expo
-- User wants to monitor native crashes, ANRs, or app hangs on iOS/Android
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/react-native` ≥6.0.0, minimum recommended ≥8.0.0).
 > Always verify against [docs.sentry.io/platforms/react-native/](https://docs.sentry.io/platforms/react-native/) before implementing.

--- a/skills/sentry-react-router-framework-sdk/SKILL.md
+++ b/skills/sentry-react-router-framework-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-react-router-framework-sdk
-description: Full Sentry SDK setup for React Router Framework mode. Use when asked to "add Sentry to React Router Framework", "install @sentry/react-router", or configure error monitoring, tracing, profiling, session replay, logs, or user feedback for a React Router v7 framework app.
+description: Full Sentry SDK setup for React Router Framework mode. Use when asked to "add Sentry to React Router Framework", "set up Sentry in React Router v7 framework mode", or when a project uses framework entry files (entry.client.tsx, entry.server.tsx) and needs error monitoring, tracing, profiling, session replay, logs, or user feedback. Covers @sentry/react-router (currently beta), reactRouterTracingIntegration, sentryOnError, and createSentryHandleRequest. For React Router non-framework mode (v5-v7) use sentry-react-sdk.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry React Router Framework SDK
 
 Opinionated wizard that scans your React Router Framework project and guides you through complete Sentry setup across client and server entry points.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to React Router Framework" or "set up Sentry in React Router v7 framework mode"
-- User wants to install or configure `@sentry/react-router`
-- User uses React Router framework entry files (`entry.client.tsx`, `entry.server.tsx`) and wants tracing/error capture
-- User asks about `reactRouterTracingIntegration`, `sentryOnError`, `createSentryHandleRequest`, or React Router wizard setup
 
 > **Important:** This SDK is currently beta.
 > For React Router non-framework/data/declarative mode (v5/v6/v7), use `sentry-react-sdk` with `@sentry/react` integrations instead.

--- a/skills/sentry-react-sdk/SKILL.md
+++ b/skills/sentry-react-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-react-sdk
-description: Full Sentry SDK setup for React. Use when asked to "add Sentry to React", "install @sentry/react", or configure error monitoring, tracing, session replay, profiling, or logging for React applications. Supports React 16+, React Router v5-v7 non-framework mode, TanStack Router, Redux, Vite, and webpack.
+description: Full Sentry SDK setup for React. Use when asked to "add Sentry to React", "install @sentry/react", set up Sentry error boundaries, or configure error monitoring, tracing, session replay, profiling, or logging for a React app. Covers React Router v5/v6/v7 non-framework navigation, Redux state, and component performance. Supports React 16+, TanStack Router, Redux, Vite, and webpack. For React Router framework mode use sentry-react-router-framework-sdk.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry React SDK
 
 Opinionated wizard that scans your React project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to React" or "set up Sentry" in a React app
-- User wants error monitoring, tracing, session replay, profiling, or logging in React
-- User mentions `@sentry/react`, React Sentry SDK, or Sentry error boundaries
-- User wants to monitor React Router v5/v6/v7 non-framework navigation, Redux state, or component performance
 
 If project is React Router **Framework mode** using `@sentry/react-router`, use `sentry-react-router-framework-sdk` instead of this skill.
 

--- a/skills/sentry-ruby-sdk/SKILL.md
+++ b/skills/sentry-ruby-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-ruby-sdk
-description: Full Sentry SDK setup for Ruby. Use when asked to add Sentry to Ruby, install sentry-ruby, setup Sentry in Rails/Sinatra/Rack, or configure error monitoring, tracing, logging, metrics, profiling, or crons for Ruby applications. Also handles migration from AppSignal, Honeybadger, Bugsnag, Rollbar, or Airbrake. Supports Rails, Sinatra, Rack, Sidekiq, and Resque.
+description: Full Sentry SDK setup for Ruby. Use when asked to "add Sentry to Ruby", install sentry-ruby or sentry-rails, "set up Sentry in Rails/Sinatra/Rack", or configure error monitoring, tracing, logging, metrics, profiling, or crons for a Ruby app. Covers monitoring exceptions, HTTP requests, and background jobs, plus migration from AppSignal, Honeybadger, Bugsnag, Rollbar, or Airbrake. Supports Rails, Sinatra, Rack, Sidekiq, and Resque.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry Ruby SDK
 
 Opinionated wizard that scans the project and guides through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Ruby" or "set up Sentry" in a Ruby app
-- User wants error monitoring, tracing, logging, metrics, profiling, or crons in Ruby
-- User mentions `sentry-ruby`, `sentry-rails`, or the Ruby Sentry SDK
-- User is migrating from AppSignal, Honeybadger, Bugsnag, Rollbar, or Airbrake to Sentry
-- User wants to monitor exceptions, HTTP requests, or background jobs in Rails/Sinatra
 
 > **Note:** SDK APIs below reflect sentry-ruby v6.6.2.
 > Always verify against [docs.sentry.io/platforms/ruby/](https://docs.sentry.io/platforms/ruby/) before implementing.

--- a/skills/sentry-sdk-skill-creator/SKILL.md
+++ b/skills/sentry-sdk-skill-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-sdk-skill-creator
-description: Create a complete Sentry SDK skill bundle for any platform. Use when asked to "create an SDK skill", "add a new platform skill", "write a Sentry skill for X", or build a new sentry-<platform>-sdk skill bundle with wizard flow and feature reference files.
+description: Create a complete Sentry SDK skill bundle for any platform. Use when asked to "create an SDK skill", "add a new platform skill", "write a Sentry skill for a language or framework", or build a new per-platform sentry-*-sdk skill bundle with wizard flow and feature reference files.
 license: Apache-2.0
 category: internal
 disable-model-invocation: true
@@ -11,13 +11,6 @@ disable-model-invocation: true
 # Create a Sentry SDK Skill Bundle
 
 Produce a complete, research-backed SDK skill bundle — a main wizard SKILL.md plus deep-dive reference files for every feature pillar the SDK supports.
-
-## Invoke This Skill When
-
-- Asked to "create a Sentry SDK skill" for a new platform
-- Asked to "add support for [language/framework]" to sentry-agent-skills
-- Building a new `sentry-<platform>-sdk` skill bundle
-- Porting the SDK skill pattern to a new Sentry SDK
 
 > Read `${SKILL_ROOT}/references/philosophy.md` first — it defines the bundle architecture, wizard flow, and design principles this skill implements.
 
@@ -132,8 +125,7 @@ The main SKILL.md implements the **four-phase wizard** from the philosophy doc. 
 ### Gather Context First
 
 Before writing, run a scout or read existing skills to understand conventions:
-- Frontmatter pattern (name, description, license)
-- "Invoke This Skill When" trigger phrases
+- Frontmatter pattern (name, description, license) — the `description` carries the "Use when" trigger phrases; do not add a separate "when to use" section in the body
 - Table formatting and code example style
 - Troubleshooting table conventions
 
@@ -141,17 +133,12 @@ Before writing, run a scout or read existing skills to understand conventions:
 
 ```markdown
 ---
-name: sentry-<platform>-sdk
-description: Full Sentry SDK setup for <Platform>. Use when asked to "add Sentry
-  to <platform>", "install <package>", or configure error monitoring, tracing,
-  [features] for <Platform> applications. Supports [frameworks].
+name: sentry-[platform]-sdk
+description: Full Sentry SDK setup for [Platform]. Use when asked to "add Sentry to [platform]", "install [package]", or configure error monitoring, tracing, profiling, logging, or crons for a [platform] app. Covers [key monitoring targets and notable APIs]. Supports [frameworks].
 license: Apache-2.0
 ---
 
-# Sentry <Platform> SDK
-
-## Invoke This Skill When
-[trigger phrases]
+# Sentry [Platform] SDK
 
 ## Phase 1: Detect
 [bash commands to scan project — package manager, framework, existing Sentry, frontend/backend]

--- a/skills/sentry-sdk-skill-creator/references/philosophy.md
+++ b/skills/sentry-sdk-skill-creator/references/philosophy.md
@@ -303,22 +303,14 @@ Minimal `SKILL.md` structure:
 
 ```markdown
 ---
-name: sentry-<platform>-sdk
-description: Full Sentry SDK setup for <Platform>. Use when asked to add Sentry
-  to a <platform> project, install the <platform> SDK, or configure error
-  monitoring, tracing, profiling, logging, or crons for <Platform>.
+name: sentry-[platform]-sdk
+description: Full Sentry SDK setup for [Platform]. Use when asked to "add Sentry to [platform]", "install [package]", or configure error monitoring, tracing, profiling, logging, or crons for a [platform] app. Covers [key monitoring targets and notable APIs — e.g. native crashes, HTTP handlers, background jobs]. Supports [frameworks].
 license: Apache-2.0
 ---
 
 # Sentry <Platform> SDK
 
 Opinionated wizard that scans your project and guides you through complete Sentry setup.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to <platform>" or "set up Sentry"
-- User wants error monitoring, tracing, profiling, or logging in <platform>
-- User mentions the <platform> Sentry SDK package name
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing.
 > Always verify against [docs.sentry.io](https://docs.sentry.io/<platform>/) before implementing.

--- a/skills/sentry-sdk-skill-creator/references/quality-checklist.md
+++ b/skills/sentry-sdk-skill-creator/references/quality-checklist.md
@@ -94,7 +94,7 @@ Watch for these red flags that indicate fabricated or outdated content:
 | Check | What to verify |
 |-------|---------------|
 | Frontmatter style | Same fields and format as other SDK skills |
-| Trigger phrase style | Same "Invoke This Skill When" pattern |
+| Trigger phrase style | "Use when …" triggers live in the `description` frontmatter, not a body section |
 | Table format | Same column headers and layout |
 | Disclaimer | Same or consciously evolved style |
 | Troubleshooting format | Same Issue/Solution table pattern |

--- a/skills/sentry-sdk-upgrade/SKILL.md
+++ b/skills/sentry-sdk-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-sdk-upgrade
-description: Upgrade the Sentry JavaScript SDK across major versions. Use when asked to upgrade Sentry, migrate to a newer version, fix deprecated Sentry APIs, or resolve breaking changes after a Sentry version bump.
+description: Upgrade the Sentry JavaScript SDK across major versions with guided migration. Use when asked to "upgrade Sentry" or "migrate the Sentry SDK", move from v7 to v8 or v8 to v9, fix deprecated Sentry APIs, resolve breaking changes after bumping @sentry/* packages, or find the right migration guide or changelog.
 license: Apache-2.0
 category: workflow
 parent: sentry-workflow
@@ -12,14 +12,6 @@ disable-model-invocation: true
 # Sentry JavaScript SDK Upgrade
 
 Upgrade the Sentry JavaScript SDK across major versions with AI-guided migration.
-
-## Invoke This Skill When
-
-- User asks to "upgrade Sentry" or "migrate Sentry SDK"
-- User mentions deprecated Sentry APIs or breaking changes after a version bump
-- User wants to move from v7 to v8, v8 to v9, or any major version jump
-- User encounters errors after updating `@sentry/*` package versions
-- User asks about Sentry migration guides or changelogs
 
 ## Phase 1: Detect
 

--- a/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-setup-ai-monitoring
-description: Setup Sentry AI Agent Monitoring in any project. Use when asked to monitor LLM calls, track AI agents, track conversations, or instrument OpenAI/Anthropic/Vercel AI/LangChain/Google GenAI/Pydantic AI. Detects installed AI SDKs and configures appropriate integrations.
+description: Set up Sentry AI Agent Monitoring to track LLM calls, agent executions, tool usage, and token consumption. Use when asked to "monitor AI/LLM calls", "track OpenAI/Anthropic usage", set up "AI observability" or "agent monitoring", or investigate token usage, model latency, or AI costs. Detects installed AI SDKs (OpenAI, Anthropic, Vercel AI, LangChain, Google GenAI, Pydantic AI) and configures the appropriate integrations. Requires tracing enabled.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup
@@ -12,12 +12,6 @@ disable-model-invocation: true
 # Setup Sentry AI Agent Monitoring
 
 Configure Sentry to track LLM calls, agent executions, tool usage, and token consumption.
-
-## Invoke This Skill When
-
-- User asks to "monitor AI/LLM calls" or "track OpenAI/Anthropic usage"
-- User wants "AI observability" or "agent monitoring"
-- User asks about token usage, model latency, or AI costs
 
 **Important:** The SDK versions, API names, and code samples below are examples. Always verify against [docs.sentry.io](https://docs.sentry.io) before implementing, as APIs and minimum versions may have changed.
 

--- a/skills/sentry-span-streaming-dart/SKILL.md
+++ b/skills/sentry-span-streaming-dart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-span-streaming-dart
-description: Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", "use traceLifecycle stream", "use Sentry.startSpan", or switch from transaction-based to streamed span delivery in a Dart or Flutter project.
+description: Migrate the Dart and Flutter Sentry SDK from transaction-based to streamed span delivery (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", use traceLifecycle stream, SentryTraceLifecycle.stream, Sentry.startSpan, or SentrySpanV2, or when you want lower-latency span delivery or per-span processing in a Dart or Flutter project.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup
@@ -15,13 +15,6 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 Migrate from the default transaction-based trace lifecycle (`SentryTraceLifecycle.static`) to span streaming (`SentryTraceLifecycle.stream`), where spans are sent individually as they complete instead of being batched into a transaction at the end.
 
 This skill covers the Dart and Flutter SDKs (`sentry`, `sentry_flutter`, and integration packages such as `sentry_dio`, `sentry_sqflite`, `sentry_drift`). For JavaScript, see [Span Streaming (JavaScript)](../sentry-span-streaming-js/SKILL.md). For Python, see [Span Streaming (Python)](../sentry-span-streaming-python/SKILL.md).
-
-## Invoke This Skill When
-
-- User asks to "enable span streaming" or "migrate to span streaming" in a Dart or Flutter project
-- User wants to switch from transaction-based to streamed span delivery
-- User mentions `traceLifecycle`, `SentryTraceLifecycle.stream`, `Sentry.startSpan`, or `SentrySpanV2`
-- User wants lower latency span delivery or per-span processing
 
 ---
 

--- a/skills/sentry-span-streaming-js/SKILL.md
+++ b/skills/sentry-span-streaming-js/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-span-streaming-js
-description: Migrate JavaScript SDK to Sentry span streaming (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", "use traceLifecycle stream", "add spanStreamingIntegration", or switch from transaction-based to streamed span delivery in a JavaScript project.
+description: Migrate the JavaScript Sentry SDK from transaction-based to streamed span delivery (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", add spanStreamingIntegration, or use traceLifecycle stream or withStreamedSpan, or when you want lower-latency span delivery or per-span processing in a JavaScript project (Browser, Node.js, Bun, Deno, Cloudflare).
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup
@@ -15,13 +15,6 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 Migrate from the default transaction-based trace lifecycle (`static`) to span streaming (`stream`), where spans are sent individually as they complete instead of being batched into a transaction at the end.
 
 This skill covers the JavaScript SDK (Browser, Node.js, Bun, Deno, Cloudflare). For Python, see [Span Streaming (Python)](../sentry-span-streaming-python/SKILL.md). For Dart/Flutter, see [Span Streaming (Dart)](../sentry-span-streaming-dart/SKILL.md).
-
-## Invoke This Skill When
-
-- User asks to "enable span streaming" or "migrate to span streaming" in a JavaScript project
-- User wants to switch from transaction-based to streamed span delivery
-- User mentions `traceLifecycle`, `spanStreamingIntegration`, or `withStreamedSpan`
-- User wants lower latency span delivery or per-span processing
 
 ---
 

--- a/skills/sentry-span-streaming-python/SKILL.md
+++ b/skills/sentry-span-streaming-python/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-span-streaming-python
-description: Migrate Python SDK to Sentry span streaming (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", "use trace_lifecycle stream", or switch from transaction-based to streamed span delivery in a Python project.
+description: Migrate the Python Sentry SDK from transaction-based to streamed span delivery (span-first trace lifecycle). Use when asked to "enable span streaming", "migrate to span streaming", use trace_lifecycle stream, the new start_span API, or sentry_sdk.traces, or when you want lower-latency span delivery or per-span processing in a Python project.
 license: Apache-2.0
 category: feature-setup
 parent: sentry-feature-setup
@@ -15,13 +15,6 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob
 Migrate from the default transaction-based trace lifecycle (`static`) to span streaming (`stream`), where spans are sent individually as they complete instead of being batched into a transaction at the end.
 
 This skill covers the Python SDK. For JavaScript, see [Span Streaming (JavaScript)](../sentry-span-streaming-js/SKILL.md). For Dart/Flutter, see [Span Streaming (Dart)](../sentry-span-streaming-dart/SKILL.md).
-
-## Invoke This Skill When
-
-- User asks to "enable span streaming" or "migrate to span streaming" in a Python project
-- User wants to switch from transaction-based to streamed span delivery
-- User mentions `trace_lifecycle`, `sentry_sdk.traces`, or the new `start_span` API
-- User wants lower latency span delivery or per-span processing
 
 ---
 

--- a/skills/sentry-svelte-sdk/SKILL.md
+++ b/skills/sentry-svelte-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-svelte-sdk
-description: Full Sentry SDK setup for Svelte and SvelteKit. Use when asked to "add Sentry to Svelte", "add Sentry to SvelteKit", "install @sentry/sveltekit", or configure error monitoring, tracing, session replay, or logging for Svelte or SvelteKit applications.
+description: Full Sentry SDK setup for Svelte and SvelteKit. Use when asked to "add Sentry to Svelte" or "SvelteKit", install @sentry/svelte or @sentry/sveltekit, or configure error monitoring, tracing, session replay, or logging for a Svelte or SvelteKit app.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,12 +12,6 @@ disable-model-invocation: true
 # Sentry Svelte SDK
 
 Opinionated wizard that scans your project and guides you through complete Sentry setup for Svelte and SvelteKit.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to Svelte" or "set up Sentry" in a Svelte/SvelteKit app
-- User wants error monitoring, tracing, session replay, or logging in Svelte or SvelteKit
-- User mentions `@sentry/svelte`, `@sentry/sveltekit`, or Sentry SDK for Svelte
 
 > **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/sveltekit` ≥10.8.0, SvelteKit ≥2.31.0).
 > Always verify against [docs.sentry.io/platforms/javascript/guides/sveltekit/](https://docs.sentry.io/platforms/javascript/guides/sveltekit/) before implementing.

--- a/skills/sentry-tanstack-start-sdk/SKILL.md
+++ b/skills/sentry-tanstack-start-sdk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-tanstack-start-sdk
-description: Full Sentry SDK setup for TanStack Start React. Use when asked to "add Sentry to TanStack Start", "install @sentry/tanstackstart-react", or configure error monitoring, tracing, session replay, logs, or user feedback in a TanStack Start React app.
+description: Full Sentry SDK setup for TanStack Start React. Use when asked to "add Sentry to TanStack Start", "install @sentry/tanstackstart-react", or configure error monitoring, tracing, session replay, logs, or user feedback for browser and server runtimes. Covers @sentry/tanstackstart-react (currently alpha), sentryTanstackStart, wrapFetchWithSentry, instrument.server.mjs, and TanStack Start middleware instrumentation.
 license: Apache-2.0
 category: sdk-setup
 parent: sentry-sdk-setup
@@ -12,13 +12,6 @@ disable-model-invocation: true
 # Sentry TanStack Start React SDK
 
 Opinionated wizard that scans your TanStack Start React project and guides you through complete Sentry setup for browser and server runtimes.
-
-## Invoke This Skill When
-
-- User asks to "add Sentry to TanStack Start" or "set up Sentry" in a TanStack Start React app
-- User wants to install or configure `@sentry/tanstackstart-react`
-- User wants error monitoring, tracing, session replay, logs, or user feedback for TanStack Start React
-- User asks about `sentryTanstackStart`, `wrapFetchWithSentry`, `instrument.server.mjs`, or TanStack Start middleware instrumentation
 
 > **Note:** This SDK is currently alpha and documented as compatible with TanStack Start `1.0 RC`.
 > Always verify against [docs.sentry.io/platforms/javascript/guides/tanstackstart-react/](https://docs.sentry.io/platforms/javascript/guides/tanstackstart-react/) before implementing.


### PR DESCRIPTION
Because the frontmatter `description` is the only part always in context, it must do the "when to use" work. A separate "Invoke This Skill When" section in the body just duplicated that info at level 2, polluting context without adding value.


### Background: how skills work (progressive disclosure)

Skills load context in three levels

1. **YAML frontmatter**: always loaded into the system prompt. Its job is to give the agent *just enough* to know **when** a skill applies, without loading the whole file.
2. **`SKILL.md` body**: loaded only once the agent decides the skill is relevant.
3. **Linked files**: fetched on demand.



