### PR TITLE
feat(skills-next): add concept references

### DIFF
--- a/skills-next/references/concepts/choosing-a-signal.md
+++ b/skills-next/references/concepts/choosing-a-signal.md
@@ -1,0 +1,68 @@
+# Choosing a signal
+
+Sentry captures several distinct **signals**. They are not interchangeable. Picking the right one is
+the single most important instrumentation decision, and the wrong one is the most common waste of
+quota. Decide by the question you are trying to answer.
+
+| You want to know… | Reach for | Why |
+|---|---|---|
+| *Something broke — what, where, and why?* | **Error** | An exception/crash with a stack trace, grouped into an issue. The default, always-on signal. |
+| *Why is this slow? What's the chain of calls? Did the request flow through the system as expected?* | **Span / trace** | Timing and structure of a request across services (distributed tracing). Powers performance-issue detection (N+1, slow DB). |
+| *What happened leading up to this?* | **Log** | A searchable, structured, trace-connected record of discrete events. Narrative context, not timing. |
+| *How many / how much / what's the trend over time?* | **Metric** | An aggregate number (counter / gauge / distribution) for a KPI you watch and alert on. |
+| *Which exact function/line is burning CPU?* | **Profile** | Code-level sampling under a traced transaction. Requires tracing on. |
+| *What did the user actually see and do?* | **Session Replay** | A video-like reproduction of a frontend/mobile session around an error or UX problem. |
+| *What does the user think went wrong?* | **User Feedback** | A qualitative report from a human, linked to the surrounding context. |
+| *Did my scheduled job run on time?* | **Cron monitor** | Check-ins that detect missed, late, or failed recurring jobs. |
+
+Most of these signals carry the same **trace ID**, so once one surfaces a problem you can pivot to the
+others in the same request — the trace is the connective tissue that ties errors, spans, logs, replays,
+and metrics together for debugging.
+
+## Comparisons
+
+- **Error vs. log.** An exception your code can't handle is an **error** (capture it as one — it
+  groups into an issue and gets a stack trace). A noteworthy thing that happened but isn't a failure
+  is a **log**. Don't log-spam things that should be errors; don't capture routine events as errors
+  and pollute the issue stream.
+- **Log vs. span.** A log answers *what happened*; a span answers *how long it took and what it
+  called*. If you find yourself logging start/end timestamps to measure duration, you want a span
+  instead.
+- **Span vs. metric.** A span is one sampled instance of an operation (great for "show me a slow
+  request"). An **Application Metric** is a numeric measurement aggregated over all occurrences at query
+  time (great for "alert when p95 latency exceeds 500ms") and, unlike a traditional metric, can carry
+  high-cardinality attributes.
+- **Metric vs. counting events.** Don't emit a custom metric for something Sentry already derives
+  from errors/spans (issue counts, throughput, latency percentiles, crash-free rate). Reserve custom
+  metrics for **business/operational KPIs** Sentry can't see — `checkout.failed`, `queue.depth`,
+  `cache.hit_ratio`.
+- **Profile rides on tracing.** Profiling is not a standalone signal — it samples *inside* traced
+  transactions. Tracing must be on first.
+
+## What to instrument where
+
+- **Errors:** everywhere, always. This is the baseline and the first thing to get working.
+- **Tracing:** the request **boundaries** first — incoming HTTP, outbound HTTP, DB / cache / queue.
+  Auto-instrumentation covers most of these once tracing is on. Add custom spans only for meaningful
+  business operations.
+- **Logging:** a few high-signal events per request with structured attributes — not a firehose.
+- **Metrics:** a small, deliberate set of KPIs that map to a real decision or alert.
+- **Replay:** frontend (and mobile) only; high sampling on errors, low on normal sessions.
+- **Crons:** every scheduled job whose silent failure would hurt.
+
+When the user is unsure, ask what question they're trying to answer and map it with the table above.
+When they say "set it up properly" / "you pick the defaults," lean on the recommended baseline:
+**errors + tracing at a modest sample rate + releases + source maps**, then add logs/replay/profiling
+as the use case warrants.
+
+## Cross-cutting concepts (not signals)
+
+These shape how the signals above behave and how you act on them — each has its own reference:
+
+- **Releases** — tie every event to a deployed version. Unlocks regression detection, crash-free
+  rates, suspect commits, and resolve-in-next-release.
+- **Monitors → Issues → Alerts** — Sentry's detection-and-response model. *Monitors* decide when a
+  signal becomes an **issue**; *Alerts* act on issues.
+- **Data scrubbing / PII** — what's sensitive, and the defense-in-depth model for keeping it out.
+- **Volume & cost** — what to keep vs. drop, and where to sample.
+- **Search query language** — the `key:value` grammar shared by every query surface.

--- a/skills-next/references/concepts/crons.md
+++ b/skills-next/references/concepts/crons.md
@@ -1,0 +1,41 @@
+# Cron / Scheduled-Job Monitoring — What & Why
+
+Monitoring for recurring jobs — cron jobs, scheduled tasks, queue workers. Sentry watches for runs that
+are **missed**, **late**, **timed out**, or **failed** and turns those into issues. It works via
+**check-ins**: the job reports `in_progress` when it starts and `ok`/`error` when it finishes; a run that
+never checks in (or checks in late) is flagged against the monitor's schedule.
+
+Reach for it where **silent failure is dangerous** — a nightly billing run, a data sync, a backup — and
+"it didn't run" is as bad as "it crashed."
+
+## Why a cron issue often isn't where you'd look
+
+- **A "missed" issue frequently isn't in the job code.** Missed means no check-in arrived in the expected
+  window — commonly the **scheduler** (misconfigured, skipped, never started the job), a **network**
+  problem (outbound firewall, flaky connection), or a timeout. Don't assume the job body threw.
+- **The real exception is a separate error event on the same trace.** If the SDK is configured, errors
+  thrown during the run are captured as normal error events and tied back to the check-in through the
+  run's trace — follow the trace from the cron issue to find them.
+- **Issue creation is threshold-gated,** not per-failure: `failure_issue_threshold` (N consecutive
+  failures before an issue opens) and `recovery_threshold` (N consecutive OKs before it resolves). A
+  single failure may not create an issue.
+- **Absence of alerts ≠ healthy.** A monitor broken for weeks gets auto-muted — it stops producing issues
+  and notifications while billing continues. A silent monitor may be muted, not passing.
+
+## Setup essentials
+
+- **Monitor config is data** (server-side): the schedule (crontab — 5-field only — or interval), the
+  **`timezone`**, **`checkin_margin`** (how late counts as missed), and **`max_runtime`** (how long counts
+  as hung). Set the last two to the job's real timing — tight enough to catch a hang, loose enough to
+  avoid false alarms.
+- **Check-ins are code** (SDK-side). Paths: the SDK **`withMonitor` / decorator** wrapper (cleanest when
+  an SDK is present — sends both start and outcome), an **HTTP check-in** (any language, ideal for shell
+  crontabs), or **`sentry-cli`** wrapping a shell command. Wrap the **whole job** so both success and
+  failure report; a bare heartbeat (single `ok`/`error`) detects *missed* but not *`max_runtime`*
+  timeouts.
+- **Use a stable, descriptive slug** (`nightly-invoice-sync`, not `job-1`) — it's the check-in key, so
+  slug churn on every deploy orphans monitors.
+
+## Related
+
+- [`monitors.md`](monitors.md) — a cron monitor is one kind of Monitor that creates issues.

--- a/skills-next/references/concepts/data-scrubbing.md
+++ b/skills-next/references/concepts/data-scrubbing.md
@@ -1,0 +1,38 @@
+# Data Scrubbing / PII — Strategy
+
+Controlling what personal or sensitive data reaches (and is stored by) Sentry — a common GDPR / PCI /
+SOC2 requirement, or just not wanting tokens in your error tracker. Treat as sensitive: emails, names,
+IPs, user IDs that map to people, full request/response **bodies**, **headers** (auth tokens, cookies,
+session IDs), query strings with tokens, passwords, and anything regulated. When in doubt, assume a field
+is sensitive.
+
+## Defense in depth — two layers, both
+
+1. **SDK-side (before data leaves the app)** — the strongest guarantee; data you never send can't leak.
+   - `sendDefaultPii` controls whether the SDK attaches request/user PII automatically (default off).
+   - `beforeSend` / `beforeSendTransaction` hooks strip, redact, or drop fields on every event.
+2. **Server-side (Sentry, the backstop)** — data-scrubbing rules scrub on ingest (Safe/Sensitive field
+   lists + an advanced selector rules engine). On by default.
+
+Scrub at the earliest layer you can; keep the server-side rules as a backstop, because you'll eventually
+capture something you didn't anticipate.
+
+## AI/LLM attributes (`gen_ai.*`)
+
+**Prompt and completion attributes (`gen_ai.input.messages`, `gen_ai.output.messages`,
+`gen_ai.tool.call.*`, …) are not scrubbed by the default server-side rules.** Their capture is itself
+opt-in (only when PII capture is enabled), but *once captured they aren't redacted* — so if you
+instrument an LLM app, explicitly scrub them with an advanced rule (`$span.data.'<attribute>'`) or
+disable their capture.
+
+## Verify, don't assume
+
+Trigger an event and confirm the sensitive fields are absent/redacted in the event detail. Logs and
+replay/screenshots are the easiest leaks — pair with [`logging.md`](logging.md) and
+[`session-replay.md`](session-replay.md).
+
+## Related
+
+- [`logging.md`](logging.md)
+- [`session-replay.md`](session-replay.md)
+- [`reduce-volume.md`](reduce-volume.md)

--- a/skills-next/references/concepts/errors.md
+++ b/skills-next/references/concepts/errors.md
@@ -1,0 +1,34 @@
+# Error monitoring
+
+Unhandled exceptions and crashes — plus anything you send explicitly with `captureException` — grouped
+into **issues** with the context needed to fix them: a stack trace, breadcrumbs (the events leading up
+to the error), and request/user/release metadata. An issue is the unit you triage, assign, resolve, and
+link a fix to.
+
+## What an issue actually is
+
+- An **issue is a group of events** sharing a fingerprint (stack trace + exception type/message), not a
+  single occurrence. Sentry surfaces one **representative event** — the one richest in context, which
+  is not necessarily the latest — so you reason about the group and drill into an event for specifics.
+- **The cause isn't always in the stack trace.** Suspect commits tie the issue to the commit that
+  likely introduced it, and a **trace-related issue** points to a *different* issue in the same request
+  that may be the real origin — the crash you're looking at can be a downstream symptom.
+- **When one bug shows up as several issues (or several bugs as one), that's a grouping problem** — the
+  fingerprint is tunable, not something to live with.
+
+## What makes an error actionable
+
+- **A readable stack trace** — minified JS or unsymbolicated native frames make an issue nearly
+  useless; readable frames depend on source maps (JS) or debug symbols (native/mobile) being uploaded.
+- **`release` and `environment` tags** — unlock regression detection, resolve-in-next-release, and
+  separating prod from staging noise. Set them from the start.
+- **Context, not PII** — tags, user IDs, and breadcrumbs make an error diagnosable; scrub sensitive
+  data before it leaves the app ([`data-scrubbing.md`](data-scrubbing.md)).
+- **Not routine control flow** — expected 404s and validation rejections aren't errors; capturing them
+  buries the real problems.
+
+## Related
+
+- [`tracing.md`](tracing.md)
+- [`releases.md`](releases.md)
+- [`data-scrubbing.md`](data-scrubbing.md)

--- a/skills-next/references/concepts/logging.md
+++ b/skills-next/references/concepts/logging.md
@@ -1,0 +1,48 @@
+# Structured Logging — What & Why
+
+Structured, trace-connected logs: each log carries a level, a message, and key/value **attributes**, and
+Sentry automatically attaches the trace ID so it correlates with the spans, errors, and other logs in
+the same request. Logs record the context and decisions that explain *what happened* during
+execution — the context a stack trace alone can't give.
+
+## When to reach for a log
+
+- **Not for timing or flow** — that's a span / trace.
+- **Not for unexpected critical failures** — that's an error (it groups into an issue with a stack
+  trace). A log is for noteworthy-but-handled events: a runtime decision (a feature flag served a
+  different path), an audit or business event (created / updated / deleted / permission changed), a
+  summary of a multi-step operation, or context around a *recoverable* failure (a retry before the final
+  attempt, a non-critical upstream that failed).
+- **Not for every function call** — high-frequency line-spam is noise and billed volume. A log should
+  answer a concrete production question and still be useful if emitted thousands of times.
+
+## Structure
+
+- **Consistent key/value attributes, not interpolation.** Namespace them (`myapp.<domain>.<field>`) and
+  reuse field names across the app so events can be searched and aggregated. A good log answers who did
+  it, what happened, and when. Attributes are what you query — `severity:error`, `trace_id:...`,
+  `user.id:...` with `AND`/`OR` (the level field is `severity` in search); raw text search matches only
+  the message, so anything you want to filter on must be an attribute.
+- **Accumulate context as a request evolves** — early logs may carry only request info; later ones add
+  the authenticated user, feature flags, and outcomes. Prefer the SDK's `set_user` over repeating a user
+  ID on every log.
+- **Levels carry meaning:** `debug` (temporary diagnostics), `info` (normal events), `warn` (recoverable
+  but notable), `error` (handled failures — prefer a real error for anything that should become an
+  issue).
+- **Log fields, not whole objects** — pick the fields you'll query and omit absent optional attributes
+  rather than logging `null`.
+- Sentry can integrate with an existing logging abstraction (Monolog, slog, Rails logger, Pino/console)
+  or you can call the SDK's logger directly.
+
+## Don't log sensitive data
+
+Assume anything logged will be read by another human. Never log passwords, tokens, API keys, or raw
+request/response bodies; prefer opaque user IDs over emails or names, and mind PCI / GDPR / CCPA /
+HIPAA-regulated fields. Server-side scrubbing is a backstop, not a license to log carelessly
+([`data-scrubbing.md`](data-scrubbing.md)).
+
+## Related
+
+- [`data-scrubbing.md`](data-scrubbing.md)
+- [`reduce-volume.md`](reduce-volume.md)
+- [`search-query-language.md`](search-query-language.md) — querying logs.

