### PR TITLE
fix(skills): make sentry-instrument frontmatter valid YAML

### DIFF
--- a/SKILL_TREE.md
+++ b/SKILL_TREE.md
@@ -29,7 +29,7 @@ Self-contained skills — start here. If you're not sure what the user needs, re
 |---|---|
 | [`sentry-debug-issue`](skills/sentry-debug-issue/SKILL.md) | Debug and fix a Sentry issue — find it (by link, ID, or search), pull full context (stack trace, breadcrumbs, trace, logs), optionally run Seer root-cause / autofix, apply the code fix, and resolve it via a `Fixes PROJECT-NAME-12A` commit/PR. Use when working a known error or hunting one down to fix. |
 | [`sentry-get-started`](skills/sentry-get-started/SKILL.md) | Guided entry point for using Sentry through your agent. Orients you to your current setup and, for a new project, sets up Sentry end to end with sane defaults — provision a project, install the SDK (errors, tracing, and whatever it enables by default), and confirm real telemetry reaches Sentry. Routes other intents (adding more signals, fixing issues) to the right skill. |
-| [`sentry-instrument`](skills/sentry-instrument/SKILL.md) | Instrument an application with Sentry — detect the platform, install and initialize the SDK if needed, and wire up any signal: error monitoring, tracing/performance, logging, metrics, profiling, session replay, user feedback, cron check-ins, and AI/LLM monitoring. Use to add Sentry to a project or to capture more than errors. |
+| [`sentry-instrument`](skills/sentry-instrument/SKILL.md) | Instrument an application with Sentry — detect the platform, install and initialize the SDK if needed, and wire up any signal — error monitoring, tracing/performance, logging, metrics, profiling, session replay, user feedback, cron check-ins, and AI/LLM monitoring. Use to add Sentry to a project or to capture more than errors. |
 
 ## Workflows
 

--- a/skills/sentry-instrument/SKILL.md
+++ b/skills/sentry-instrument/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-instrument
-description: Instrument an application with Sentry — detect the platform, install and initialize the SDK if needed, and wire up any signal: error monitoring, tracing/performance, logging, metrics, profiling, session replay, user feedback, cron check-ins, and AI/LLM monitoring. Use to add Sentry to a project or to capture more than errors.
+description: Instrument an application with Sentry — detect the platform, install and initialize the SDK if needed, and wire up any signal — error monitoring, tracing/performance, logging, metrics, profiling, session replay, user feedback, cron check-ins, and AI/LLM monitoring. Use to add Sentry to a project or to capture more than errors.
 license: Apache-2.0
 ---
 


### PR DESCRIPTION
The `sentry-instrument` skill description contained an unquoted colon-space — `…and wire up any signal: error monitoring…`. A YAML parser reads `signal: error monitoring…` as a nested mapping, so the frontmatter fails to parse and skill loaders that validate it as YAML error out ("frontmatter must be valid YAML").

Replaces the colon with an em-dash (consistent with the em-dash already used earlier in the description) and regenerates `SKILL_TREE.md`, whose flat Standalone-Skills index renders the description verbatim.