### PR TITLE
feat(installer): offer to copy a get-started prompt after install

### DIFF
--- a/packages/installer/src/__tests__/clipboard.test.ts
+++ b/packages/installer/src/__tests__/clipboard.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from "node:events";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const spawn = vi.hoisted(() => vi.fn());
+vi.mock("node:child_process", () => ({ spawn }));
+
+import { copyToClipboard } from "../clipboard";
+
+// A minimal fake child process: exposes a stdin whose end() records the written
+// text, and drives the exit/error events the module listens for.
+function fakeChild(behavior: { code?: number; error?: boolean }) {
+  const child = new EventEmitter() as any;
+  const stdin = new EventEmitter() as any;
+  stdin.end = vi.fn();
+  child.stdin = stdin;
+
+  queueMicrotask(() => {
+    if (behavior.error) {
+      child.emit("error", new Error("ENOENT"));
+      return;
+    }
+    child.emit("exit", behavior.code ?? 0);
+  });
+
+  return child;
+}
+
+afterEach(() => {
+  spawn.mockReset();
+});
+
+describe("copyToClipboard", () => {
+  it("uses pbcopy on macOS and writes the text to stdin", async () => {
+    const child = fakeChild({ code: 0 });
+    spawn.mockReturnValue(child);
+
+    const ok = await copyToClipboard("hello", "darwin");
+
+    expect(ok).toBe(true);
+    expect(spawn).toHaveBeenCalledWith("pbcopy", []);
+    expect(child.stdin.end).toHaveBeenCalledWith("hello");
+  });
+
+  it("uses clip on Windows", async () => {
+    spawn.mockImplementation(() => fakeChild({ code: 0 }));
+
+    const ok = await copyToClipboard("hello", "win32");
+
+    expect(ok).toBe(true);
+    expect(spawn).toHaveBeenCalledWith("clip", []);
+  });
+
+  it("falls through Linux tools until one succeeds", async () => {
+    const behaviors = [{ error: true }, { code: 0 }]; // wl-copy missing, xclip works
+    spawn.mockImplementation(() => fakeChild(behaviors.shift()!));
+
+    const ok = await copyToClipboard("hello", "linux");
+
+    expect(ok).toBe(true);
+    expect(spawn).toHaveBeenNthCalledWith(1, "wl-copy", []);
+    expect(spawn).toHaveBeenNthCalledWith(2, "xclip", ["-selection", "clipboard"]);
+  });
+
+  it("returns false when every tool is unavailable", async () => {
+    spawn.mockImplementation(() => fakeChild({ error: true }));
+
+    const ok = await copyToClipboard("hello", "linux");
+
+    expect(ok).toBe(false);
+    expect(spawn).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns false when the tool exits non-zero", async () => {
+    spawn.mockReturnValue(fakeChild({ code: 1 }));
+
+    const ok = await copyToClipboard("hello", "darwin");
+
+    expect(ok).toBe(false);
+  });
+});

