### PR TITLE
docs(cloudflare): Update Cloudflare docs, also suggest new entrypoint

### DIFF
--- a/src/references/sdks/cloudflare/durable-objects.md
+++ b/src/references/sdks/cloudflare/durable-objects.md
@@ -4,8 +4,9 @@
 > Durable Object instrumentation: v8.x+
 > `instrumentPrototypeMethods`: v10.x+
 > Workflow instrumentation: v10.x+
-> D1 instrumentation: v8.x+
+> D1 automatic (`env`-based) instrumentation: v10.x+
 > Durable Object Storage instrumentation: v10.x+
+> RPC trace propagation (`enableRpcTracePropagation`): v10.52.0+
 
 ---
 
@@ -122,6 +123,33 @@ class MyDurableObjectBase extends DurableObject<Env> {
 }
 ```
 
+### Classes Built on Durable Objects (Agents SDK)
+
+`instrumentDurableObjectWithSentry` also works with classes that extend a Durable Object base — including the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/) `Agent` and `AIChatAgent` classes (which are Durable Objects under the hood). Wrap and export them the same way:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare";
+import { AIChatAgent } from "@cloudflare/ai-chat";
+
+class MyChatAgentBase extends AIChatAgent<Env> {
+  // ...agent logic (RPC methods, onChatMessage, etc.)
+}
+
+export const MyChatAgent = Sentry.instrumentDurableObjectWithSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  }),
+  MyChatAgentBase,
+);
+```
+
+Since Agents use the instance name as a stable identifier, `this.name` is a natural conversation ID for AI monitoring — pass it to `Sentry.setConversationId(this.name)` (see the Workers AI section in `./tracing.md`).
+
+### RPC Trace Propagation
+
+Trace context isn't propagated across Durable Object RPC calls by default. To connect a caller Worker and a DO into a single distributed trace, set `enableRpcTracePropagation: true` on **both** the caller (`withSentry`) and the DO (`instrumentDurableObjectWithSentry`) — recommended whenever you use Durable Objects. See [RPC Trace Propagation in `./tracing.md`](./tracing.md#rpc-trace-propagation) for the full setup.
+
 ---
 
 ## Workflows
@@ -196,7 +224,7 @@ The SDK generates a deterministic trace ID from the workflow instance ID. This m
 
 ### Overview
 
-`instrumentD1WithSentry` wraps a Cloudflare D1 database binding to automatically create spans and breadcrumbs for all queries.
+D1 bindings are **automatically instrumented** when accessed through the handler's `env`. As long as your Worker is wrapped with `withSentry` (or the DO/Workflow is wrapped), every query on `env.DB` creates spans and breadcrumbs — no manual wrapping needed.
 
 ### Setup
 
@@ -210,17 +238,16 @@ export default Sentry.withSentry(
   }),
   {
     async fetch(request, env, ctx) {
-      // Wrap the D1 binding
-      const db = Sentry.instrumentD1WithSentry(env.DB);
-
-      // Use as normal — all queries are traced
-      const users = await db.prepare("SELECT * FROM users WHERE active = ?").bind(1).all();
+      // env.DB is already instrumented — use it directly
+      const users = await env.DB.prepare("SELECT * FROM users WHERE active = ?").bind(1).all();
 
       return new Response(JSON.stringify(users.results));
     },
   } satisfies ExportedHandler<Env>,
 );
 ```
+
+> **Deprecated:** the explicit `Sentry.instrumentD1WithSentry(env.DB)` wrapper still works but is **deprecated and will be removed in v11**. Access `env.DB` directly instead — it's instrumented automatically.
 
 ### Instrumented Methods
 
@@ -230,21 +257,25 @@ export default Sentry.withSentry(
 | `statement.run()` | SQL query text | Execute with metadata return |
 | `statement.all()` | SQL query text | Returns all rows with metadata |
 | `statement.raw()` | SQL query text | Returns raw row arrays |
+| `db.batch([...])` | SQL of the batched statements | Executes multiple statements in one transaction |
+| `db.exec(sql)` | SQL query text | Executes raw SQL |
 
 All methods create:
 - A `db.query` span with the SQL statement as the span name
 - A breadcrumb in the `query` category
 - Span attributes: `cloudflare.d1.query_type`, `cloudflare.d1.duration`, `cloudflare.d1.rows_read`, `cloudflare.d1.rows_written`
 
+`db.batch()` and `db.exec()` additionally set:
+- `db.operation.name` — `batch` or `exec`
+- `db.operation.batch.size` — number of statements (for `batch`)
+
 ### Bind Support
 
 The instrumentation follows through `statement.bind()`:
 
 ```typescript
