### PR TITLE
release: add 0.1.4 changelog entry

### DIFF
--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.1.4
+
+- Add a `remove` subcommand to uninstall the Sentry plugin from your agents.
+- After a successful install, offer to copy a get-started prompt to your
+  clipboard so there's an obvious first thing to try.
+
 ## 0.1.3
 
 - Lead the README with the install command and add a demo to the npm package


### PR DESCRIPTION
Prep for the next `@sentry/ai` release. Adds the `0.1.4` section so `craft prepare` (the Release action) has a changelog entry to release against — the `simple` changelog policy expects the section to exist first.

Covers the two user-facing installer changes since 0.1.3: the `remove` subcommand (#201) and the post-install get-started prompt copy (#274).

Once this merges, run the **Release** workflow with version `0.1.4` to cut the release branch and build the tarball; publish then goes through the usual `getsentry/publish` flow.