### PR TITLE
ref(skills): stop the workflow/feature routers pointing at legacy skills

### DIFF
--- a/skills/sentry-feature-setup/SKILL.md
+++ b/skills/sentry-feature-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-feature-setup
-description: Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry pipelines, create alerts and notifications, enable span streaming, or set up Sentry Snapshots.
+description: Configure specific Sentry features beyond basic SDK setup. Use when asked to monitor AI/LLM calls, set up OpenTelemetry pipelines, create alerts and notifications, or set up Sentry Snapshots.
 license: Apache-2.0
 role: router
 ---
@@ -9,7 +9,7 @@ role: router
 
 # Sentry Feature Setup
 
-Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring, OpenTelemetry pipelines, alerts, and deciding which signal to instrument where. This page helps you find the right feature skill for your task.
+Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring, OpenTelemetry pipelines, alerts, and Sentry Snapshots. This page helps you find the right feature skill for your task.
 
 ## Start Here — Read This Before Doing Anything
 
@@ -18,11 +18,11 @@ Configure specific Sentry capabilities beyond basic SDK setup — AI monitoring,
 1. If the user mentions **AI monitoring, LLM tracing, conversations, or instrumenting an AI SDK** (OpenAI, Anthropic, LangChain, Vercel AI, Google GenAI, Pydantic AI) → `sentry-setup-ai-monitoring`
 2. If the user mentions **OpenTelemetry, OTel Collector, or multi-service telemetry routing** → `sentry-otel-exporter-setup`
 3. If the user mentions **alerts, notifications, on-call, Slack/PagerDuty/Discord integration, or workflow rules** → `sentry-create-alert`
-4. If the user mentions **span streaming, traceLifecycle, trace_lifecycle, spanStreamingIntegration, or switching from transactions to streamed spans** → `sentry-span-streaming-js` (JavaScript), `sentry-span-streaming-python` (Python), or `sentry-span-streaming-dart` (Dart/Flutter)
-5. If the user is unsure **which signal to use** — log vs span vs metric, "what to instrument where", or how to choose between errors, traces, logs, and metrics → `sentry-instrumentation-guide`
-6. If the user mentions **Apple/Cocoa snapshot testing or Sentry Snapshots for Apple platforms** — SnapshotPreviews, Apple Snapshots, Cocoa snapshots, Xcode snapshot testing, Swift previews for Sentry Snapshots, iOS, macOS, tvOS, watchOS, or visionOS → `sentry-snapshots-cocoa`.
+4. If the user mentions **Apple/Cocoa snapshot testing or Sentry Snapshots for Apple platforms** — SnapshotPreviews, Apple Snapshots, Cocoa snapshots, Xcode snapshot testing, Swift previews for Sentry Snapshots, iOS, macOS, tvOS, watchOS, or visionOS → `sentry-snapshots-cocoa`.
 
 When unclear, **ask the user** which feature they want to configure. Do not guess.
+
+> Instrumenting a signal (tracing/spans, logging, metrics, span streaming, or deciding what to emit) is now part of the standalone `sentry-instrument` skill.
 
 ---
 
@@ -34,11 +34,6 @@ When unclear, **ask the user** which feature they want to configure. Do not gues
 | Sentry Snapshots for Apple/Cocoa — upload Apple snapshot images to Sentry; prefer SnapshotPreviews when Swift previews exist | [`sentry-snapshots-cocoa`](../sentry-snapshots-cocoa/SKILL.md) |
 | OpenTelemetry Collector with Sentry Exporter — multi-project routing, automatic project creation | [`sentry-otel-exporter-setup`](../sentry-otel-exporter-setup/SKILL.md) |
 | Alerts via workflow engine API — email, Slack, PagerDuty, Discord | [`sentry-create-alert`](../sentry-create-alert/SKILL.md) |
-| Span streaming (JavaScript) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-js`](../sentry-span-streaming-js/SKILL.md) |
-| Span streaming (Python) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-python`](../sentry-span-streaming-python/SKILL.md) |
-| Span streaming (Dart/Flutter) — migrate from transaction-based to streamed span delivery | [`sentry-span-streaming-dart`](../sentry-span-streaming-dart/SKILL.md) |
-| Instrumentation guide — decide which signal to reach for (error vs span vs log vs metric), "what to instrument where" | [`sentry-instrumentation-guide`](../sentry-instrumentation-guide/SKILL.md) |
-| Instruments structured Sentry logs in a new or existing application | [`sentry-instrument-logging`](../sentry-instrument-logging/SKILL.md) |
 
 Each skill contains its own detection logic, prerequisites, and step-by-step instructions. Trust the skill — read it carefully and follow it. Do not improvise or take shortcuts.
 