-const db = Sentry.instrumentD1WithSentry(env.DB);
-
 // bind() returns a new statement — it's also instrumented
-const result = await db
+const result = await env.DB
   .prepare("INSERT INTO users (name, email) VALUES (?, ?)")
   .bind("Alice", "alice@example.com")
   .run();
@@ -252,20 +283,19 @@ const result = await db
 
 ### Limitations
 
-- `db.exec()` and `db.batch()` are **not** instrumented — only prepared statements
 - Query parameters are not captured in span data (to avoid PII leakage)
 
 ---
 
 ## Best Practices
 
-1. **Instrument D1 once per request** — call `instrumentD1WithSentry(env.DB)` at the top of your handler and use the wrapped binding throughout.
+1. **Access D1 via `env`** — use `env.DB` directly; it's auto-instrumented. Don't reach for the deprecated `instrumentD1WithSentry` wrapper.
 
 2. **Export wrapped classes** — always export the instrumented class (`Sentry.instrumentDurableObjectWithSentry(...)`) as the binding target, not the base class.
 
 3. **Use `instrumentPrototypeMethods` selectively** — it wraps all prototype methods which adds overhead. Use an array of method names if you only need specific RPC methods.
 
-4. **Don't wrap already-wrapped objects** — calling `instrumentD1WithSentry` twice on the same binding is harmless (it checks for existing instrumentation) but unnecessary.
+4. **Enable RPC trace propagation for cross-Worker traces** — set `enableRpcTracePropagation: true` on both caller and receiver when you want DO/service-binding RPC calls in one trace (see [RPC Trace Propagation](#rpc-trace-propagation)).
 
 5. **Workflow error handling** — step errors are captured with `handled: true` since Workflows may retry steps. The dedupe integration is automatically disabled.
 
@@ -277,7 +307,7 @@ const result = await db
 |-------|----------|
 | DO errors not captured | Ensure you exported the instrumented class, not the base class |
 | RPC methods not creating spans | Enable `instrumentPrototypeMethods: true` or list specific methods |
-| D1 queries not traced | Call `instrumentD1WithSentry(env.DB)` before executing queries |
+| D1 queries not traced | Access the binding via `env.DB` (auto-instrumented by `withSentry`) and ensure `tracesSampleRate` is set |
 | Workflow spans disconnected | Verify all steps in the same workflow instance share the same trace (automatic) |
 | Storage operations not traced | Ensure you're using `instrumentDurableObjectWithSentry` — storage instrumentation is included |
-| `db.batch()` not creating spans | Expected — batch and exec are not instrumented; use prepared statements |
+| DO / service-binding RPC calls in separate traces | Set `enableRpcTracePropagation: true` on both caller and receiver |

--- a/src/references/sdks/cloudflare/index.md
+++ b/src/references/sdks/cloudflare/index.md
@@ -2,7 +2,7 @@
 
 Opinionated wizard that scans your Cloudflare project and guides you through complete Sentry setup for Workers, Pages, Durable Objects, Queues, Workflows, and Hono.
 
-> **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/cloudflare` v10.55.0).
+> **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/cloudflare` v10.67.0).
 > Always verify against [docs.sentry.io/platforms/javascript/guides/cloudflare/](https://docs.sentry.io/platforms/javascript/guides/cloudflare/) before implementing.
 
 ---
@@ -63,11 +63,13 @@ cat package.json 2>/dev/null | grep -E '"react"|"vue"|"svelte"|"next"'
 | Hono framework? | Recommend standalone `@sentry/hono` package (v10.55.0+) for cleaner integration |
 | `@sentry/cloudflare` already installed? | Skip install, go to feature config |
 | Durable Objects configured? | Recommend `instrumentDurableObjectWithSentry` |
-| D1 databases bound? | Recommend `instrumentD1WithSentry` |
+| D1 databases bound? | Auto-instrumented by `withSentry` when accessed via `env.DB` (no manual wrap) |
 | Queues configured? | `withSentry` auto-instruments queue handlers |
 | Workflows configured? | Recommend `instrumentWorkflowWithSentry` |
 | Cron triggers configured? | `withSentry` auto-instruments scheduled handlers; recommend Crons monitoring |
-| `nodejs_als` or `nodejs_compat` flag set? | **Required** — SDK needs `AsyncLocalStorage` |
+| `nodejs_als` or `nodejs_compat` flag set? | **Required** — SDK needs `AsyncLocalStorage`. Recommend `nodejs_compat` generally, and with it the `@sentry/cloudflare/nodejs_compat` entrypoint (drop-in swap, unlocks Prisma + Vercel AI SDK v7, becomes default in v11) |
+| Prisma ORM used? | Recommend `prismaIntegration` via the `/nodejs_compat` entrypoint — see `./nodejs-compat.md` |
+| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+) |
 | AI/LLM libraries? | Recommend AI Monitoring integrations |
 | Companion frontend? | Trigger Phase 4 cross-link |
 
@@ -144,7 +146,18 @@ compatibility_flags = ["nodejs_als"]
 }
 ```
 
-> `nodejs_als` is lighter — it only enables `AsyncLocalStorage`. Use `nodejs_compat` if your code also needs other Node.js APIs.
+> `nodejs_als` is the minimum — it only enables `AsyncLocalStorage`. **`nodejs_compat` is generally recommended:** it's a superset of `nodejs_als` and unlocks the `/nodejs_compat` entrypoint below (more integrations and features), which becomes the SDK default in v11. Prefer `nodejs_compat` unless you have a specific reason to keep the runtime minimal.
+
+#### `/nodejs_compat` Entrypoint (recommended)
+
+When your Worker runs with the `nodejs_compat` flag, use the dedicated `@sentry/cloudflare/nodejs_compat` entrypoint instead of the default one. It's a drop-in import swap — everything (`withSentry`, `sentryPagesPlugin`, etc.) works the same — but it unlocks additional Node.js-only functionality on Cloudflare, such as the `prismaIntegration` and Vercel AI SDK v7 support:
+
+```typescript
+// Drop-in replacement — everything else works the same
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+```
+
+**For new projects, default to this entrypoint** (add the `nodejs_compat` flag and import from `@sentry/cloudflare/nodejs_compat` from the start). Requires SDK v10.64.0+. It becomes the **default entrypoint in v11**, so adopting it now is the recommended path and eases the upgrade. See `./nodejs-compat.md` for full setup (Prisma).
 
 #### Install
 
@@ -183,6 +196,22 @@ export default Sentry.withSentry(
 - The first argument is a callback that receives `env` — use this to read secrets like `SENTRY_DSN`
 - The SDK reads DSN, environment, release, debug, tunnel, and traces sample rate from `env` automatically (see [Environment Variables](#environment-variables))
 - `withSentry` wraps all exported handlers — you do not need separate wrappers for `scheduled`, `queue`, etc.
+
+#### Automatic Binding Instrumentation
+
+`withSentry` (and `sentryPagesPlugin`) wraps the `env` object so that supported bindings are **automatically instrumented on access** — no manual wrapping needed. As long as your handler uses the `env` passed in by the SDK:
+
+| Binding | Auto-instrumented | Docs status |
+|---------|-------------------|-------------|
+| **D1** (`env.DB`) | Query spans + breadcrumbs | Documented |
+| **Workers AI** (`env.AI`) | `gen_ai` spans (v10.67.0+) | Documented |
+| **Queue producers** | Producer send spans | Verified in SDK source; not yet in published docs |
+| **R2 buckets** | Object operation spans | Verified in SDK source; not yet in published docs |
+| **RateLimit** | `limit()` spans | Verified in SDK source; not yet in published docs |
+
+> Because D1 is auto-instrumented via `env`, the manual `instrumentD1WithSentry` wrapper is no longer needed (it's deprecated and slated for removal in v11). See `./durable-objects.md`.
+>
+> To link Durable Object and service-binding (JSRPC) calls into one trace, set `enableRpcTracePropagation: true` on both caller and receiver — **recommended** whenever you use RPC, Durable Objects, or Workflows. See [RPC Trace Propagation](#configuration-reference) and `./tracing.md`.
 
 #### Pages Setup
 
@@ -371,10 +400,11 @@ Load the corresponding reference file and follow its steps:
 | Feature | Reference file | Load when... |
 |---------|---------------|-------------|
 | Error Monitoring | `./error-monitoring.md` | Always (baseline) — unhandled exceptions, manual capture, scopes, enrichment |
-| Tracing | `./tracing.md` | HTTP request tracing, outbound fetch spans, D1 query spans, distributed tracing |
+| Tracing | `./tracing.md` | HTTP request tracing, outbound fetch spans, D1/Workers AI spans, distributed tracing, RPC trace propagation |
 | Logging | `./logging.md` | Structured logs via `Sentry.logger.*`, log-to-trace correlation |
 | Crons | `./crons.md` | Scheduled handler monitoring, `withMonitor`, check-in API |
-| Durable Objects | `./durable-objects.md` | Instrument Durable Object classes for error capture and spans |
+| Durable Objects / Workflows / D1 | `./durable-objects.md` | Instrument Durable Object and Workflow classes; D1 auto-instrumentation |
+| Node.js Compat | `./nodejs-compat.md` | `nodejs_compat` flag set, or Prisma / Vercel AI SDK v7 detected — `/nodejs_compat` entrypoint, `prismaIntegration` |
 
 For each feature: read the reference file, follow its steps exactly, and verify before moving on.
 
@@ -402,6 +432,7 @@ For each feature: read the reference file, follow its steps exactly, and verify 
 | `tracePropagationTargets` | `(string\|RegExp)[]` | all URLs | Control which outbound requests get trace headers |
 | `skipOpenTelemetrySetup` | `boolean` | `false` | Opt-out of OpenTelemetry compatibility tracer |
 | `instrumentPrototypeMethods` | `boolean \| string[]` | `false` | Durable Object: instrument prototype methods for RPC spans |
+| `enableRpcTracePropagation` | `boolean` | `false` | Links RPC calls (Worker↔DO, Worker↔Worker service bindings) into one trace. **Recommended** when using RPC / Durable Objects / Workflows — set on **both** caller and receiver (v10.52.0+). See `./tracing.md` |
 
 ### Data Collection Reference
 
@@ -443,6 +474,8 @@ These are registered automatically by `getDefaultIntegrations()`:
 | `requestDataIntegration` | Attach request data to events |
 | `consoleIntegration` | Capture `console.*` calls as breadcrumbs |
 
+> **Not default:** `prismaIntegration` is available on Cloudflare **only** via the `@sentry/cloudflare/nodejs_compat` entrypoint and must be added manually. See `./nodejs-compat.md`.
+
 ---
 
 ## Verification
@@ -473,7 +506,8 @@ Deploy and trigger the route, then check your [Sentry Issues dashboard](https://
 | Errors captured | Throw in a fetch handler, verify in Sentry |
 | Tracing working | Check Performance tab for HTTP spans |
 | Source maps working | Check stack trace shows readable file/line names |
-| D1 spans (if configured) | Run a D1 query, check for `db.query` spans |
+| D1 spans (if configured) | Run a D1 query via `env.DB` (auto-instrumented), check for `db.query` spans |
+| Workers AI spans (if configured) | Call `env.AI.run(...)`, check for `gen_ai` spans |
 | Scheduled monitoring (if configured) | Trigger a cron, check Crons dashboard |
 
 ---
@@ -524,7 +558,9 @@ Connecting frontend and backend with linked Sentry projects enables **distribute
 | Events lost on short-lived requests | SDK not flushing before worker terminates | Ensure `withSentry` or `sentryPagesPlugin` wraps your handler — they use `ctx.waitUntil()` to flush |
 | Hono errors not captured | Hono app not instrumented | Use `@sentry/hono/cloudflare` — import `sentry` middleware and call `app.use(sentry(app, options))` |
 | Durable Object errors missing | DO class not instrumented | Wrap class with `Sentry.instrumentDurableObjectWithSentry()` — see `./durable-objects.md` |
-| D1 queries not creating spans | D1 binding not instrumented | Wrap binding with `Sentry.instrumentD1WithSentry(env.DB)` before use |
+| D1 queries not creating spans | Not using the SDK-provided `env`, or accessing DB outside the wrapped handler | Use the `env` passed into your handler — `withSentry` auto-instruments D1 bindings on access. No manual wrapping needed |
+| Spans inside `waitUntil()` missing | Root span already ended before the background task ran | Wrap deferred work in `Sentry.startSpan({ ..., forceTransaction: true }, ...)` — see `./tracing.md` |
+| Traces not linked across RPC / DO calls | RPC trace propagation not enabled | Set `enableRpcTracePropagation: true` on **both** caller and receiver (v10.52.0+) — see `./tracing.md` |
 | Scheduled handler not monitored | `withSentry` not wrapping the handler | Ensure `export default Sentry.withSentry(...)` wraps your entire exported handler object |
 | Release not auto-detected | `CF_VERSION_METADATA` binding not configured | Add `[version_metadata]` with `binding = "CF_VERSION_METADATA"` to `wrangler.toml` |
 | Duplicate events in Workflows | Dedupe integration filtering step failures | SDK automatically disables dedupe for Workflows; verify you use `instrumentWorkflowWithSentry` |

--- a/src/references/sdks/cloudflare/nodejs-compat.md
+++ b/src/references/sdks/cloudflare/nodejs-compat.md
@@ -1,0 +1,107 @@
+# Node.js Compatibility Entrypoint — Sentry Cloudflare SDK
+
+> `@sentry/cloudflare/nodejs_compat` entrypoint: v10.64.0+
+> Prisma integration (Cloudflare): via `/nodejs_compat` entrypoint only
+> Requires the `nodejs_compat` compatibility flag in Wrangler config
+
+---
+
+## Overview
+
+Cloudflare Workers can run with Node.js APIs enabled through the [`nodejs_compat` compatibility flag](https://developers.cloudflare.com/workers/runtime-apis/nodejs/). To take advantage of this, the Cloudflare SDK ships a dedicated `@sentry/cloudflare/nodejs_compat` entrypoint that unlocks Node.js SDK features which aren't available in the default Workers runtime.
+
+**Using this entrypoint is generally recommended, and it's the default choice for new projects.** It's a drop-in replacement for the default `@sentry/cloudflare` import that adds functionality (see [What It Unlocks](#what-it-unlocks)) without removing anything — and it becomes the default entrypoint in v11, so adopting it now keeps you ahead of that change. The only prerequisite is the `nodejs_compat` flag, which is itself a superset of the `nodejs_als` flag the SDK already needs. For a new Worker, enable `nodejs_compat` and import from `@sentry/cloudflare/nodejs_compat` from the start.
+
+> The `/nodejs_compat` entrypoint requires SDK version `10.64.0` or higher. It will become the **default entrypoint in the next major version (v11)**.
+
+### What It Unlocks
+
+The `/nodejs_compat` entrypoint enables Node.js-only integrations and features on Cloudflare, including:
+
+- **`prismaIntegration`** — tracing Prisma ORM queries (see [Prisma Integration](#prisma-integration) below)
+- **Vercel AI SDK v7 support** for the `vercelAIIntegration`
+
+---
+
+## Usage
+
+The entrypoint is a drop-in replacement for `@sentry/cloudflare` — switching over only requires changing your imports:
+
+```typescript
+// Before
+import * as Sentry from "@sentry/cloudflare";
+
+// After
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+```
+
+Everything else (`withSentry`, `sentryPagesPlugin`, `instrumentDurableObjectWithSentry`, etc.) works exactly the same.
+
+### Prerequisite: `nodejs_compat` Flag
+
+To use the entrypoint, your Worker must set the `nodejs_compat` compatibility flag in your Wrangler configuration:
+
+**wrangler.jsonc:**
+```jsonc
+{
+  "compatibility_flags": ["nodejs_compat"]
+}
+```
+
+**wrangler.toml:**
+```toml
+compatibility_flags = ["nodejs_compat"]
+```
+
+> `nodejs_compat` is a superset of `nodejs_als` — it enables `AsyncLocalStorage` (which the SDK requires) plus the rest of the Node.js compatibility surface. If you're already on `nodejs_compat`, using the `/nodejs_compat` entrypoint is recommended.
+
+---
+
+## Prisma Integration
+
+On Cloudflare, the `prismaIntegration` is **only** available through the `/nodejs_compat` entrypoint.
+
+Import Sentry from the `@sentry/cloudflare/nodejs_compat` entrypoint and add `prismaIntegration` to your init options:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+    integrations: [Sentry.prismaIntegration()],
+  }),
+  {
+    async fetch(request, env, ctx) {
+      return new Response("OK");
+    },
+  } satisfies ExportedHandler<Env>,
+);
+```
+
+The integration creates a span for each query and reports relevant details to Sentry.
+
+**Supported Prisma versions:** `5.x`, `6.x`, `7.x`.
+
+In Prisma **v5**, you also need to add the `tracing` preview feature to the `generator` block of your Prisma schema:
+
+```txt
+// schema.prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["tracing"]
+}
+```
+
+For details on the span structure Prisma's OpenTelemetry tracing produces (e.g., `prisma:client:operation`, `prisma:engine:db_query`), see the [Prisma trace output docs](https://www.prisma.io/docs/orm/prisma-client/observability-and-logging/opentelemetry-tracing#trace-output).
+
+---
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| `prismaIntegration` not found / no Prisma spans | Importing from the default entrypoint | Import from `@sentry/cloudflare/nodejs_compat` and ensure SDK ≥ v10.64.0 |
+| Prisma v5 produces no spans | Missing `tracing` preview feature | Add `previewFeatures = ["tracing"]` to the `generator` block in `schema.prisma` |
+| Node.js APIs undefined at runtime | Using `/nodejs_compat` entrypoint without the flag | Add `nodejs_compat` to `compatibility_flags` in Wrangler config |