--- a/packages/installer/src/clipboard.ts
+++ b/packages/installer/src/clipboard.ts
@@ -1,0 +1,54 @@
+import { spawn } from "node:child_process";
+
+// The clipboard tool(s) to try, per platform. macOS ships pbcopy and Windows
+// ships clip, so each has a single candidate. Linux has no standard tool, so we
+// try Wayland (wl-copy) then X11 (xclip, xsel) and use the first that works.
+function clipboardCommands(platform: NodeJS.Platform): string[][] {
+  switch (platform) {
+    case "darwin":
+      return [["pbcopy"]];
+    case "win32":
+      return [["clip"]];
+    default:
+      return [
+        ["wl-copy"],
+        ["xclip", "-selection", "clipboard"],
+        ["xsel", "--clipboard", "--input"],
+      ];
+  }
+}
+
+// Copy `text` to the system clipboard, returning whether it landed. Never
+// throws: a missing tool (common on headless Linux) resolves to false so the
+// caller can fall back to printing the text instead.
+export async function copyToClipboard(
+  text: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<boolean> {
+  for (const [command, ...args] of clipboardCommands(platform)) {
+    if (await tryCopy(command, args, text)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function tryCopy(command: string, args: string[], text: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args);
+
+    child.on("error", () => resolve(false));
+    // Resolve on `exit`, not `close`: Linux clipboard tools (xclip, wl-copy,
+    // xsel) fork a background process to serve the selection and leave the
+    // stdio pipes open, so `close` can hang forever. `exit` fires as soon as
+    // the foreground process terminates, which is all we need — we only write
+    // to stdin and never read the tool's output.
+    child.on("exit", (code) => resolve(code === 0));
+
+    // A missing tool closes stdin before we write, raising EPIPE; swallow it so
+    // the rejection surfaces through the "error"/"exit" handlers above instead.
+    child.stdin.on("error", () => {});
+    child.stdin.end(text);
+  });
+}

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -1,4 +1,4 @@
-import { checkbox } from "@inquirer/prompts";
+import { checkbox, confirm } from "@inquirer/prompts";
 import { ListrInquirerPromptAdapter } from "@listr2/prompt-adapter-inquirer";
 import {
   color,
@@ -21,6 +21,7 @@ import {
   type InstallResult,
 } from "./run";
 import type { OutputSink } from "./system";
+import { copyToClipboard } from "./clipboard";
 
 const BANNER_LINES = [
   "█▀ █▀▀ █▄░█ ▀█▀ █▀█ █▄█   █▀▀ █▀█ █▀█   ▄▀█ █",
@@ -142,6 +143,16 @@ interface FlowMode {
    * affected agents to restart.
    */
   closing(names: string[]): string;
+  /**
+   * When set (install only), offer to copy a get-started prompt to the clipboard
+   * after at least one agent was acted on. Remove has nothing to get started.
+   */
+  getStarted?: {
+    /** Confirm-prompt question. */
+    message: string;
+    /** The text copied to the clipboard when the user accepts. */
+    prompt: string;
+  };
 }
 
 // "Claude Code", "Claude Code and Codex", "Claude Code, Codex, and Grok".
@@ -204,6 +215,39 @@ async function promptForAgents(
   });
 
   return eligible.filter((detection) => selectedIds.includes(detection.harness.id));
+}
+
+// Offer to copy the get-started prompt to the clipboard, defaulting to yes.
+// Declining (or cancelling the prompt) skips quietly; when the copy is
+// unavailable (no clipboard tool), the prompt text is printed so it can be
+// copied by hand. Only runs in install mode with at least one agent acted on.
+async function promptGetStarted(
+  getStarted: NonNullable<FlowMode["getStarted"]>,
+  task: TaskWrapper,
+): Promise<void> {
+  let wantsCopy: boolean;
+  try {
+    wantsCopy = await task.prompt(ListrInquirerPromptAdapter).run(confirm, {
+      message: getStarted.message,
+      default: true,
+      theme: { prefix: color.blue("◇") },
+    });
+  } catch (err) {
+    if (!isCancel(err)) throw err;
+    task.skip("Skipped");
+    return;
+  }
+
+  if (!wantsCopy) {
+    task.skip("Maybe next time");
+    return;
+  }
+
+  const copied = await copyToClipboard(getStarted.prompt);
+  task.title = copied
+    ? "Copied a get-started prompt to your clipboard"
+    : "Copy this prompt to get started";
+  task.stdout().write(`\n${color.gray(getStarted.prompt)}\n`);
 }
 
 // Translate one harness action (install/update or remove) into Listr task
@@ -278,6 +322,10 @@ const installMode: FlowMode = {
   closing: (names) => {
     const speak = names.length === 1 ? "agent now speaks" : "agents now speak";
     return `\nDone. Restart ${listFormatter.format(names)}. ${color.dim(`Your ${speak} Sentry.`)}`;
+  },
+  getStarted: {
+    message: "Would you like to copy a prompt to get started with Sentry?",
+    prompt: "Use the `sentry-get-started` skill for this project.",
   },
 };
 
@@ -382,6 +430,15 @@ async function runFlow(
           },
         );
       },
+    },
+    {
+      title: "Get started with Sentry",
+      // Install-only, and only worth asking once an agent actually learned
+      // Sentry. Non-interactive runs never prompt.
+      enabled: (ctx) =>
+        interactive && !ctx.cancelled && !!mode.getStarted && ctx.affected.length > 0,
+      rendererOptions: { persistentOutput: true },
+      task: (_ctx, task) => promptGetStarted(mode.getStarted!, task),
     },
   ];
 


### PR DESCRIPTION
After a successful install, the installer now asks one final question — "Would you like to copy a prompt to get started with Sentry?" — defaulting to yes. Accepting copies `Use the ``sentry-get-started`` skill for this project.` to the clipboard, giving the user an obvious first thing to try instead of a bare "Done, restart your agent."

The step is install-only (the remove/neuralyze flow has nothing to get started with) and only runs when at least one agent was actually acted on, so non-interactive and no-op runs stay quiet. Declining or cancelling skips silently.

Clipboard copy lives in a new zero-dependency `clipboard.ts` helper that spawns the platform tool (`pbcopy` on macOS, `clip` on Windows, and `wl-copy` → `xclip` → `xsel` on Linux). It never throws: when no clipboard tool is available (common on headless Linux) it resolves false and the caller prints the prompt text so it can be copied by hand.