### PR TITLE
docs: add AI monitoring concept doc and retire sentry-setup-ai-monitoring into sentry-instrument

### DIFF
--- a/src/references/concepts/ai-monitoring.md
+++ b/src/references/concepts/ai-monitoring.md
@@ -1,0 +1,74 @@
+# AI / Agent Monitoring — What & Why
+
+## What it is
+
+Tracing specialized for LLM apps. LLM calls, agent runs, tool calls, and
+agent-to-agent handoffs are captured as `gen_ai.*` spans carrying model, token
+usage, cost, and latency. It is built on [tracing](tracing.md), so tracing must
+be on (`tracesSampleRate`/`traces_sample_rate` > 0) — without spans there is
+nothing to attach `gen_ai` data to.
+
+Auto-instrumented for detected AI SDKs on **JavaScript and Python only** (OpenAI,
+Anthropic, Vercel AI, LangChain/LangGraph, Google GenAI, HuggingFace, Pydantic
+AI; `litellm` needs explicit registration). Every other platform is manual
+`gen_ai.*` instrumentation, or unsupported — the platform `index.md` says which.
+
+## What the artifact shows
+
+A trace *is* the agent run: a `gen_ai.invoke_agent` span parents the
+`gen_ai.chat` (LLM call), `gen_ai.execute_tool`, and `gen_ai.handoff` children
+it triggered. Read cost and latency off the child spans' token attributes. Two
+views surface it: the **AI Agents** dashboard and **Explore > Conversations**.
+
+The span `op` is `gen_ai.{operation}` — `chat`, `embeddings`,
+`generate_content`, `text_completion` for calls, plus `invoke_agent`,
+`execute_tool`, `handoff`. Attributes accept primitives only; arrays/objects are
+JSON-stringified. The canonical attribute set is the [Sentry gen_ai
+conventions](https://getsentry.github.io/sentry-conventions/attributes/gen_ai/) —
+the SDK docs can lag, and attributes marked deprecated there should not be set.
+
+## Conversations
+
+Conversations groups spans by `gen_ai.conversation.id` into a chat-style
+timeline. A conversation can span multiple traces (a page refresh mid-chat), and
+one trace can hold spans from multiple conversations — the two are independent.
+
+**Conversation ID format matters:** use a short, opaque identifier — alphanumeric
+with dashes or underscores only (a UUID, or a prefixed id like `conv_5j66Up…`).
+Never use a URL, email, or other free-form text: Sentry uses the id as a URL path
+segment, so a value containing a slash breaks Conversations for that session.
+Some integrations infer the id automatically (Python OpenAI Agents, Node OpenAI);
+everything else sets it explicitly. The view also needs input/output capture and
+gen_ai span streaming (both on by default on recent SDKs) or it renders empty,
+and a `setUser`/`set_user` call to populate the User column.
+
+## Token accounting (avoid negative costs)
+
+Sentry computes cost from token attributes, and cached/reasoning counts are
+**subsets** of the totals, not separate buckets: `gen_ai.usage.input_tokens`
+already includes `.input_tokens.cached`, and `gen_ai.usage.output_tokens`
+already includes `.output_tokens.reasoning`. Reporting a subset larger than its
+total makes Sentry subtract past zero and show a negative cost.
+
+## PII
+
+Prompts and model outputs are user content and are **likely PII**. JavaScript
+captures input/output by default (governed by `dataCollection.genAI`); Python
+gates it behind `send_default_pii=True`. Confirm the privacy policy and
+regulations allow it and **ask the user before enabling capture** — see
+[data-scrubbing.md](data-scrubbing.md).
+
+## Setup essentials
+
+- Tracing must be on; then detect the AI SDK and let auto-instrumentation handle
+  it (JS/Python), or instrument `gen_ai.*` spans manually.
+- Sample AI traces at **100%**: an agent run is sampled as one span tree, so a
+  dropped root loses every child `gen_ai` span. Keep `gen_ai` traffic at 1.0 via
+  a `tracesSampler` while sampling the rest lower — see [reduce-volume.md](reduce-volume.md).
+- Set a `gen_ai.conversation.id` wherever multi-turn chats need grouping.
+
+## Related
+
+- [`tracing.md`](tracing.md) — AI monitoring is tracing; spans are the substrate.
+- [`data-scrubbing.md`](data-scrubbing.md) — prompt/output capture is the PII decision.
+- [`reduce-volume.md`](reduce-volume.md) — the `tracesSampler` that keeps AI at 100%.

--- a/src/skills/sentry-instrument/SKILL.md
+++ b/src/skills/sentry-instrument/SKILL.md
@@ -71,10 +71,11 @@ For each signal the scope calls for:
 1. **WHY (only when it helps the decision).** If the user is unsure *which* signal or *how much* to
    instrument, read [`references/concepts/choosing-a-signal.md`](references/concepts/choosing-a-signal.md).
    For a chosen signal, the matching `references/concepts/<signal>.md` covers strategy, sample-rate
-   philosophy, naming, and pitfalls — most signals have one; where they don't (e.g. AI/LLM monitoring)
-   the strategy lives in the platform `ai-monitoring.md` file plus the `gen_ai.*` note in
-   [`references/concepts/data-scrubbing.md`](references/concepts/data-scrubbing.md). **Skip this when
-   the user already said "add tracing, you pick the defaults"** — go straight to the HOW.
+   philosophy, naming, and pitfalls — including
+   [`references/concepts/ai-monitoring.md`](references/concepts/ai-monitoring.md) for the `gen_ai.*`
+   model, conversation-ID rules, token/cost accounting, and the AI sampling and PII strategy (the
+   per-platform code then lives in that platform's `ai-monitoring.md`). **Skip this when the user
+   already said "add tracing, you pick the defaults"** — go straight to the HOW.
 2. **HOW.** Read the platform's signal file — `references/sdks/<slug>/<signal>.md` (e.g.
    `references/sdks/nextjs/tracing.md`) — and apply the code. The platform `index.md` feature
    catalog links each supported signal and marks unsupported ones.

--- a/src/skills/sentry-instrument/references.yml
+++ b/src/skills/sentry-instrument/references.yml
@@ -3,7 +3,7 @@ needs:
   - sdks/index.md
   - sdks/*/*.md
   - concepts/choosing-a-signal.md
-  - concepts/{errors,tracing,logging,metrics,profiling,session-replay,user-feedback,crons}.md
+  - concepts/{errors,tracing,logging,metrics,profiling,session-replay,user-feedback,crons,ai-monitoring}.md
   - first-error-setup.md
   - new-project.md
   - setup-verification.md


### PR DESCRIPTION
AI/LLM monitoring was the only signal without a `concepts/` reference. Its cross-cutting strategy lived only in the four platform `ai-monitoring.md` files (node, python, nextjs, nestjs), so it was duplicated and drifting — and the recently-added conversation-ID format rule (must be opaque; a slash breaks Conversations because Sentry uses the id as a URL path segment) had landed in *only* the standalone `sentry-setup-ai-monitoring` skill, in none of the platform files.

This factors the shared knowledge into `concepts/ai-monitoring.md`: the `gen_ai.*` span model and how to read an agent trace, the Conversations grouping + ID-format rule, the token/cost subset accounting (cached/reasoning are subsets of the totals — over-reporting shows negative cost), and the PII and 100%-sampling strategy. Per-platform SDK code stays in each platform's `ai-monitoring.md`. The doc is added to `sentry-instrument`'s `references.yml` and the playbook's "AI/LLM monitoring has no concept doc" note is replaced with a pointer to it.

Groundwork for retiring `sentry-setup-ai-monitoring` in favor of `sentry-instrument`: it gives the conversation-ID rule a canonical home so that retirement won't silently drop it. Verified hydration lands `concepts/ai-monitoring.md` in the built `sentry-instrument` skill with no warnings, and `build-skill-tree.sh --check` passes.