### PR TITLE
ref(skills): move curl navigation to the skills.sentry.dev server

### DIFF
--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -2,35 +2,6 @@
 
 You are **Sentry's AI assistant**. You help developers set up Sentry, debug production issues, and configure monitoring — guided by expert skill files you load on demand from this index.
 
-## How to Use These Skills
-
-Tell your AI coding assistant:
-
-    Use curl to download, read and follow: https://skills.sentry.dev/sdks
-
-Or for a specific SDK:
-
-    Use curl to download, read and follow: https://skills.sentry.dev/sentry-nextjs-sdk/SKILL.md
-
-**Why curl?** Skills are detailed 10–20 KB markdown files. Fetch tools (like WebFetch) often summarize them, losing critical configuration details. `curl -sL` guarantees the full content.
-
-### Entry Points
-
-| URL | What it loads |
-|---|---|
-| `https://skills.sentry.dev/` | This page — full skill index |
-| `https://skills.sentry.dev/sdks` | SDK setup — detect platform and install Sentry |
-| `https://skills.sentry.dev/workflows` | Workflows — debug issues, review code, upgrade SDKs |
-| `https://skills.sentry.dev/features` | Features — AI monitoring, alerts, OpenTelemetry |
-
-### Fetching Individual Skills
-
-Append the skill path from the `Path` column in the tables below:
-
-    https://skills.sentry.dev/<skill-name>/SKILL.md
-
-Do not guess or shorten URLs. Use exact paths from the tables.
-
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume what the user needs based on their project files. Do not start installing packages, creating files, or running commands until you have confirmed the user's intent.
@@ -44,7 +15,7 @@ Do not guess or shorten URLs. Use exact paths from the tables.
 
 2. **Wait for their answer.** Do not proceed until the user tells you what they want.
 
-3. **Fetch the matching skill** from the tables below and follow its instructions step by step.
+3. **Read the matching skill** from the tables below and follow its instructions step by step.
 
 Each skill file contains its own detection logic, prerequisites, and configuration steps. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 
@@ -54,27 +25,27 @@ Each skill file contains its own detection logic, prerequisites, and configurati
 
 Install and configure Sentry for any platform. If unsure which SDK fits, detect the platform from the user's project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `build.gradle`, etc.).
 
-| Platform | Skill | Path |
-|---|---|---|
-| Android | [`sentry-android-sdk`](skills/sentry-android-sdk/SKILL.md) | `sentry-android-sdk/SKILL.md` |
-| browser JavaScript | [`sentry-browser-sdk`](skills/sentry-browser-sdk/SKILL.md) | `sentry-browser-sdk/SKILL.md` |
-| Cloudflare Workers and Pages | [`sentry-cloudflare-sdk`](skills/sentry-cloudflare-sdk/SKILL.md) | `sentry-cloudflare-sdk/SKILL.md` |
-| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | [`sentry-cocoa-sdk`](skills/sentry-cocoa-sdk/SKILL.md) | `sentry-cocoa-sdk/SKILL.md` |
-| .NET | [`sentry-dotnet-sdk`](skills/sentry-dotnet-sdk/SKILL.md) | `sentry-dotnet-sdk/SKILL.md` |
-| Elixir | [`sentry-elixir-sdk`](skills/sentry-elixir-sdk/SKILL.md) | `sentry-elixir-sdk/SKILL.md` |
-| Flutter and Dart | [`sentry-flutter-sdk`](skills/sentry-flutter-sdk/SKILL.md) | `sentry-flutter-sdk/SKILL.md` |
-| Go | [`sentry-go-sdk`](skills/sentry-go-sdk/SKILL.md) | `sentry-go-sdk/SKILL.md` |
-| NestJS | [`sentry-nestjs-sdk`](skills/sentry-nestjs-sdk/SKILL.md) | `sentry-nestjs-sdk/SKILL.md` |
-| Next.js | [`sentry-nextjs-sdk`](skills/sentry-nextjs-sdk/SKILL.md) | `sentry-nextjs-sdk/SKILL.md` |
-| Node.js, Bun, and Deno | [`sentry-node-sdk`](skills/sentry-node-sdk/SKILL.md) | `sentry-node-sdk/SKILL.md` |
-| PHP | [`sentry-php-sdk`](skills/sentry-php-sdk/SKILL.md) | `sentry-php-sdk/SKILL.md` |
-| Python | [`sentry-python-sdk`](skills/sentry-python-sdk/SKILL.md) | `sentry-python-sdk/SKILL.md` |
-| React Native and Expo | [`sentry-react-native-sdk`](skills/sentry-react-native-sdk/SKILL.md) | `sentry-react-native-sdk/SKILL.md` |
-| React Router Framework mode | [`sentry-react-router-framework-sdk`](skills/sentry-react-router-framework-sdk/SKILL.md) | `sentry-react-router-framework-sdk/SKILL.md` |
-| React | [`sentry-react-sdk`](skills/sentry-react-sdk/SKILL.md) | `sentry-react-sdk/SKILL.md` |
-| Ruby | [`sentry-ruby-sdk`](skills/sentry-ruby-sdk/SKILL.md) | `sentry-ruby-sdk/SKILL.md` |
-| Svelte and SvelteKit | [`sentry-svelte-sdk`](skills/sentry-svelte-sdk/SKILL.md) | `sentry-svelte-sdk/SKILL.md` |
-| TanStack Start React | [`sentry-tanstack-start-sdk`](skills/sentry-tanstack-start-sdk/SKILL.md) | `sentry-tanstack-start-sdk/SKILL.md` |
+| Platform | Skill |
+|---|---|
+| Android | [`sentry-android-sdk`](skills/sentry-android-sdk/SKILL.md) |
+| browser JavaScript | [`sentry-browser-sdk`](skills/sentry-browser-sdk/SKILL.md) |
+| Cloudflare Workers and Pages | [`sentry-cloudflare-sdk`](skills/sentry-cloudflare-sdk/SKILL.md) |
+| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | [`sentry-cocoa-sdk`](skills/sentry-cocoa-sdk/SKILL.md) |
+| .NET | [`sentry-dotnet-sdk`](skills/sentry-dotnet-sdk/SKILL.md) |
+| Elixir | [`sentry-elixir-sdk`](skills/sentry-elixir-sdk/SKILL.md) |
+| Flutter and Dart | [`sentry-flutter-sdk`](skills/sentry-flutter-sdk/SKILL.md) |
+| Go | [`sentry-go-sdk`](skills/sentry-go-sdk/SKILL.md) |
+| NestJS | [`sentry-nestjs-sdk`](skills/sentry-nestjs-sdk/SKILL.md) |
+| Next.js | [`sentry-nextjs-sdk`](skills/sentry-nextjs-sdk/SKILL.md) |
+| Node.js, Bun, and Deno | [`sentry-node-sdk`](skills/sentry-node-sdk/SKILL.md) |
+| PHP | [`sentry-php-sdk`](skills/sentry-php-sdk/SKILL.md) |
+| Python | [`sentry-python-sdk`](skills/sentry-python-sdk/SKILL.md) |
+| React Native and Expo | [`sentry-react-native-sdk`](skills/sentry-react-native-sdk/SKILL.md) |
+| React Router Framework mode | [`sentry-react-router-framework-sdk`](skills/sentry-react-router-framework-sdk/SKILL.md) |
+| React | [`sentry-react-sdk`](skills/sentry-react-sdk/SKILL.md) |
+| Ruby | [`sentry-ruby-sdk`](skills/sentry-ruby-sdk/SKILL.md) |
+| Svelte and SvelteKit | [`sentry-svelte-sdk`](skills/sentry-svelte-sdk/SKILL.md) |
+| TanStack Start React | [`sentry-tanstack-start-sdk`](skills/sentry-tanstack-start-sdk/SKILL.md) |
 
 ### Platform Detection Priority
 
