### PR TITLE
feat(installer): accept a custom get-started prompt

### DIFF
--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Accept an optional install instruction and include it in the prompt offered
+  for copying after installation.
+
 ## 0.1.4
 
 - Add a `remove` subcommand to uninstall the Sentry plugin from your agents.

--- a/packages/installer/README.md
+++ b/packages/installer/README.md
@@ -22,11 +22,12 @@ Restart your AI tools afterward to load the plugin.
 ## Options
 
 ```bash
-npx @sentry/ai install                  # interactive — pick which agents to set up
-npx @sentry/ai install --no-interactive # install into every detected agent
+npx @sentry/ai install                         # interactive — pick which agents to set up
+npx @sentry/ai install "Setup logging"         # copy a custom prompt after installation
+npx @sentry/ai install --no-interactive        # install into every detected agent
 ```
 
-The non-interactive mode is intended for CI and unattended runs.
+When an instruction follows `install`, the installer offers to copy a prompt such as `The Sentry plugin has just been installed. Setup logging` after installation. Without an instruction, it offers the default get-started prompt. The non-interactive mode is intended for CI and unattended runs and skips this prompt.
 
 ## What it installs
 

--- a/packages/installer/src/__tests__/ui-prompt.test.ts
+++ b/packages/installer/src/__tests__/ui-prompt.test.ts
@@ -1,0 +1,33 @@
+import { checkbox, confirm } from "@inquirer/prompts";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { copyToClipboard } from "../clipboard";
+import { runInstaller } from "../ui";
+import { fakeHarness } from "./fake-harness";
+
+vi.mock("@inquirer/prompts", () => ({
+  checkbox: vi.fn(),
+  confirm: vi.fn(),
+}));
+
+vi.mock("../clipboard", () => ({
+  copyToClipboard: vi.fn(),
+}));
+
+describe("runInstaller get-started prompt", () => {
+  beforeEach(() => {
+    vi.mocked(checkbox).mockResolvedValue(["claude"]);
+    vi.mocked(confirm).mockResolvedValue(true);
+    vi.mocked(copyToClipboard).mockResolvedValue(true);
+  });
+
+  it("offers to copy a prompt built from the install instruction", async () => {
+    const claude = fakeHarness({ id: "claude", detected: true });
+
+    const ok = await runInstaller([claude], { instruction: "Setup logging" });
+
+    expect(ok).toBe(true);
+    expect(copyToClipboard).toHaveBeenCalledWith(
+      "The Sentry plugin has just been installed. Setup logging",
+    );
+  });
+});

--- a/packages/installer/src/__tests__/ui.test.ts
+++ b/packages/installer/src/__tests__/ui.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
-import { runInstaller, runRemover } from "../ui";
+import { getStartedPrompt, runInstaller, runRemover } from "../ui";
 import { fakeHarness } from "./fake-harness";
+
+describe("getStartedPrompt", () => {
+  it("uses the default prompt when no instruction is provided", () => {
+    expect(getStartedPrompt()).toBe("Use the `sentry-get-started` skill for this project.");
+  });
+
+  it("builds a prompt from the install instruction", () => {
+    expect(getStartedPrompt("Setup logging")).toBe(
+      "The Sentry plugin has just been installed. Setup logging",
+    );
+  });
+
+  it("trims the instruction and ignores whitespace-only input", () => {
+    expect(getStartedPrompt("  Setup tracing.  ")).toBe(
+      "The Sentry plugin has just been installed. Setup tracing.",
+    );
+    expect(getStartedPrompt("   ")).toBe("Use the `sentry-get-started` skill for this project.");
+  });
+});
 
 // These cover the non-interactive path, which skips the prompt and installs
 // every detected agent. The interactive selector is exercised manually.

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -50,11 +50,18 @@ const install = defineCommand({
     name: "install",
     description: "Install the Sentry plugin into your detected AI coding assistants",
   },
-  args: agentSelectionArgs,
+  args: {
+    instruction: {
+      type: "positional",
+      description: "Instruction to include in the prompt copied after installation",
+      required: false,
+    },
+    ...agentSelectionArgs,
+  },
   async run({ args }) {
     const interactive = args.interactive && !args.yes;
     try {
-      const ok = await runInstaller(harnesses, { interactive });
+      const ok = await runInstaller(harnesses, { interactive, instruction: args.instruction });
       process.exit(ok ? 0 : 1);
     } catch (err) {
       // Unexpected error outside the Listr runner: capture and flush before exit

--- a/packages/installer/src/ui.ts
+++ b/packages/installer/src/ui.ts
@@ -85,6 +85,9 @@ export interface RunOptions {
   // When false, skip the selector and install every detected agent (CI smoke
   // tests, unattended runs). The selection task is disabled in this mode.
   interactive?: boolean;
+  // When provided, use this instruction to build the prompt offered after a
+  // successful install.
+  instruction?: string;
 }
 
 interface Ctx {
@@ -308,6 +311,15 @@ function actionTask(ctx: Ctx, detection: Detection, mode: FlowMode): ListrTask<C
   };
 }
 
+const DEFAULT_GET_STARTED_PROMPT = "Use the `sentry-get-started` skill for this project.";
+const INSTALLED_PROMPT_PREFIX = "The Sentry plugin has just been installed.";
+
+export function getStartedPrompt(instruction?: string): string {
+  const trimmed = instruction?.trim();
+
+  return trimmed ? `${INSTALLED_PROMPT_PREFIX} ${trimmed}` : DEFAULT_GET_STARTED_PROMPT;
+}
+
 // Install (and update) targets every detected agent, with a shimmering tagline.
 const installMode: FlowMode = {
   header: introTitle,
@@ -325,7 +337,7 @@ const installMode: FlowMode = {
   },
   getStarted: {
     message: "Would you like to copy a prompt to get started with Sentry?",
-    prompt: "Use the `sentry-get-started` skill for this project.",
+    prompt: DEFAULT_GET_STARTED_PROMPT,
   },
 };
 
@@ -345,7 +357,15 @@ const removeMode: FlowMode = {
 };
 
 export function runInstaller(harnesses: Harness[], options: RunOptions = {}): Promise<boolean> {
-  return runFlow(harnesses, installMode, options);
+  const mode = {
+    ...installMode,
+    getStarted: {
+      ...installMode.getStarted!,
+      prompt: getStartedPrompt(options.instruction),
+    },
+  };
+
+  return runFlow(harnesses, mode, options);
 }
 
 export function runRemover(harnesses: Harness[], options: RunOptions = {}): Promise<boolean> {


### PR DESCRIPTION
## Summary

- accept an optional instruction after the `install` subcommand
- offer to copy a prompt prefixed with `The Sentry plugin has just been installed.`
- preserve the existing default prompt when no instruction is provided
- document the new command form and cover the clipboard flow

## Validation

- `pnpm --filter @sentry/ai test` (88 tests)
- `pnpm --filter @sentry/ai build`
- `npx @sentry/ai install "Setup logging" --help`