--- a/skills-next/references/concepts/metrics.md
+++ b/skills-next/references/concepts/metrics.md
@@ -1,0 +1,42 @@
+# Application Metrics — What & Why
+
+**Application Metrics** are numeric values you emit and watch over time, trace-connected so a spike on a
+chart links back to the producing traces. Unlike traditional (StatsD-style) metrics they support high
+cardinality and dimensionality — a key difference that changes how you instrument them (see below).
+Three types, picked by the question:
+
+| Type | Answers | Example |
+|---|---|---|
+| **count** | *How many?* | `checkout.failed`, `signup.completed` |
+| **gauge** | *What's the value now?* | `queue.depth`, `connections.active` |
+| **distribution** | *What's the spread (p50/p95/max)?* | `api.latency`, `payload.size` |
+
+## What Application Metrics excel at
+
+They answer *how many / how much / what's the trend* — the aggregate view you alert and build dashboards
+on, where the other signals don't fit: tracing is for request performance and flow, logging for runtime
+decisions and audit trails, errors for critical failures. A metric tells you *that* something moved, not
+*why* — and because Application Metrics are trace-connected, you pivot from a point on the chart to its
+samples and the traces behind them to find the cause.
+
+## Setup essentials
+
+- **Don't re-invent what Sentry derives** — issue counts, throughput, latency percentiles, and
+  crash-free rate come from errors/spans for free. Reserve Application Metrics for KPIs Sentry can't
+  see: conversion, business failures, saturation, cache-hit ratio.
+- **A KPI already sitting in your logs is a candidate to promote to a metric** — a log is an ephemeral
+  signal optimized for search; a metric is a durable, review-worthy code artifact optimized for alerting
+  and dashboards.
+- **High cardinality and dimensionality are fine — and a key benefit.** Unlike traditional metrics,
+  Application Metrics can carry high-cardinality attributes (user IDs, request IDs, URLs); don't force
+  low-cardinality attributes the way you would with a StatsD-style metric or you'll throw away useful
+  signal. Set **units** on distributions (ms, bytes) and name consistently (`domain.thing.action`).
+- Values are emitted **per occurrence and aggregated at query time** (not a client-side pre-aggregate).
+- The old beta `Sentry.metrics.increment` / StatsD-style API was **removed in SDK v9** — use the current
+  `count` / `gauge` / `distribution` API (the exact surface varies by platform).
+
+## Related
+
+- [`monitors.md`](monitors.md) — a Metric Monitor can alert on an Application Metric (it can also watch
+  logs, spans, or errors — it isn't metrics-specific).
+- [`tracing.md`](tracing.md) — Application Metrics complement, don't replace, spans.

--- a/skills-next/references/concepts/monitors.md
+++ b/skills-next/references/concepts/monitors.md
@@ -1,0 +1,66 @@
+# Monitors → Issues → Alerts — The Model
+
+Sentry separates **what you detect** from **what you do about it**, in three stages — **Monitors**
+detect, **Issues** are the unit you triage, and **Alerts** respond:
+
+- A **Monitor** decides *when* a signal becomes an **issue**.
+- An **Issue** is the unit you triage — a grouped, stateful object (status, priority, assignee, history).
+- An **Alert** decides *what to do* once an issue matches its conditions — notify Slack, page someone,
+  open a ticket, hit a webhook.
+
+Monitors detect; Alerts respond. They're configured independently: one alert can watch many
+monitors/projects, and one monitor can feed several alerts.
+
+> Terminology: this model uses **Metric Monitor** for the detection stage and reserves **Alert** for the
+> response stage. Older docs and integrations still say "metric **alert**" for the same detection
+> concept — treat them as the same thing; the rename isn't fully settled across the product.
+
+## Monitors — when a signal becomes an issue
+
+- **Default monitors** — auto-created per project: the **Issue Stream Monitor** and **Error Monitor**
+  (the error-detection / grouping pipeline). Nothing to set up; worth knowing they're "monitors" in this
+  model.
+- **Custom monitors:**
+  - **Metric Monitor** — a threshold on errors / spans / logs / releases / Application Metrics; the threshold
+    can be **fixed**, a **percentage change** vs. a prior window, or **dynamic anomaly detection**. Often
+    created straight from a saved Discover or Metrics-Explorer query.
+  - **Cron Monitor** — a scheduled-job watch via check-ins ([`crons.md`](crons.md)).
+  - **Uptime Monitor** — periodic HTTP checks against a URL.
+  - **Mobile Builds Monitor** — app-size thresholds across iOS/Android builds.
+
+**Monitor config also sets issue attributes at creation** — priority, auto-resolve, and assignee
+(ownership rules can override the assignee). The monitor decides not just *that* something becomes an
+issue but *how important* it is and *who owns it*.
+
+## Alerts — acting on issues
+
+An alert is **sources → triggers → filters → actions**:
+
+- **Sources** — which projects/monitors it watches.
+- **Triggers** — which issue-state changes fire it (new, regression, reappearance, resolved); triggers
+  are OR'd.
+- **Filters** — conditions the issue/event must match before actions run (priority, frequency, tags,
+  assignment, age); filter groups can be ANY or ALL. **If an issue exists but no alert fired, a filter is
+  usually why.**
+- **Actions** — Slack, email, PagerDuty, Discord, Jira, webhook, …
+
+## When to reach for what
+
+- *"Tell me in Slack when a new issue shows up"* → an **Alert** (the default error monitor already makes
+  the issues).
+- *"Alert when error rate / latency / a metric crosses a line"* → a **Metric Monitor**, then an alert.
+- *"My nightly job didn't run"* → a **Cron Monitor**. *"Is my endpoint up?"* → an **Uptime Monitor**.
+
+## Coverage honesty
+
+Alert creation is automatable via Sentry's workflow-engine API; several monitor types (uptime,
+dashboards) are heavier UI/API hand-offs today — be upfront about what the agent can do end-to-end vs.
+where it walks the user through the UI. The MCP can generally only **read** alert rules, still useful for
+verifying after creation.
+
+## Related
+
+- [`crons.md`](crons.md)
+- [`metrics.md`](metrics.md)
+- [`releases.md`](releases.md)
+- [`search-query-language.md`](search-query-language.md)