@@ -95,51 +66,51 @@ When multiple SDKs could match, prefer the more specific one:
 
 Debug production issues and maintain code quality with Sentry context.
 
-| Use when | Skill | Path |
-|---|---|---|
-| Analyze and resolve Sentry comments on GitHub Pull Requests | [`sentry-code-review`](skills/sentry-code-review/SKILL.md) | `sentry-code-review/SKILL.md` |
-| Find and fix issues from Sentry using MCP | [`sentry-fix-issues`](skills/sentry-fix-issues/SKILL.md) | `sentry-fix-issues/SKILL.md` |
-| Review a project's PRs to check for issues detected in code review by Seer Bug Prediction | [`sentry-pr-code-review`](skills/sentry-pr-code-review/SKILL.md) | `sentry-pr-code-review/SKILL.md` |
-| Upgrade the Sentry JavaScript SDK across major versions | [`sentry-sdk-upgrade`](skills/sentry-sdk-upgrade/SKILL.md) | `sentry-sdk-upgrade/SKILL.md` |
+| Use when | Skill |
+|---|---|
+| Analyze and resolve Sentry comments on GitHub Pull Requests | [`sentry-code-review`](skills/sentry-code-review/SKILL.md) |
+| Find and fix issues from Sentry using MCP | [`sentry-fix-issues`](skills/sentry-fix-issues/SKILL.md) |
+| Review a project's PRs to check for issues detected in code review by Seer Bug Prediction | [`sentry-pr-code-review`](skills/sentry-pr-code-review/SKILL.md) |
+| Upgrade the Sentry JavaScript SDK across major versions | [`sentry-sdk-upgrade`](skills/sentry-sdk-upgrade/SKILL.md) |
 
 ## Feature Setup
 
 Configure specific Sentry capabilities beyond basic SDK setup.
 
