### PR TITLE
chore(dist): bump all plugins to 1.1.0

### DIFF
--- a/plugin-src/claude/plugin.json
+++ b/plugin-src/claude/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "sentry",
   "description": "Sentry Plugin for Claude Code to help with debugging including MCP, commands, and skill capabilities.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Sentry"
   },

--- a/plugin-src/codex/plugin.json
+++ b/plugin-src/codex/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Sentry Plugin for Codex to help with debugging including MCP and skill capabilities.",
   "author": {
     "name": "Sentry",

--- a/plugin-src/cursor/plugin.json
+++ b/plugin-src/cursor/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sentry",
   "description": "Sentry Plugin for Cursor to help with debugging including MCP, commands, and skill capabilities.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Sentry"
   },

--- a/plugin-src/grok/plugin.json
+++ b/plugin-src/grok/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Sentry Plugin for Grok to help with debugging including MCP, commands, and skill capabilities.",
   "author": {
     "name": "Sentry",


### PR DESCRIPTION
Cuts a 1.1.0 release of the four per-agent plugin distributions (claude, cursor, codex, grok), bumping each `plugin-src/<agent>/plugin.json` from 1.0.0. This releases the accumulated skills and commands that have landed since 1.0.0. Merging to `main` triggers the Deploy plugins workflow, which rebuilds each tree and pushes it to its `getsentry/plugin-<agent>` repo.

The root backwards-compat manifests (`.claude-plugin/`, `.cursor-plugin/`) are intentionally left at 1.0.0, and the separately-released `@sentry/ai` installer package is untouched.