--- a/skills/sentry-workflow/SKILL.md
+++ b/skills/sentry-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sentry-workflow
-description: Fix production issues and review code with Sentry context. Use when asked to fix Sentry errors, debug issues, triage exceptions, review PR comments from Sentry, or resolve bugs.
+description: Review code and keep Sentry SDKs up to date. Use when asked to resolve Sentry bot comments on a PR, address Seer bug predictions in PR reviews, or upgrade the Sentry SDK across major versions.
 license: Apache-2.0
 role: router
 ---
@@ -9,18 +9,19 @@ role: router
 
 # Sentry Workflows
 
-Debug production issues and maintain code quality with Sentry context. This page helps you find the right workflow skill for your task.
+Maintain code quality and keep your Sentry SDK up to date. This page helps you find the right workflow skill for your task.
 
 ## Start Here — Read This Before Doing Anything
 
 **Do not skip this section.** Do not assume which workflow the user needs. Ask first.
 
-1. If the user mentions **fixing errors, debugging exceptions, or investigating production issues** → `sentry-fix-issues`
-2. If the user mentions **Sentry bot comments or `sentry[bot]` on a PR** → `sentry-code-review`
-3. If the user mentions **Seer, bug prediction, or reviewing PRs for predicted issues** → `sentry-pr-code-review`
-4. If the user mentions **upgrading Sentry, migrating SDK versions, or fixing deprecated APIs** → `sentry-sdk-upgrade`
+1. If the user mentions **Sentry bot comments or `sentry[bot]` on a PR** → `sentry-code-review`
+2. If the user mentions **Seer, bug prediction, or reviewing PRs for predicted issues** → `sentry-pr-code-review`
+3. If the user mentions **upgrading Sentry, migrating SDK versions, or fixing deprecated APIs** → `sentry-sdk-upgrade`
 
-When unclear, **ask the user** whether the task involves live production issues, PR review comments, or SDK upgrades. Do not guess.
+When unclear, **ask the user** whether the task involves PR review comments or SDK upgrades. Do not guess.
+
+> Fixing or investigating a production issue? That's the standalone `sentry-debug-issue` skill.
 
 ---
 
@@ -28,7 +29,6 @@ When unclear, **ask the user** whether the task involves live production issues,
 
 | Use when | Skill |
 |---|---|
-| Finding and fixing production issues — stack traces, breadcrumbs, event data | [`sentry-fix-issues`](../sentry-fix-issues/SKILL.md) |
 | Resolving comments from `sentry[bot]` on GitHub PRs | [`sentry-code-review`](../sentry-code-review/SKILL.md) |
 | Fixing issues detected by Seer Bug Prediction in PR reviews | [`sentry-pr-code-review`](../sentry-pr-code-review/SKILL.md) |
 | Upgrading the Sentry JavaScript SDK — migration guides, breaking changes, deprecated APIs | [`sentry-sdk-upgrade`](../sentry-sdk-upgrade/SKILL.md) |


### PR DESCRIPTION
`sentry-workflow` and `sentry-feature-setup` (both still active routers in `skills/`) route to skills that moved to `skills-legacy/` in #265: `sentry-fix-issues`, `sentry-span-streaming-{js,python,dart}`, `sentry-instrumentation-guide`, and `sentry-instrument-logging`.

Those targets are excluded from the plugin build and aren't served by the proxy, so the routes dangle — verified:
- **Proxy:** `skills.sentry.dev/workflows` (200) routes to `sentry-fix-issues`, but `skills.sentry.dev/sentry-fix-issues/SKILL.md` → **404**.
- **Built plugin:** `sentry-workflow` ships and links to `sentry-fix-issues`, which is **absent** (skills-legacy isn't bundled).

Removes those entries from both routers (routing rules + tables) and trims the descriptions/intros. Adds pointers: production-issue debugging → the standalone `sentry-debug-issue`; signal instrumentation → `sentry-instrument`. The stayed feature leaves (`sentry-setup-ai-monitoring`, `sentry-otel-exporter-setup`, `sentry-create-alert`, `sentry-snapshots-cocoa`) remain. `build-skill-tree.sh --check` passes.

(This is the same cleanup that was folded into #265 but got lost when that PR merged.)