### PR TITLE
docs: restore log-quality guidance to the logging concept doc

### DIFF
--- a/references/concepts/logging.md
+++ b/references/concepts/logging.md
@@ -62,8 +62,8 @@ Review each log you add or change, and drop any that can't answer yes to all of 
 - **Safe** — no PII, secrets, raw payloads, or unstable exception-message text?
 - **Actionable** — would seeing it change how someone investigates or responds?
 
-For each log you keep, be able to say: *"This log is valuable because it helps answer &lt;specific
-question&gt;."* Drop logs that merely confirm a routine UI interaction, duplicate a generic API failure,
+For each log you keep, be able to say: *"This log is valuable because it helps answer <specific
+question>."* Drop logs that merely confirm a routine UI interaction, duplicate a generic API failure,
 or record an expected validation failure without adding context.
 
 ## Related

--- a/references/concepts/logging.md
+++ b/references/concepts/logging.md
@@ -23,12 +23,18 @@ execution — the context a stack trace alone can't give.
   it, what happened, and when. Attributes are what you query — `severity:error`, `trace_id:...`,
   `user.id:...` with `AND`/`OR` (the level field is `severity` in search); raw text search matches only
   the message, so anything you want to filter on must be an attribute.
+- **Agree conventions once, across services.** Decide the attribute namespacing, event-name phrasing,
+  and levels up front so logs from every language and service can be searched and correlated together.
+  On both sides of a call that propagates trace headers (`baggage` / `sentry-trace`), use the same
+  attribute names so a single trace reads coherently across services.
 - **Accumulate context as a request evolves** — early logs may carry only request info; later ones add
   the authenticated user, feature flags, and outcomes. Prefer the SDK's `set_user` over repeating a user
   ID on every log.
 - **Levels carry meaning:** `debug` (temporary diagnostics), `info` (normal events), `warn` (recoverable
-  but notable), `error` (handled failures — prefer a real error for anything that should become an
-  issue).
+  but notable), `error` (handled failures). For anything critical — or that should group into an issue
+  with a stack trace — capture a real Sentry **error** event, not a log. On the `error`-level logs you
+  do keep, include what explains the failure: retry count, the response status and key non-sensitive
+  request/response fields for external calls, and the runtime decisions that led there.
 - **Log fields, not whole objects** — pick the fields you'll query and omit absent optional attributes
   rather than logging `null`.
 - Sentry can integrate with an existing logging abstraction (Monolog, slog, Rails logger, Pino/console)
@@ -36,10 +42,29 @@ execution — the context a stack trace alone can't give.
 
 ## Don't log sensitive data
 
-Assume anything logged will be read by another human. Never log passwords, tokens, API keys, or raw
-request/response bodies; prefer opaque user IDs over emails or names, and mind PCI / GDPR / CCPA /
-HIPAA-regulated fields. Server-side scrubbing is a backstop, not a license to log carelessly
-([`data-scrubbing.md`](data-scrubbing.md)).
+Assume anything logged will be read by another human. Never log passwords, tokens, or API keys; prefer
+opaque user IDs over emails or names, and mind PCI / GDPR / CCPA / HIPAA-regulated fields. Large raw
+payloads — a full LLM prompt/response, a webhook or HTTP body — have legitimate debugging uses, but
+users put personal data in prompts and bodies carry secrets, so weigh the cost and risk and prefer
+logging the specific fields you'll query over the whole payload. Server-side scrubbing is a backstop,
+not a license to log carelessly ([`data-scrubbing.md`](data-scrubbing.md)).
+
+## Is a log worth keeping?
+
+Review each log you add or change, and drop any that can't answer yes to all of these:
+
+- **Production question** — what concrete production question does it answer?
+- **Useful at volume** — would it still help if emitted thousands of times?
+- **Right signal** — is it better as a span, a metric, or a real Sentry error?
+- **Not already covered** — does an exception, an existing log, or a shared API/client wrapper already
+  capture it?
+- **Consistent** — do its event name and attributes follow the app's conventions?
+- **Safe** — no PII, secrets, raw payloads, or unstable exception-message text?
+- **Actionable** — would seeing it change how someone investigates or responds?
+
+For each log you keep, be able to say: *"This log is valuable because it helps answer &lt;specific
+question&gt;."* Drop logs that merely confirm a routine UI interaction, duplicate a generic API failure,
+or record an expected validation failure without adding context.
 
 ## Related
 


### PR DESCRIPTION
While checking the `sentry-instrument-logging` → `sentry-instrument` migration for lost fidelity, three pieces of strategy from the retired skill turned out to be materially thinner (or absent) in `references/concepts/logging.md`. This restores them:

- **"Is a log worth keeping?" checklist** — the 7-point review (production question, useful at volume, right signal, not already covered, consistent, safe, actionable) plus the "This log is valuable because it helps answer ⟨question⟩" justification test.
- **Cross-service convention coherence** — agree attribute namespacing / naming / levels once so logs from every language correlate, and use the same attribute names on both sides of a `baggage`/`sentry-trace` boundary.
- **Error-log context + large-payload nuance** — what to include on `error` logs (retry count, response status + non-sensitive fields, runtime decisions), and the restored nuance that large raw payloads (LLM prompt/response, webhook/HTTP bodies) have legitimate uses but should be weighed against cost/risk rather than flatly banned.

Only the concept doc changes; references aren't scanned by the skill-tree validator, so no `SKILL_TREE.md` impact.