-| Feature | Skill | Path |
-|---|---|---|
-| Create Sentry alerts using the workflow engine API | [`sentry-create-alert`](skills/sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
-| Instruments structured Sentry logs in a new or existing application | [`sentry-instrument-logging`](skills/sentry-instrument-logging/SKILL.md) | `sentry-instrument-logging/SKILL.md` |
-| Decide which Sentry signal to reach for when instrumenting code — error, span, span attribute, log, or metric | [`sentry-instrumentation-guide`](skills/sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
-| Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
-| Setup Sentry AI Agent Monitoring in any project | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
-| Full Sentry Snapshots setup for Apple/Cocoa projects | [`sentry-snapshots-cocoa`](skills/sentry-snapshots-cocoa/SKILL.md) | `sentry-snapshots-cocoa/SKILL.md` |
-| Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-dart`](skills/sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
-| Migrate JavaScript SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-js`](skills/sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
-| Migrate Python SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-python`](skills/sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |
+| Feature | Skill |
+|---|---|
+| Create Sentry alerts using the workflow engine API | [`sentry-create-alert`](skills/sentry-create-alert/SKILL.md) |
+| Instruments structured Sentry logs in a new or existing application | [`sentry-instrument-logging`](skills/sentry-instrument-logging/SKILL.md) |
+| Decide which Sentry signal to reach for when instrumenting code — error, span, span attribute, log, or metric | [`sentry-instrumentation-guide`](skills/sentry-instrumentation-guide/SKILL.md) |
+| Configure the OpenTelemetry Collector with Sentry Exporter for multi-project routing and automatic project creation | [`sentry-otel-exporter-setup`](skills/sentry-otel-exporter-setup/SKILL.md) |
+| Setup Sentry AI Agent Monitoring in any project | [`sentry-setup-ai-monitoring`](skills/sentry-setup-ai-monitoring/SKILL.md) |
+| Full Sentry Snapshots setup for Apple/Cocoa projects | [`sentry-snapshots-cocoa`](skills/sentry-snapshots-cocoa/SKILL.md) |
+| Migrate Dart/Flutter SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-dart`](skills/sentry-span-streaming-dart/SKILL.md) |
+| Migrate JavaScript SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-js`](skills/sentry-span-streaming-js/SKILL.md) |
+| Migrate Python SDK to Sentry span streaming (span-first trace lifecycle) | [`sentry-span-streaming-python`](skills/sentry-span-streaming-python/SKILL.md) |
 
 ## Quick Lookup
 
-Match your project to a skill by keywords. Append the path to `https://skills.sentry.dev/` to fetch.
+Match your project to a skill by keywords.
 
-| Keywords | Path |
+| Keywords | Skill |
 |---|---|
-| android, kotlin, java, jetpack compose | `sentry-android-sdk/SKILL.md` |
-| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | `sentry-browser-sdk/SKILL.md` |
-| cloudflare, cloudflare workers, cloudflare pages, wrangler, durable objects, d1, hono | `sentry-cloudflare-sdk/SKILL.md` |
-| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | `sentry-cocoa-sdk/SKILL.md` |
-| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | `sentry-dotnet-sdk/SKILL.md` |
-| elixir, phoenix, plug, liveview, oban, quantum, mix | `sentry-elixir-sdk/SKILL.md` |
-| flutter, dart, sentry_flutter, pubspec, dio | `sentry-flutter-sdk/SKILL.md` |
-| go, golang, gin, echo, fiber | `sentry-go-sdk/SKILL.md` |
-| nestjs, nest | `sentry-nestjs-sdk/SKILL.md` |
-| nextjs, next.js, next | `sentry-nextjs-sdk/SKILL.md` |
-| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | `sentry-node-sdk/SKILL.md` |
-| php, laravel, symfony | `sentry-php-sdk/SKILL.md` |
-| python, django, flask, fastapi, celery, starlette | `sentry-python-sdk/SKILL.md` |
-| react native, expo | `sentry-react-native-sdk/SKILL.md` |
-| react-router framework, @sentry/react-router, @react-router/dev, react-router reveal | `sentry-react-router-framework-sdk/SKILL.md` |
-| react, react router, tanstack, redux, vite | `sentry-react-sdk/SKILL.md` |
-| ruby, rails, sinatra, sidekiq, rack | `sentry-ruby-sdk/SKILL.md` |
-| svelte, sveltekit | `sentry-svelte-sdk/SKILL.md` |
-| tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react | `sentry-tanstack-start-sdk/SKILL.md` |
+| android, kotlin, java, jetpack compose | [`sentry-android-sdk`](skills/sentry-android-sdk/SKILL.md) |
+| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | [`sentry-browser-sdk`](skills/sentry-browser-sdk/SKILL.md) |
+| cloudflare, cloudflare workers, cloudflare pages, wrangler, durable objects, d1, hono | [`sentry-cloudflare-sdk`](skills/sentry-cloudflare-sdk/SKILL.md) |
+| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | [`sentry-cocoa-sdk`](skills/sentry-cocoa-sdk/SKILL.md) |
+| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | [`sentry-dotnet-sdk`](skills/sentry-dotnet-sdk/SKILL.md) |
+| elixir, phoenix, plug, liveview, oban, quantum, mix | [`sentry-elixir-sdk`](skills/sentry-elixir-sdk/SKILL.md) |
+| flutter, dart, sentry_flutter, pubspec, dio | [`sentry-flutter-sdk`](skills/sentry-flutter-sdk/SKILL.md) |
+| go, golang, gin, echo, fiber | [`sentry-go-sdk`](skills/sentry-go-sdk/SKILL.md) |
+| nestjs, nest | [`sentry-nestjs-sdk`](skills/sentry-nestjs-sdk/SKILL.md) |
+| nextjs, next.js, next | [`sentry-nextjs-sdk`](skills/sentry-nextjs-sdk/SKILL.md) |
+| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | [`sentry-node-sdk`](skills/sentry-node-sdk/SKILL.md) |
+| php, laravel, symfony | [`sentry-php-sdk`](skills/sentry-php-sdk/SKILL.md) |
+| python, django, flask, fastapi, celery, starlette | [`sentry-python-sdk`](skills/sentry-python-sdk/SKILL.md) |
+| react native, expo | [`sentry-react-native-sdk`](skills/sentry-react-native-sdk/SKILL.md) |
+| react-router framework, @sentry/react-router, @react-router/dev, react-router reveal | [`sentry-react-router-framework-sdk`](skills/sentry-react-router-framework-sdk/SKILL.md) |
+| react, react router, tanstack, redux, vite | [`sentry-react-sdk`](skills/sentry-react-sdk/SKILL.md) |
+| ruby, rails, sinatra, sidekiq, rack | [`sentry-ruby-sdk`](skills/sentry-ruby-sdk/SKILL.md) |
+| svelte, sveltekit | [`sentry-svelte-sdk`](skills/sentry-svelte-sdk/SKILL.md) |
+| tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react | [`sentry-tanstack-start-sdk`](skills/sentry-tanstack-start-sdk/SKILL.md) |

--- a/scripts/build-skill-tree.sh
+++ b/scripts/build-skill-tree.sh
@@ -180,23 +180,20 @@ build_table_rows() {
   local skills=("$@")
 
   for name in ${skills[@]+"${skills[@]}"}; do
-    local file desc col_val skill_path
+    local file desc col_val
     file="$(skill_get "$name" file)"
     desc="$(skill_get "$name" desc)"
     col_val="$(get_column_value "$desc" "$category")"
-    # Strip leading "skills/" from file path for the fetchable URL path
-    skill_path="${file#skills/}"
-    printf "| %s | [\`%s\`](%s) | \`%s\` |\n" "$col_val" "$name" "$file" "$skill_path"
+    printf "| %s | [\`%s\`](%s) |\n" "$col_val" "$name" "$file"
   done
 }
 
 # Build keyword lookup rows for SDK skills
-# Maps common platform keywords to fetchable paths
+# Maps common platform keywords to their skill files
 build_keyword_lookup() {
   for name in ${SKILLS_SDK_SETUP[@]+"${SKILLS_SDK_SETUP[@]}"}; do
-    local file keywords skill_path
+    local file keywords
     file="$(skill_get "$name" file)"
-    skill_path="${file#skills/}"
 
     case "$name" in
       sentry-android-sdk)
@@ -241,7 +238,7 @@ build_keyword_lookup() {
         keywords="$name" ;;
     esac
 
-    printf "| %s | \`%s\` |\n" "$keywords" "$skill_path"
+    printf "| %s | [\`%s\`](%s) |\n" "$keywords" "$name" "$file"
   done
 }
 
@@ -250,35 +247,6 @@ generate_skill_tree() {
 # Sentry Skills
 
 You are **Sentry's AI assistant**. You help developers set up Sentry, debug production issues, and configure monitoring — guided by expert skill files you load on demand from this index.
-
-## How to Use These Skills
-
-Tell your AI coding assistant:
-
-    Use curl to download, read and follow: https://skills.sentry.dev/sdks
-
-Or for a specific SDK:
-
-    Use curl to download, read and follow: https://skills.sentry.dev/sentry-nextjs-sdk/SKILL.md
-
-**Why curl?** Skills are detailed 10–20 KB markdown files. Fetch tools (like WebFetch) often summarize them, losing critical configuration details. `curl -sL` guarantees the full content.
-
-### Entry Points
-
-| URL | What it loads |
-|---|---|
-| `https://skills.sentry.dev/` | This page — full skill index |
-| `https://skills.sentry.dev/sdks` | SDK setup — detect platform and install Sentry |
-| `https://skills.sentry.dev/workflows` | Workflows — debug issues, review code, upgrade SDKs |
-| `https://skills.sentry.dev/features` | Features — AI monitoring, alerts, OpenTelemetry |
-
-### Fetching Individual Skills
-
-Append the skill path from the `Path` column in the tables below:
-
-    https://skills.sentry.dev/<skill-name>/SKILL.md
-
-Do not guess or shorten URLs. Use exact paths from the tables.
 
 ## Start Here — Read This Before Doing Anything
 
@@ -293,7 +261,7 @@ Do not guess or shorten URLs. Use exact paths from the tables.
 
 2. **Wait for their answer.** Do not proceed until the user tells you what they want.
 
-3. **Fetch the matching skill** from the tables below and follow its instructions step by step.
+3. **Read the matching skill** from the tables below and follow its instructions step by step.
 
 Each skill file contains its own detection logic, prerequisites, and configuration steps. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 
@@ -311,8 +279,8 @@ HEADER
 Install and configure Sentry for any platform. If unsure which SDK fits, detect the platform from the user's project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `build.gradle`, etc.).
 
 SDK_HEADER
-  printf "| %s | Skill | Path |\n" "$col_sdk"
-  printf "|---|---|---|\n"
+  printf "| %s | Skill |\n" "$col_sdk"
+  printf "|---|---|\n"
   build_table_rows "sdk-setup" ${SKILLS_SDK_SETUP[@]+"${SKILLS_SDK_SETUP[@]}"}
 
   cat <<'SDK_ROUTING'
@@ -342,8 +310,8 @@ SDK_ROUTING
 Debug production issues and maintain code quality with Sentry context.
 
 WF_HEADER
-  printf "| %s | Skill | Path |\n" "$col_wf"
-  printf "|---|---|---|\n"
+  printf "| %s | Skill |\n" "$col_wf"
+  printf "|---|---|\n"
   build_table_rows "workflow" ${SKILLS_WORKFLOW[@]+"${SKILLS_WORKFLOW[@]}"}
 
   # Feature Setup
@@ -355,8 +323,8 @@ WF_HEADER
 Configure specific Sentry capabilities beyond basic SDK setup.
 
 FS_HEADER
-  printf "| %s | Skill | Path |\n" "$col_fs"
-  printf "|---|---|---|\n"
+  printf "| %s | Skill |\n" "$col_fs"
+  printf "|---|---|\n"
   build_table_rows "feature-setup" ${SKILLS_FEATURE_SETUP[@]+"${SKILLS_FEATURE_SETUP[@]}"}
 
   # Quick Lookup section
@@ -364,9 +332,9 @@ FS_HEADER
 
 ## Quick Lookup
 
-Match your project to a skill by keywords. Append the path to `https://skills.sentry.dev/` to fetch.
+Match your project to a skill by keywords.
 
-| Keywords | Path |
+| Keywords | Skill |
 |---|---|
 LOOKUP_HEADER
   build_keyword_lookup

--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -11,14 +11,6 @@ role: router
 
 Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring, OpenTelemetry pipelines, alerts, and deciding which signal to instrument where. This page helps you find the right feature skill for your task.
 
-## How to Fetch Skills
-
-Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
-
-    curl -sL https://skills.sentry.dev/sentry-setup-ai-monitoring/SKILL.md
-
-Append the path from the `Path` column in the table below to `https://skills.sentry.dev/`. Do not guess or shorten URLs.
-
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume which feature the user needs. Ask first.
@@ -36,18 +28,17 @@ When unclear, **ask the user** which feature they want to configure. Do not gues
 
 ## Feature Skills
 
-| Feature | Skill | Path |
-|---|---|---|
-| AI/LLM monitoring and conversations — instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI | [`sentry-setup-ai-monitoring`](../sentry-setup-ai-monitoring/SKILL.md) | `sentry-setup-ai-monitoring/SKILL.md` |
-| Sentry Snapshots for Apple/Cocoa — upload Apple snapshot images to Sentry; prefer SnapshotPreviews when Swift previews exist | [`sentry-snapshots-cocoa`](../sentry-snapshots-cocoa/SKILL.md) | `sentry-snapshots-cocoa/SKILL.md` |
-| OpenTelemetry Collector with Sentry Exporter — multi-project routing, automatic project creation | [`sentry-otel-exporter-setup`](../sentry-otel-exporter-setup/SKILL.md) | `sentry-otel-exporter-setup/SKILL.md` |
-| Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) | `sentry-create-alert/SKILL.md` |
-| Span streaming (JavaScript) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-js`](../sentry-span-streaming-js/SKILL.md) | `sentry-span-streaming-js/SKILL.md` |
-| Span streaming (Python) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-python`](../sentry-span-streaming-python/SKILL.md) | `sentry-span-streaming-python/SKILL.md` |
-| Span streaming (Dart/Flutter) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-dart`](../sentry-span-streaming-dart/SKILL.md) | `sentry-span-streaming-dart/SKILL.md` |
-| Instrumentation guide — decide which signal to reach for (error vs span vs log vs metric), "what to instrument where" | [`sentry-instrumentation-guide`](../sentry-instrumentation-guide/SKILL.md) | `sentry-instrumentation-guide/SKILL.md` |
-| Instruments structured Sentry logs in a new or existing application | [`sentry-instrument-logging`](../sentry-instrument-logging/SKILL.md) | `sentry-instrument-logging/SKILL.md` |
-
+| Feature | Skill |
+|---|---|
+| AI/LLM monitoring and conversations — instrument OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI | [`sentry-setup-ai-monitoring`](../sentry-setup-ai-monitoring/SKILL.md) |
+| Sentry Snapshots for Apple/Cocoa — upload Apple snapshot images to Sentry; prefer SnapshotPreviews when Swift previews exist | [`sentry-snapshots-cocoa`](../sentry-snapshots-cocoa/SKILL.md) |
+| OpenTelemetry Collector with Sentry Exporter — multi-project routing, automatic project creation | [`sentry-otel-exporter-setup`](../sentry-otel-exporter-setup/SKILL.md) |
+| Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) |
+| Span streaming (JavaScript) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-js`](../sentry-span-streaming-js/SKILL.md) |
+| Span streaming (Python) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-python`](../sentry-span-streaming-python/SKILL.md) |
+| Span streaming (Dart/Flutter) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-dart`](../sentry-span-streaming-dart/SKILL.md) |
+| Instrumentation guide — decide which signal to reach for (error vs span vs log vs metric), "what to instrument where" | [`sentry-instrumentation-guide`](../sentry-instrumentation-guide/SKILL.md) |
+| Instruments structured Sentry logs in a new or existing application | [`sentry-instrument-logging`](../sentry-instrument-logging/SKILL.md) |
 
 Each skill contains its own detection logic, prerequisites, and step-by-step instructions. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 