--- a/skills-next/references/concepts/profiling.md
+++ b/skills-next/references/concepts/profiling.md
@@ -1,0 +1,31 @@
+# Profiling — What & Why
+
+Code-level sampling of production execution. Tracing tells you *which operation* is slow; profiling
+tells you *which function and line* inside it is burning the time. The output is a **flame graph**,
+also available as **differential** ("what got slower between releases") views.
+
+## What a flame graph represents
+
+A flame graph aggregates many stack samples, and its two shapes have **different x-axes**. In a
+single-profile graph X is time and **width = time spent**, so the bottleneck is the deepest wide frame
+with high **self-time** (time in the function itself, excluding children) — a wide frame with little
+self-time just means the cost is in a child. In an **aggregated** graph X is not time; **width = how
+often a frame appears** across samples. Frames are colored **application vs. system**: you can only act
+on your own code, so a wide *application* frame is the target, not a wide system frame. A profile
+covers one thread at a time.
+
+## Setup essentials
+
+- **Modes:** **Continuous profiling** (backend; Python/Node today) and **UI profiling**
+  (frontend/mobile) are the current products; legacy transaction-based profiling is being replaced.
+- **The dependency to get right:** in the default **`manual` lifecycle** mode, profiling runs
+  *independently* of tracing — you start/stop it explicitly (`start_profiler`/`stop_profiler`), and
+  nothing is collected until you do. Only the optional **`trace` lifecycle** mode (and legacy
+  transaction-based profiling) require tracing on and sample relative to sampled transactions.
+- **Sample, don't profile everything** — ~1–5% CPU overhead; sampling is session-scoped. Mind minimum
+  SDK versions (support varies by platform).
+
+## Related
+
+- [`tracing.md`](tracing.md) — profiling localizes a bottleneck tracing pointed at.
+- [`reduce-volume.md`](reduce-volume.md) — sampling/overhead tradeoffs.

