### PR TITLE
release: add 0.2.0 changelog entry

### DIFF
--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.2.0
 
 - Accept an optional install instruction and include it in the prompt offered
   for copying after installation.


### PR DESCRIPTION
Release prep for the installer `@sentry/ai` 0.2.0. Promotes the pending `Unreleased` changelog section (the #290 custom get-started prompt feature) to a `0.2.0` heading so `craft prepare` can cut the release — its `simple` changelog policy requires the version heading to already exist.

Once this lands, the Release workflow will be re-run with version `0.2.0`.