--- a/skills/sentry-sdk-setup/SKILL.md
+++ b/skills/sentry-sdk-setup/SKILL.md
@@ -11,21 +11,13 @@ role: router
 
 Set up Sentry error monitoring, tracing, and session replay in any language or framework. This page helps you find the right SDK skill for your project.
 
-## How to Fetch Skills
-
-Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
-
-    curl -sL https://skills.sentry.dev/sentry-nextjs-sdk/SKILL.md
-
-Append the path from the `Path` column in the table below to `https://skills.sentry.dev/`. Do not guess or shorten URLs.
-
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume which SDK the user needs based on their project files. Do not start installing packages or creating config files until you have confirmed the user's intent.
 
 1. **Detect the platform** from project files (`package.json`, `go.mod`, `requirements.txt`, `Gemfile`, `*.csproj`, `build.gradle`, etc.).
 2. **Tell the user what you found** and which SDK you recommend.
-3. **Wait for confirmation** before fetching the skill and proceeding.
+3. **Wait for confirmation** before reading the skill and proceeding.
 
 Each SDK skill contains its own detection logic, prerequisites, and step-by-step configuration. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 
@@ -33,27 +25,27 @@ Each SDK skill contains its own detection logic, prerequisites, and step-by-step
 
 ## SDK Skills
 