--- a/skills-next/references/concepts/reduce-volume.md
+++ b/skills-next/references/concepts/reduce-volume.md
@@ -1,0 +1,43 @@
+# Volume & Cost — Strategy
+
+Sentry bills by the volume of each signal (errors, spans, replays, profiles), and logs and metrics are
+billed by *size* — so attribute count and message length matter, not just event count. Reducing volume
+is keeping the data that earns its place and dropping the rest — for quota *and* for signal-to-noise.
+
+## The core tradeoff, per signal
+
+- **Errors:** sample *lightly* or not at all — usually what you can't afford to miss. The cheapest win is
+  **filtering known noise** (browser-extension errors, bots, a specific bogus exception), not blanket
+  down-sampling.
+- **Spans / traces:** sample *aggressively* — the highest-volume signal and biggest lever. A
+  `tracesSampler` that keeps important paths and drops health-check noise beats a flat low rate. (Note
+  `tracesSampleRate: 0` doesn't disable tracing — see [`tracing.md`](tracing.md).)
+- **Replays / profiles:** keep the asymmetric/sampled defaults (high on error, low on normal).
+- **Logs / metrics:** billed by size — trim attribute count and message length, not just event count,
+  on top of emitting fewer, higher-signal events.
+
+## Where to sample — head vs. server-side
+
+- **Client / head sampling (SDK)** — decide before sending; cheapest, and the decision propagates across
+  a trace so you keep whole traces. The first lever.
+- **Server-side (Sentry)** — a backstop, and for what the SDK can't cleanly decide:
+  - **Inbound data filters** — browser-extension errors, known crawlers, legacy browsers, `localhost`,
+    specific error messages or releases, by IP. (Some are Business-plan.)
+  - **Per-DSN rate limits** — cap a noisy key. **Spike protection** — an automatic guard against a sudden
+    flood. **Delete & Discard** — stop ingesting a specific high-volume issue entirely.
+
+## A practical workflow
+
+1. **Find the top offenders first** (MCP / `/seer` / Explore across errors, spans, and logs) — don't cut
+   blind.
+2. **Filter known noise** — high precision, no fidelity loss on real data.
+3. **Tune span sampling** with a `tracesSampler` — the biggest lever.
+4. **Set rate limits / spike protection** as a safety net.
+5. **Re-measure** to confirm you cut noise, not signal.
+
+## Related
+
+- [`tracing.md`](tracing.md) — span sampling, the main lever.
+- [`logging.md`](logging.md)
+- [`session-replay.md`](session-replay.md)
+- [`profiling.md`](profiling.md)

--- a/skills-next/references/concepts/releases.md
+++ b/skills-next/references/concepts/releases.md
@@ -1,0 +1,36 @@
+# Releases — What & Why
+
+A **release** is a version of your code deployed to an environment. Tying every event to its exact
+version unlocks:
+
+- **Regression detection** — when an issue first appeared and whether it came back in a later release.
+- **Crash-free rates / release health** — error-free sessions and users per release (session tracking is
+  on by default in most modern SDKs).
+- **Suspect commits** — the specific commit(s) likely responsible for an issue, surfaced on the issue
+  with a suggested assignee.
+- **Resolve-in-next-release** and **`Fixes SENTRY-XXX`** — resolve an issue and let Sentry track whether
+  it stays fixed in the version that ships the fix.
+
+## While debugging
+
+Releases let you pin the exact code that was running when an issue was produced — diff against that
+revision rather than assuming `main` matches — and **suspect commits** on the issue are the fastest "what
+changed." Suspect commits need the source-control integration below; without it you still get
+release-scoped regression and health, just not the culprit commit.
+
+## Setup essentials — two ingredients
+
+1. **The `release` (and `environment`) tag on events** — set in the SDK `init` (or `SENTRY_RELEASE`).
+   Without it every event is "unknown release" and regression/health features can't work.
+2. **The release object + commits + deploy, created in CI** — via `sentry-cli` or the GitHub Action.
+   **Associating commits is what powers suspect commits**, and that association needs a **source-control
+   integration** (GitHub/GitLab) connected in Sentry's UI (an OAuth step the agent can't do). The
+   **release name must match** between the SDK tag and the CI-created release, or events won't attribute.
+
+Use a meaningful, unique version (a commit SHA or semver), set `environment` so staging noise doesn't
+pollute prod health, and finalize the release + record the deploy at deploy time.
+
+## Related
+
+- [`monitors.md`](monitors.md) — release-health / crash-rate monitors build on this.
+- [`search-query-language.md`](search-query-language.md) — `release`, `firstRelease`, `release.stage`.