--- a/src/references/sdks/cloudflare/tracing.md
+++ b/src/references/sdks/cloudflare/tracing.md
@@ -4,6 +4,8 @@
 > Streaming response span tracking: v10.x+
 > `propagateTraceparent`: v10.x+
 > OpenTelemetry compatibility tracer: v10.x+
+> RPC trace propagation (`enableRpcTracePropagation`): v10.52.0+
+> Workers AI (`env.AI`) `gen_ai` spans: v10.67.0+
 
 ---
 
@@ -14,7 +16,7 @@ The Cloudflare SDK is **not natively OpenTelemetry-based** (unlike `@sentry/node
 - Spans emitted via `@opentelemetry/api` are captured by Sentry
 - The SDK creates its own HTTP server spans for incoming requests
 - Outbound `fetch()` calls are automatically traced via `fetchIntegration`
-- D1 queries are traced when you use `instrumentD1WithSentry`
+- D1 queries and Workers AI (`env.AI`) calls are traced automatically when accessed via `env`
 
 ---
 
@@ -119,20 +121,73 @@ Each outbound fetch creates a child span with method, URL, and response status.
 
 ### D1 Query Spans
 
-When you instrument D1 with `instrumentD1WithSentry`, all queries create `db.query` spans:
+D1 bindings are **auto-instrumented** by `withSentry` — access `env.DB` from the handler's `env` and queries create `db.query` spans automatically (no manual wrapping needed):
 
 ```typescript
-const db = Sentry.instrumentD1WithSentry(env.DB);
-
-// This creates a db.query span with the SQL statement
-const result = await db.prepare("SELECT * FROM users WHERE id = ?").bind(1).run();
+// env.DB is auto-instrumented — no wrapper required
+const result = await env.DB.prepare("SELECT * FROM users WHERE id = ?").bind(1).run();
 ```
 
 Span attributes include:
-- `cloudflare.d1.query_type` — `first`, `run`, `all`, or `raw`
+- `cloudflare.d1.query_type` — `first`, `run`, `all`, `raw`, `batch`, or `exec`
 - `cloudflare.d1.duration` — query duration
 - `cloudflare.d1.rows_read` — number of rows read
 - `cloudflare.d1.rows_written` — number of rows written
+
+See `./durable-objects.md` for full D1 coverage (prepared statements, `batch`, `exec`).
+
+### Workers AI Spans
+
+The Cloudflare Workers AI binding (`env.AI`) is auto-instrumented by `withSentry` (v10.67.0+). Calls to `env.AI.run(...)` create `gen_ai` spans following Sentry's AI Agent Monitoring conventions — capturing model, request parameters, and token usage:
+
+```typescript
+// env.AI is auto-instrumented — creates a gen_ai span
+const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+  messages: [{ role: "user", content: "What is the capital of France?" }],
+});
+```
+
+#### Tracking Conversations
+
+> **Beta:** configuration options and behavior may change.
+
+The Workers AI instrumentation does **not** infer the conversation ID automatically. To group multi-turn AI calls into a single [Conversation](https://docs.sentry.io/product/ai/monitoring/conversations/), set the ID manually with `Sentry.setConversationId(id)`. It's applied as the `gen_ai.conversation.id` attribute to **all AI spans within the current scope**, so call it once at the start of a request handler — before any `env.AI.run(...)` calls — and every AI span for that request is grouped. Pass `null` to unset it.
+
+When you use the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/), each agent instance already has a stable identifier — its Durable Object instance name, `this.name` — which is a natural conversation ID. Set it at the top of the handler (`onRequest` for `Agent`, `onChatMessage` for `AIChatAgent`) so every AI call triggered while handling that message shares the ID:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare";
+import { AIChatAgent } from "@cloudflare/ai-chat";
+
+class MyChatAgentBase extends AIChatAgent<Env> {
+  async onChatMessage(): Promise<Response | undefined> {
+    // Every AI call in this chat session shares the same conversation ID
+    Sentry.setConversationId(this.name);
+
+    const result = await this.env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+      messages: this.messages.map((m) => ({
+        role: m.role,
+        content: m.parts
+          .filter((p) => p.type === "text")
+          .map((p) => p.text)
+          .join(""),
+      })),
+    });
+
+    return new Response(JSON.stringify(result));
+  }
+}
+
+export const MyChatAgent = Sentry.instrumentDurableObjectWithSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  }),
+  MyChatAgentBase,
+);
+```
+
+For a plain `Agent`, the pattern is the same — call `Sentry.setConversationId(this.name)` at the top of `onRequest` before your `this.env.AI.run(...)` calls. Grouped calls appear in the [Conversations](https://docs.sentry.io/product/ai/monitoring/conversations/) view, where you can inspect token usage, latency, and errors across the whole conversation.
 
 ---
 
@@ -260,6 +315,40 @@ return new Response(`<html><head>${metaTags}</head>...`, {
 });
 ```
 
+### RPC Trace Propagation
+
+> `enableRpcTracePropagation`: v10.52.0+
+
+Trace context isn't propagated across [Service Binding](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/) / [RPC](https://developers.cloudflare.com/workers/runtime-apis/rpc/) calls (including Durable Object RPC and Workflows) by default. Set `enableRpcTracePropagation: true` on **both** the caller and the receiver to link these calls into a single distributed trace.
+
+**Recommended:** enable it whenever your Workers communicate over RPC / service bindings or you use Durable Objects or Workflows.
+
+**Caller (Worker calling into a service binding / DO):**
+
+```typescript
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+    enableRpcTracePropagation: true,
+  }),
+  handler,
+);
+```
+
+**Receiver (the Durable Object / target Worker):**
+
+```typescript
+export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+    enableRpcTracePropagation: true,
+  }),
+  MyDurableObjectBase,
+);
+```
+
 ---
 
 ## Durable Object Tracing
@@ -298,11 +387,26 @@ See the Workflows section in `./durable-objects.md` for full setup.
 
 2. **Use `tracePropagationTargets`** — avoid leaking trace headers to third-party APIs. Only propagate to your own services.
 
-3. **Instrument D1** — `instrumentD1WithSentry` adds almost no overhead and gives you query-level visibility.
+3. **Access bindings via `env`** — D1 and Workers AI are auto-instrumented when you use `env.DB` / `env.AI` directly, giving query- and model-level visibility with no manual wrapping.
 
 4. **Use `startSpan` for custom operations** — wrap business logic in spans for detailed visibility beyond HTTP/DB.
 
 5. **Don't forget `span.end()`** — when using `startInactiveSpan` or `startSpanManual`, always end the span.
+
+### `waitUntil()` Background Work
+
+Spans started inside `ctx.waitUntil()` run **after** the response is returned, so the request's root span has usually already ended. To make sure background spans are recorded as their own transaction, start them with `forceTransaction: true`:
+
+```typescript
+ctx.waitUntil(
+  Sentry.startSpan(
+    { name: "background-cleanup", op: "task", forceTransaction: true },
+    async () => {
+      await cleanup(env.DB);
+    },
+  ),
+);
+```
 
 ---
 
@@ -313,6 +417,8 @@ See the Workflows section in `./durable-objects.md` for full setup.
 | No traces appearing | Verify `tracesSampleRate` or `tracesSampler` is set in init options |
 | Missing outbound fetch spans | Ensure `fetchIntegration` is not removed from `defaultIntegrations` |
 | Trace headers not propagated | Check `tracePropagationTargets` includes the target URL |
-| D1 spans not appearing | Ensure `instrumentD1WithSentry(env.DB)` is called before queries |
+| D1 spans not appearing | Access the binding via `env.DB` (auto-instrumented by `withSentry`); ensure `tracesSampleRate` is set |
+| RPC / Durable Object calls not in the same trace | Set `enableRpcTracePropagation: true` on **both** caller and receiver |
+| Background (`waitUntil`) work missing from traces | Start the span with `forceTransaction: true` |
 | Very short span durations (0ms) | Expected for CPU-bound work — Cloudflare Workers timers only advance during I/O |
 | Streaming response spans too short | Update to latest SDK — streaming response tracking was added in v10.x |


### PR DESCRIPTION
This is now in sync with the docs. 

This also adds the `enableRpcTracePropagation` flag (and is also the recommended approach).