-| Platform | Skill | Path |
-|---|---|---|
-| Android | [`sentry-android-sdk`](../sentry-android-sdk/SKILL.md) | `sentry-android-sdk/SKILL.md` |
-| browser JavaScript | [`sentry-browser-sdk`](../sentry-browser-sdk/SKILL.md) | `sentry-browser-sdk/SKILL.md` |
-| Cloudflare Workers and Pages | [`sentry-cloudflare-sdk`](../sentry-cloudflare-sdk/SKILL.md) | `sentry-cloudflare-sdk/SKILL.md` |
-| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | [`sentry-cocoa-sdk`](../sentry-cocoa-sdk/SKILL.md) | `sentry-cocoa-sdk/SKILL.md` |
-| .NET | [`sentry-dotnet-sdk`](../sentry-dotnet-sdk/SKILL.md) | `sentry-dotnet-sdk/SKILL.md` |
-| Elixir | [`sentry-elixir-sdk`](../sentry-elixir-sdk/SKILL.md) | `sentry-elixir-sdk/SKILL.md` |
-| Go | [`sentry-go-sdk`](../sentry-go-sdk/SKILL.md) | `sentry-go-sdk/SKILL.md` |
-| NestJS | [`sentry-nestjs-sdk`](../sentry-nestjs-sdk/SKILL.md) | `sentry-nestjs-sdk/SKILL.md` |
-| Next.js | [`sentry-nextjs-sdk`](../sentry-nextjs-sdk/SKILL.md) | `sentry-nextjs-sdk/SKILL.md` |
-| Node.js, Bun, and Deno | [`sentry-node-sdk`](../sentry-node-sdk/SKILL.md) | `sentry-node-sdk/SKILL.md` |
-| PHP | [`sentry-php-sdk`](../sentry-php-sdk/SKILL.md) | `sentry-php-sdk/SKILL.md` |
-| Python | [`sentry-python-sdk`](../sentry-python-sdk/SKILL.md) | `sentry-python-sdk/SKILL.md` |
-| Flutter and Dart | [`sentry-flutter-sdk`](../sentry-flutter-sdk/SKILL.md) | `sentry-flutter-sdk/SKILL.md` |
-| React Native and Expo | [`sentry-react-native-sdk`](../sentry-react-native-sdk/SKILL.md) | `sentry-react-native-sdk/SKILL.md` |
-| React | [`sentry-react-sdk`](../sentry-react-sdk/SKILL.md) | `sentry-react-sdk/SKILL.md` |
-| React Router Framework | [`sentry-react-router-framework-sdk`](../sentry-react-router-framework-sdk/SKILL.md) | `sentry-react-router-framework-sdk/SKILL.md` |
-| TanStack Start React | [`sentry-tanstack-start-sdk`](../sentry-tanstack-start-sdk/SKILL.md) | `sentry-tanstack-start-sdk/SKILL.md` |
-| Ruby | [`sentry-ruby-sdk`](../sentry-ruby-sdk/SKILL.md) | `sentry-ruby-sdk/SKILL.md` |
-| Svelte and SvelteKit | [`sentry-svelte-sdk`](../sentry-svelte-sdk/SKILL.md) | `sentry-svelte-sdk/SKILL.md` |
+| Platform | Skill |
+|---|---|
+| Android | [`sentry-android-sdk`](../sentry-android-sdk/SKILL.md) |
+| browser JavaScript | [`sentry-browser-sdk`](../sentry-browser-sdk/SKILL.md) |
+| Cloudflare Workers and Pages | [`sentry-cloudflare-sdk`](../sentry-cloudflare-sdk/SKILL.md) |
+| Apple platforms (iOS, macOS, tvOS, watchOS, visionOS) | [`sentry-cocoa-sdk`](../sentry-cocoa-sdk/SKILL.md) |
+| .NET | [`sentry-dotnet-sdk`](../sentry-dotnet-sdk/SKILL.md) |
+| Elixir | [`sentry-elixir-sdk`](../sentry-elixir-sdk/SKILL.md) |
+| Go | [`sentry-go-sdk`](../sentry-go-sdk/SKILL.md) |
+| NestJS | [`sentry-nestjs-sdk`](../sentry-nestjs-sdk/SKILL.md) |
+| Next.js | [`sentry-nextjs-sdk`](../sentry-nextjs-sdk/SKILL.md) |
+| Node.js, Bun, and Deno | [`sentry-node-sdk`](../sentry-node-sdk/SKILL.md) |
+| PHP | [`sentry-php-sdk`](../sentry-php-sdk/SKILL.md) |
+| Python | [`sentry-python-sdk`](../sentry-python-sdk/SKILL.md) |
+| Flutter and Dart | [`sentry-flutter-sdk`](../sentry-flutter-sdk/SKILL.md) |
+| React Native and Expo | [`sentry-react-native-sdk`](../sentry-react-native-sdk/SKILL.md) |
+| React | [`sentry-react-sdk`](../sentry-react-sdk/SKILL.md) |
+| React Router Framework | [`sentry-react-router-framework-sdk`](../sentry-react-router-framework-sdk/SKILL.md) |
+| TanStack Start React | [`sentry-tanstack-start-sdk`](../sentry-tanstack-start-sdk/SKILL.md) |
+| Ruby | [`sentry-ruby-sdk`](../sentry-ruby-sdk/SKILL.md) |
+| Svelte and SvelteKit | [`sentry-svelte-sdk`](../sentry-svelte-sdk/SKILL.md) |
 
 ### Platform Detection Priority
 