--- a/skills-next/references/concepts/session-replay.md
+++ b/skills-next/references/concepts/session-replay.md
@@ -1,0 +1,31 @@
+# Session Replay — What & Why
+
+A reconstruction of a user session around an error or UX problem. On **web** it's rebuilt from DOM
+snapshots and events (rrweb — *not* a screen recording), so it's lightweight; on **mobile** it's a
+view-hierarchy reconstruction plus periodic screenshots, with more aggressive default redaction.
+Replays link to the errors, traces, and rage/dead clicks in the same session. It's a **frontend/mobile**
+signal — there's nothing to replay on a backend.
+
+## What a replay adds over a stack trace
+
+A replay is the *user's path*, timestamp-synced to everything else in the session — the clicks,
+navigations, network calls, and console output that led to the error, not just the frame where it threw.
+Two UX signals live here that never surface as exceptions: a **dead click** (a click that produces no
+response within ~7s) and a **rage click** (the repeated-click subset) — and these are promoted to their
+own **issues**, so a real UX problem can exist with no exception behind it.
+
+## Setup essentials
+
+- **Two sample rates, asymmetric:** keep `replaysOnErrorSampleRate` **high** (often `1.0` — you want a
+  replay for any session that errored) and `replaysSessionSampleRate` **low** (a few percent — capturing
+  every healthy session is expensive).
+- **Privacy.** Defaults **mask all text and block media** — start there; use mask/block selectors to
+  redact sensitive fields before unmasking anything globally, and treat network request/response **body
+  capture as opt-in**. Mobile redacts more aggressively by default; still review sensitive screens.
+
+## Related
+
+- [`data-scrubbing.md`](data-scrubbing.md)
+- [`reduce-volume.md`](reduce-volume.md)
+- [`search-query-language.md`](search-query-language.md) — replay properties (`count_rage_clicks`,
+  `click.*`, `count_errors`, …).