@@ -75,29 +67,29 @@ When multiple SDKs could match, prefer the more specific one:
 
 ## Quick Lookup
 
-Match your project to a skill by keywords. Append the path to `https://skills.sentry.dev/` to fetch.
+Match your project to a skill by keywords.
 
-| Keywords | Path |
+| Keywords | Skill |
 |---|---|
-| android, kotlin, java, jetpack compose | `sentry-android-sdk/SKILL.md` |
-| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | `sentry-browser-sdk/SKILL.md` |
-| cloudflare, cloudflare workers, cloudflare pages, wrangler, durable objects, d1 | `sentry-cloudflare-sdk/SKILL.md` |
-| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | `sentry-cocoa-sdk/SKILL.md` |
-| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | `sentry-dotnet-sdk/SKILL.md` |
-| go, golang, gin, echo, fiber | `sentry-go-sdk/SKILL.md` |
-| elixir, phoenix, plug, oban | `sentry-elixir-sdk/SKILL.md` |
-| nestjs, nest | `sentry-nestjs-sdk/SKILL.md` |
-| nextjs, next.js, next | `sentry-nextjs-sdk/SKILL.md` |
-| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | `sentry-node-sdk/SKILL.md` |
-| php, laravel, symfony | `sentry-php-sdk/SKILL.md` |
-| python, django, flask, fastapi, celery, starlette | `sentry-python-sdk/SKILL.md` |
-| flutter, dart, pubspec | `sentry-flutter-sdk/SKILL.md` |
-| react native, expo | `sentry-react-native-sdk/SKILL.md` |
-| react, react router, tanstack, redux, vite | `sentry-react-sdk/SKILL.md` |
-| react-router framework, @sentry/react-router, @react-router/dev, react-router reveal | `sentry-react-router-framework-sdk/SKILL.md` |
-| tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react | `sentry-tanstack-start-sdk/SKILL.md` |
-| ruby, rails, sinatra, sidekiq, rack | `sentry-ruby-sdk/SKILL.md` |
-| svelte, sveltekit | `sentry-svelte-sdk/SKILL.md` |
+| android, kotlin, java, jetpack compose | [`sentry-android-sdk`](../sentry-android-sdk/SKILL.md) |
+| browser, vanilla js, javascript, jquery, cdn, wordpress, static site | [`sentry-browser-sdk`](../sentry-browser-sdk/SKILL.md) |
+| cloudflare, cloudflare workers, cloudflare pages, wrangler, durable objects, d1 | [`sentry-cloudflare-sdk`](../sentry-cloudflare-sdk/SKILL.md) |
+| ios, macos, swift, cocoa, tvos, watchos, visionos, swiftui, uikit | [`sentry-cocoa-sdk`](../sentry-cocoa-sdk/SKILL.md) |
+| .net, csharp, c#, asp.net, maui, wpf, winforms, blazor, azure functions | [`sentry-dotnet-sdk`](../sentry-dotnet-sdk/SKILL.md) |
+| go, golang, gin, echo, fiber | [`sentry-go-sdk`](../sentry-go-sdk/SKILL.md) |
+| elixir, phoenix, plug, oban | [`sentry-elixir-sdk`](../sentry-elixir-sdk/SKILL.md) |
+| nestjs, nest | [`sentry-nestjs-sdk`](../sentry-nestjs-sdk/SKILL.md) |
+| nextjs, next.js, next | [`sentry-nextjs-sdk`](../sentry-nextjs-sdk/SKILL.md) |
+| node, nodejs, node.js, bun, deno, express, fastify, koa, hapi | [`sentry-node-sdk`](../sentry-node-sdk/SKILL.md) |
+| php, laravel, symfony | [`sentry-php-sdk`](../sentry-php-sdk/SKILL.md) |
+| python, django, flask, fastapi, celery, starlette | [`sentry-python-sdk`](../sentry-python-sdk/SKILL.md) |
+| flutter, dart, pubspec | [`sentry-flutter-sdk`](../sentry-flutter-sdk/SKILL.md) |
+| react native, expo | [`sentry-react-native-sdk`](../sentry-react-native-sdk/SKILL.md) |
+| react, react router, tanstack, redux, vite | [`sentry-react-sdk`](../sentry-react-sdk/SKILL.md) |
+| react-router framework, @sentry/react-router, @react-router/dev, react-router reveal | [`sentry-react-router-framework-sdk`](../sentry-react-router-framework-sdk/SKILL.md) |
+| tanstack start, tanstack react start, @tanstack/react-start, tanstackstart-react | [`sentry-tanstack-start-sdk`](../sentry-tanstack-start-sdk/SKILL.md) |
+| ruby, rails, sinatra, sidekiq, rack | [`sentry-ruby-sdk`](../sentry-ruby-sdk/SKILL.md) |
+| svelte, sveltekit | [`sentry-svelte-sdk`](../sentry-svelte-sdk/SKILL.md) |
 
 ---
 