--- a/skills-next/references/concepts/tracing.md
+++ b/skills-next/references/concepts/tracing.md
@@ -1,0 +1,44 @@
+# Tracing & Performance — What & Why
+
+## What it is
+
+Distributed tracing reconstructs one request as it flows across frontend, backend, and downstream
+services. A trace is a tree of **spans** — each a timed operation (an HTTP request, a DB query, a
+function call) with a name, duration, parent, and attributes. The root span is the **transaction**.
+Tracing answers *why* something is slow, and it's the substrate Sentry uses to **automatically detect
+performance issues** — N+1 queries, slow DB calls, render-blocking assets, consecutive HTTP calls
+(detection requires tracing on).
+
+## What a trace shows
+
+A trace is a waterfall of spans nested by ancestry, and the shape *is* the diagnosis: the widest
+span — or a gap between spans — is where the time went (a slow query, a blocking upstream call), which
+the stack trace alone can't tell you. A trace is also a cross-issue view: an error inside it links to
+its issue, and the real root cause can be a *different* issue in the same request — a frontend exception,
+say, driven by a failing span in the backend service upstream. Two shapes to read correctly — a dashed/orphan span means a transaction is **missing**
+(unsent, sampled out, rate-limited), usually from a low sample rate rather than a real gap; multiple
+roots usually means a custom-instrumentation trace-ID bug. A span also carries its profile, the bridge
+down to the function level.
+
+## Setup essentials
+
+- **Sampling is the main cost/signal lever** (trace volume dwarfs errors). `tracesSampleRate` is a flat
+  fraction (start 5–20% in prod); `tracesSampler` is a function returning a per-transaction rate — use
+  it to sample *down* noise (health checks) and *up* the paths you care about. **`tracesSampleRate: 0`
+  does not disable tracing** — it keeps tracing enabled but samples nothing; omit the sampling config
+  entirely to truly disable. The head-of-trace sampling decision propagates downstream, so you capture
+  whole traces, not fragments.
+- **Cross-service:** add your API domains to `tracePropagationTargets` so the SDK attaches trace headers
+  (`sentry-trace`, `baggage`, and the newer `traceparent`) on outbound requests, and allow those
+  headers via CORS — or propagation silently fails and you get two disconnected traces.
+- **Instrument boundaries first** (incoming/outbound HTTP, DB / cache / queue — mostly
+  auto-instrumented), add custom spans for meaningful business operations, and keep span names
+  **low-cardinality and templated** (`GET /users/:id`, not `/users/12345`) with searchable attributes
+  rather than baking values into the name. Follow Sentry's semantic conventions (aligned with
+  OpenTelemetry) for span and attribute names so they match what the product expects.
+
+## Related
+
+- [`profiling.md`](profiling.md)
+- [`reduce-volume.md`](reduce-volume.md) — sampling is the main lever.
+- [`search-query-language.md`](search-query-language.md) — span properties for querying traces.