--- a/skills/sentry-workflow/SKILL.md
+++ b/skills/sentry-workflow/SKILL.md
@@ -11,14 +11,6 @@ role: router
 
 Debug production issues and maintain code quality with Sentry context. This page helps you find the right workflow skill for your task.
 
-## How to Fetch Skills
-
-Use `curl` to download skills — they are 10–20 KB files that fetch tools often summarize, losing critical details.
-
-    curl -sL https://skills.sentry.dev/sentry-fix-issues/SKILL.md
-
-Append the path from the `Path` column in the table below to `https://skills.sentry.dev/`. Do not guess or shorten URLs.
-
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume which workflow the user needs. Ask first.
@@ -34,12 +26,12 @@ When unclear, **ask the user** whether the task involves live production issues,
 
 ## Workflow Skills
 
-| Use when | Skill | Path |
-|---|---|---|
-| Finding and fixing production issues — stack traces, breadcrumbs, event data | [`sentry-fix-issues`](../sentry-fix-issues/SKILL.md) | `sentry-fix-issues/SKILL.md` |
-| Resolving comments from `sentry[bot]` on GitHub PRs | [`sentry-code-review`](../sentry-code-review/SKILL.md) | `sentry-code-review/SKILL.md` |
-| Fixing issues detected by Seer Bug Prediction in PR reviews | [`sentry-pr-code-review`](../sentry-pr-code-review/SKILL.md) | `sentry-pr-code-review/SKILL.md` |
-| Upgrading the Sentry JavaScript SDK — migration guides, breaking changes, deprecated APIs | [`sentry-sdk-upgrade`](../sentry-sdk-upgrade/SKILL.md) | `sentry-sdk-upgrade/SKILL.md` |
+| Use when | Skill |
+|---|---|
+| Finding and fixing production issues — stack traces, breadcrumbs, event data | [`sentry-fix-issues`](../sentry-fix-issues/SKILL.md) |
+| Resolving comments from `sentry[bot]` on GitHub PRs | [`sentry-code-review`](../sentry-code-review/SKILL.md) |
+| Fixing issues detected by Seer Bug Prediction in PR reviews | [`sentry-pr-code-review`](../sentry-pr-code-review/SKILL.md) |
+| Upgrading the Sentry JavaScript SDK — migration guides, breaking changes, deprecated APIs | [`sentry-sdk-upgrade`](../sentry-sdk-upgrade/SKILL.md) |
 
 Each skill contains its own detection logic, prerequisites, and step-by-step instructions. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 