--- a/skills-next/references/concepts/user-feedback.md
+++ b/skills-next/references/concepts/user-feedback.md
@@ -1,0 +1,32 @@
+# User Feedback — What & Why
+
+Qualitative reports from real users, linked to Sentry context — the surrounding error, replay, trace,
+release, and user. The one signal that captures *what the human thinks went wrong*, which the machine
+signals can't tell you.
+
+## What a feedback entry is worth
+
+Its value is the **linked context**, not the prose. A feedback entry carries a pivot to the moment it's
+about: a widget submission attaches the user's replay (roughly the minute before they hit submit) and
+the page URL; a crash-report submission links straight to the **issue**. So feedback is a way *into* the
+machine signals from the human side — and it surfaces as its own issue category (`Feedback`) rather than
+living in a separate silo.
+
+## Setup essentials — three mechanisms
+
+- **Feedback widget** (browser only) — an embeddable, auto-injectable button/form with an optional
+  screenshot. The default for web.
+- **`captureFeedback` API** — programmatic; the cross-platform path (mobile/desktop/backend) and when
+  you want control over your own UI.
+- **Crash-report modal** — prompts for detail right after an error fires; the practical option where
+  there's no persistent UI to host a widget.
+
+Decide required fields and screenshots up front (more fields = fewer but richer submissions), **route
+feedback somewhere actionable** (Slack / Jira / an alert) so it isn't a black hole, and apply
+replay-grade masking to screenshots — they capture whatever is on screen.
+
+## Related
+
+- [`session-replay.md`](session-replay.md)
+- [`data-scrubbing.md`](data-scrubbing.md)
+- [`search-query-language.md`](search-query-language.md) — user-feedback properties.


### PR DESCRIPTION
Splits the shared concept reference docs out of the get-started (#235) and "remaining unorganized content" changes into a single dedicated PR.

Adds `skills-next/references/concepts/` — per-signal concept explainers (errors, tracing, logging, session replay, profiling, user feedback, metrics, monitors, crons, releases, data scrubbing, volume/cost) plus the signal-selection guide. These are the shared "what this signal is and how to reason about it" layer consumed by the skills-next setup and debugging skills.

Each doc leads with the concept and mental model — what an issue actually is, what a trace shows, why a cron issue often isn't in the job code — followed by a terse, Sentry-specific setup section, rather than being a setup manual or a generic engineering how-to. Claims were checked against sentry-docs.