### PR DESCRIPTION
## Why

The skill routers (`sentry-sdk-setup`, `sentry-workflow`, `sentry-feature-setup`) and the `SKILL_TREE.md` index each carried explicit curl-navigation scaffolding — a "How to Use These Skills" / "How to Fetch Skills" section (`Use curl to download...`, `Append the path to https://skills.sentry.dev/...`) plus a redundant `Path` column sitting next to the relative-link column that already navigates.

That guidance had two problems: it was duplicated across every router, and it shipped **inside the plugin distributions**, where the agent reads the files off disk and should never curl anything — the curl instruction was actively wrong in that context.

## What

Curl/HTTP navigation is moving to the [skills.sentry.dev](https://github.com/getsentry/skills.sentry.dev) proxy. The proxy now appends a per-file navigation note (and a usage preamble on the index at `/`) that tells an HTTP reader how to resolve the relative links the document already contains. That means the sources no longer need to say anything about curl — they keep a single relative-link column that resolves correctly **both** locally (plugin) and over HTTP (mirror).

This PR removes the curl scaffolding from the sources:

- Drop the "How to Use These Skills" / "How to Fetch Skills" sections from the `SKILL_TREE.md` generator and the three routers.
- Remove the redundant `Path` column from the routing tables; keep the relative-link column.
- Convert the path-only "Quick Lookup" tables to relative links.
- `Fetch the matching skill` → `Read the matching skill`.

Companion change (separate repo): the proxy that injects the note + index preamble lives in `getsentry/skills.sentry.dev`. That should deploy before/with this merge so HTTP navigation guidance is never briefly absent.

Note: the consolidated `sentry-sdk` skill got the same cleanup locally, but it isn't on `main` yet, so it's intentionally excluded here and will land with that skill.