### PR TITLE
docs(cloudflare): add dedicated Agent Tracing reference

### DIFF
--- a/src/references/sdks/cloudflare/ai-monitoring.md
+++ b/src/references/sdks/cloudflare/ai-monitoring.md
@@ -95,7 +95,24 @@ export default Sentry.withSentry(
 );
 ```
 
-No extra setup. Workers AI does **not** infer a conversation ID — see [Tracking Conversations](#tracking-conversations).
+**Auto-instrumentation covers the spans — not the grouping.** Workers AI does **not** infer a conversation ID, so without one every `env.AI.run(...)` call lands as an isolated span and the Conversations view stays empty. For any chat-style app, set a conversation ID as part of this setup — don't treat it as a later add-on:
+
+1. Generate a stable session ID on the client (e.g. `crypto.randomUUID()` once per chat session) and send it with every AI request
+2. In the handler, call `Sentry.setConversationId(id)` **before** any `env.AI.run(...)` calls
+
+```typescript
+async fetch(request, env, ctx) {
+  const { conversationId, messages } = await request.json();
+
+  // Before any AI calls — groups this request's gen_ai spans into a Conversation
+  Sentry.setConversationId(conversationId);
+
+  const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", { messages });
+  return new Response(JSON.stringify(result));
+}
+```
+
+See [Tracking Conversations](#tracking-conversations) for scope semantics, user attribution, and the Agents SDK pattern.
 
 ---
 

--- a/src/references/sdks/cloudflare/ai-monitoring.md
+++ b/src/references/sdks/cloudflare/ai-monitoring.md
@@ -1,0 +1,512 @@
+# AI / LLM Monitoring (Agent Tracing) — Sentry Cloudflare SDK
+
+> Minimum SDK: `@sentry/cloudflare` >=10.61.0 (Gen AI span streaming on by default).
+> Workers AI (`env.AI`) auto-instrumentation: v10.67.0+. Vite plugin build-time instrumentation: v10.68.0+ (experimental).
+> Docs: [docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/](https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/)
+
+Sentry Agent Tracing captures `gen_ai` spans for LLM calls, agent runs, and tool executions — token usage, latency, prompts/responses, and error rates — and groups multi-turn chats in Conversations.
+
+---
+
+## The Cloudflare Difference
+
+The Cloudflare Workers runtime (`workerd`) does **not support runtime monkey-patching**, so the automatic AI instrumentation that Node.js gets for free does not happen here. On Cloudflare there are three ways to get `gen_ai` spans, in order of preference:
+
+| Path | Covers | How it works |
+|------|--------|-------------|
+| **1. Workers AI binding** (automatic) | `env.AI.run(...)` | `withSentry` wraps `env` — nothing to do (v10.67.0+) |
+| **2. Vite plugin** (build-time, experimental) | `openai`, `@anthropic-ai/sdk`, `@google/genai`, `ai` (Vercel AI SDK) | `sentryCloudflareVitePlugin` injects `diagnostics_channel` calls into the bundled packages at build time (v10.68.0+) |
+| **3. Manual client wrapping** | OpenAI, Anthropic, Google Gen AI, LangChain, LangGraph | Wrap each client/graph with the matching `Sentry.instrument*` helper |
+
+LangChain and LangGraph are **not** covered by the Vite plugin's channel injection — they always require the manual helpers (path 3).
+
+---
+
+## Prerequisites
+
+Tracing must be enabled — AI spans require an active trace. Pass `dataCollection` so generative AI content (prompts and responses) is collected according to SDK defaults:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+    dataCollection: {
+      // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+      // https://docs.sentry.io/platforms/javascript/guides/cloudflare/configuration/options/#dataCollection
+      // userInfo: false,
+      // httpBodies: [],
+    },
+  }),
+  handler,
+);
+```
+
+**PII warning:** with `dataCollection` set (even `{}`), genAI input/output capture is **on by default** — prompts and model responses are sent to Sentry. To turn it off:
+
+```typescript
+dataCollection: {
+  genAI: { inputs: false, outputs: false },
+},
+```
+
+Per-integration `recordInputs` / `recordOutputs` options override the global default.
+
+---
+
+## Integration Matrix
+
+| AI stack | Supported versions | Instrumentation | Min SDK |
+|----------|--------------------|-----------------|---------|
+| Workers AI (`env.AI`) | — | Automatic via `withSentry` | 10.67.0 |
+| OpenAI (`openai`) | `>=4.0.0 <7` | Vite plugin **or** `instrumentOpenAiClient` | 10.68.0 / — |
+| Anthropic (`@anthropic-ai/sdk`) | `>=0.19.2 <1.0.0` | Vite plugin **or** `instrumentAnthropicAiClient` | 10.68.0 / — |
+| Google Gen AI (`@google/genai`) | `>=0.10.0 <2` | Vite plugin **or** `instrumentGoogleGenAIClient` | 10.68.0 / — |
+| Vercel AI SDK (`ai`) | `>=3.0.0 <=7` | `vercelAIIntegration` (+ Vite plugin injection) | 10.6.0; v7 needs 10.64.0 + `/nodejs_compat` entrypoint |
+| LangChain (`langchain`) | `>=0.1.0 <2.0.0` | `createLangChainCallbackHandler` (manual only) | — |
+| LangGraph (`@langchain/langgraph`) | `>=0.2.0 <2.0.0` | `instrumentLangGraph` (manual only) | — |
+| Other providers (Bedrock, Mistral, Groq, …) | — | Manual `gen_ai.*` spans | — |
+
+---
+
+## Path 1: Workers AI (Automatic)
+
+The Workers AI binding is auto-instrumented by `withSentry` (v10.67.0+). Calls to `env.AI.run(...)` create `gen_ai` spans capturing model, request parameters, and token usage — as long as your handler uses the `env` the SDK passes in:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare";
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  }),
+  {
+    async fetch(request, env, ctx) {
+      // env.AI is automatically instrumented
+      const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+        messages: [{ role: "user", content: "What is the capital of France?" }],
+      });
+      return new Response(JSON.stringify(result));
+    },
+  } satisfies ExportedHandler<Env>,
+);
+```
+
+No extra setup. Workers AI does **not** infer a conversation ID — see [Tracking Conversations](#tracking-conversations).
+
+---
+
+## Path 2: Vite Plugin (Build-Time Instrumentation)
+
+> **Experimental** (v10.68.0+): options and behavior may change or be removed in any release. Verify against the [Vite plugin docs](https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/vite-plugin/) before implementing.
+
+`sentryCloudflareVitePlugin` ships with `@sentry/cloudflare` (no extra package) via the `@sentry/cloudflare/vite` export. It is designed to run alongside the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/). With `useDiagnosticsChannelInjection` enabled, it injects `diagnostics_channel.tracingChannel` calls into supported bundled packages — including `openai`, `@anthropic-ai/sdk`, `@google/genai`, and `ai` — so the SDK traces them without monkey-patching. The matching Sentry integrations are registered automatically; you don't wrap clients or add integrations manually.
+
+**Prerequisite:** the injected code uses Node.js `diagnostics_channel` at runtime, so the Worker must have the `nodejs_compat` compatibility flag (see `./nodejs-compat.md`).
+
+```typescript
+// vite.config.ts
+import { cloudflare } from "@cloudflare/vite-plugin";
+import { sentryCloudflareVitePlugin } from "@sentry/cloudflare/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [
+    cloudflare(),
+    sentryCloudflareVitePlugin({
+      _experimental: {
+        useDiagnosticsChannelInjection: true,
+      },
+    }),
+  ],
+});
+```
+
+Keep `withSentry` in your Worker entry as usual:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare/nodejs_compat";
+import OpenAI from "openai";
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+  }),
+  {
+    async fetch(request, env, ctx) {
+      const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+      // Traced automatically — the Vite plugin injected channels at build time
+      const response = await openai.chat.completions.create({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: "Hello" }],
+      });
+      return new Response(response.choices[0].message.content);
+    },
+  } satisfies ExportedHandler<Env>,
+);
+```
+
+Both `vite build` and `vite dev` are instrumented. When the option is disabled or omitted, the plugin is a no-op.
+
+### Auto-Instrumentation (Experimental)
+
+The plugin can also wrap your Worker at build time so you don't need `withSentry` in your code. With `autoInstrumentation` enabled, it reads your Wrangler config, wraps the default export with `Sentry.withSentry()`, and wraps configured Durable Object and Workflow classes with the matching `instrument*WithSentry` helper:
+
+```typescript
+// vite.config.ts
+sentryCloudflareVitePlugin({
+  _experimental: {
+    autoInstrumentation: true,
+    useDiagnosticsChannelInjection: true,
+  },
+}),
+```
+
+Provide Sentry options via a co-located `instrument.server.*` file (`.ts`, `.mts`, `.js`, `.mjs`, or `.cjs`) next to your Worker entry — use `defineCloudflareOptions` for type-checking:
+
+```typescript
+// instrument.server.ts
+import { defineCloudflareOptions } from "@sentry/cloudflare";
+
+export default defineCloudflareOptions((env) => ({
+  dsn: env.SENTRY_DSN,
+  tracesSampleRate: 1.0,
+}));
+```
+
+If no `instrument.server.*` file exists, the SDK reads configuration (DSN, release, environment, sample rate) from the Worker's `env` bindings at runtime.
+
+### Migrating From Wrangler
+
+If you deploy with `wrangler` directly today:
+
+1. Set up the [Cloudflare Vite plugin](https://developers.cloudflare.com/workers/vite-plugin/get-started/) and add a `vite.config.ts` with `cloudflare()` and `sentryCloudflareVitePlugin()` as above.
+2. Run `vite build` before `wrangler deploy`, and use `vite dev` instead of `wrangler dev` for local development.
+
+Your existing `wrangler.jsonc`/`wrangler.toml` stays the input config — the plugin generates the deployed output during the build. Everything works without Vite too; you just miss the build-time instrumentation of bundled dependencies.
+
+---
+
+## Path 3: Manual Client Wrapping
+
+Use these when you don't build with Vite, or for LangChain/LangGraph (which the Vite plugin doesn't cover). All wrappers default `recordInputs`/`recordOutputs` to `true` when `dataCollection.genAI` inputs/outputs are on (the default).
+
+### OpenAI
+
+```typescript
+import OpenAI from "openai";
+import * as Sentry from "@sentry/cloudflare";
+
+const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
+const client = Sentry.instrumentOpenAiClient(openai, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+// Use the wrapped client instead of the original instance
+const response = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages: [{ role: "user", content: "Hello" }],
+});
+```
+
+Traces `chat.completions.create()` and `responses.create()`.
+
+### Anthropic
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+import * as Sentry from "@sentry/cloudflare";
+
+const anthropic = new Anthropic({ apiKey: env.ANTHROPIC_API_KEY });
+const client = Sentry.instrumentAnthropicAiClient(anthropic, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+```
+
+### Google Gen AI
+
+```typescript
+import { GoogleGenAI } from "@google/genai";
+import * as Sentry from "@sentry/cloudflare";
+
+const genAI = new GoogleGenAI({ apiKey: env.GOOGLE_API_KEY });
+const client = Sentry.instrumentGoogleGenAIClient(genAI, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+```
+
+### Vercel AI SDK
+
+The `vercelAIIntegration` is **not enabled by default** — add it to `Sentry.init` options, and pass `experimental_telemetry: { isEnabled: true }` to every `generateText` / `generateObject` / `streamText` / `ToolLoopAgent` call:
+
+```typescript
+import * as Sentry from "@sentry/cloudflare";
+import { generateText } from "ai";
+
+export default Sentry.withSentry(
+  (env: Env) => ({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0,
+    integrations: [Sentry.vercelAIIntegration()],
+  }),
+  {
+    async fetch(request, env, ctx) {
+      const result = await generateText({
+        model: openai("gpt-4o"),
+        prompt: "Hello",
+        experimental_telemetry: {
+          isEnabled: true,
+          recordInputs: true,
+          recordOutputs: true,
+        },
+      });
+      return new Response(result.text);
+    },
+  } satisfies ExportedHandler<Env>,
+);
+```
+
+**Version constraints:**
+- AI SDK v3–v6: works on the default `@sentry/cloudflare` entrypoint (SDK >=10.6.0)
+- AI SDK **v7**: requires SDK >=10.64.0 and the `@sentry/cloudflare/nodejs_compat` entrypoint (see `./nodejs-compat.md`). Setting `recordInputs`/`recordOutputs` on the integration itself is also only supported there — on the default entrypoint, set them per call via `experimental_telemetry`
+- Don't use the AI SDK's own `registerTelemetry` API (v7+) together with this integration — it duplicates spans
+
+### LangChain
+
+Create a callback handler and pass it to LangChain operations (`invoke`, `stream`, `batch`):
+
+```typescript
+import { ChatAnthropic } from "@langchain/anthropic";
+import * as Sentry from "@sentry/cloudflare";
+
+const callbackHandler = Sentry.createLangChainCallbackHandler({
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+const model = new ChatAnthropic({ model: "claude-3-5-sonnet-20241022", apiKey: env.ANTHROPIC_API_KEY });
+await model.invoke("Tell me a joke", { callbacks: [callbackHandler] });
+```
+
+Captures chat model invocations, LLM pipelines, chain executions, and tool calls. Supported provider packages: `@langchain/anthropic`, `@langchain/openai`, `@langchain/google-genai`, `@langchain/mistralai`, `@langchain/google-vertexai`, `@langchain/groq`.
+
+### LangGraph
+
+Instrument the `StateGraph` **before** calling `.compile()`:
+
+```typescript
+import { StateGraph, MessagesAnnotation, START, END } from "@langchain/langgraph";
+import * as Sentry from "@sentry/cloudflare";
+
+const agent = new StateGraph(MessagesAnnotation)
+  .addNode("agent", callLLM)
+  .addEdge(START, "agent")
+  .addEdge("agent", END);
+
+Sentry.instrumentLangGraph(agent, {
+  recordInputs: true,
+  recordOutputs: true,
+});
+
+const graph = agent.compile({ name: "my_agent" });
+```
+
+Captures `gen_ai.create_agent` (compile) and `gen_ai.invoke_agent` (invoke) spans.
+
+---
+
+## Tracking Conversations
+
+> **Beta:** configuration options and behavior may change.
+
+Conversations groups multi-turn AI activity into a single replay of messages and tool calls at **Explore > Conversations**. Every AI span in a chat session must share the same `gen_ai.conversation.id`.
+
+Some integrations infer the ID automatically. For everything else — **including Workers AI** — set it yourself at the start of every request or operation that makes AI calls, before those calls run. Reuse the same session ID across messages in the chat; the ID applies to AI spans on the current isolation scope (request-scoped). Pass `null` to unset:
+
+```typescript
+Sentry.setConversationId("conv_abc123");
+```
+
+With the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/), each agent instance has a stable identifier — its Durable Object instance name, `this.name` — which is a natural conversation ID. Set it at the top of the handler (`onRequest` for `Agent`, `onChatMessage` for `AIChatAgent`); see `./tracing.md` for a full `AIChatAgent` example with `instrumentDurableObjectWithSentry`.
+
+### Identifying Users
+
+To populate the **User** column in Conversations, call `setUser` once per request or session, before any AI calls:
+
+```typescript
+Sentry.setUser({ id: "user_123", email: "jane@example.com", username: "jane" });
+```
+
+Any of `id`, `email`, or `username` is sufficient.
+
+### Streaming Gen AI Spans
+
+Since SDK 10.61.0, `gen_ai` spans are sent as standalone envelope items instead of being bundled into the transaction (`streamGenAiSpans` defaults to `true`). This prevents AI spans with large inputs/outputs from hitting transaction payload limits, and is **required** for Conversations to work. **Self-hosted Sentry** users should set `streamGenAiSpans: false` — standalone `gen_ai` spans may not be ingested by a self-hosted instance.
+
+---
+
+## Manual `gen_ai.*` Spans
+
+For unsupported providers (Bedrock, Mistral, Groq, Cohere, …) or custom agent logic, create spans yourself. Spans nest like this:
+
+```
+invoke_agent My Agent            (gen_ai.invoke_agent)
+├── chat gpt-4o                  (gen_ai.chat)          ← 1st LLM call
+├── execute_tool get_weather     (gen_ai.execute_tool)  ← tool run
+└── chat gpt-4o                  (gen_ai.chat)          ← 2nd LLM call
+```
+
+Naming rules: span `op` MUST be `gen_ai.{operation.name}`; span `name` SHOULD be `"{operation.name} {model-or-agent-or-tool}"`. Attributes only accept primitives — JSON-stringify arrays/objects. Messages use the `{role, parts}` format: `[{"role": "user", "parts": [{"type": "text", "content": "..."}]}]`.
+
+### AI request (`gen_ai.chat`)
+
+```typescript
+const messages = [{ role: "user", parts: [{ type: "text", content: "Tell me a joke" }] }];
+
+await Sentry.startSpan(
+  {
+    op: "gen_ai.chat",
+    name: "chat o3-mini",
+    attributes: {
+      "gen_ai.operation.name": "chat",
+      "gen_ai.request.model": "o3-mini",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.input.messages": JSON.stringify(messages),
+    },
+  },
+  async (span) => {
+    const result = await client.chat.completions.create({ model: "o3-mini", messages });
+    span.setAttribute("gen_ai.response.model", result.model);
+    span.setAttribute(
+      "gen_ai.output.messages",
+      JSON.stringify([{ role: "assistant", parts: [{ type: "text", content: result.choices[0].message.content }] }]),
+    );
+    span.setAttribute("gen_ai.usage.input_tokens", result.usage.prompt_tokens);
+    span.setAttribute("gen_ai.usage.output_tokens", result.usage.completion_tokens);
+    return result;
+  },
+);
+```
+
+`gen_ai.operation.name` MUST be `"chat"`, `"embeddings"`, `"generate_content"`, or `"text_completion"`.
+
+### Agent lifecycle (`gen_ai.invoke_agent`)
+
+```typescript
+await Sentry.startSpan(
+  {
+    op: "gen_ai.invoke_agent",
+    name: "invoke_agent Weather Agent",
+    attributes: {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": "Weather Agent",
+      "gen_ai.request.model": "o3-mini",
+    },
+  },
+  async (span) => {
+    const result = await myAgent.run();
+    span.setAttribute("gen_ai.usage.input_tokens", result.usage.inputTokens);
+    span.setAttribute("gen_ai.usage.output_tokens", result.usage.outputTokens);
+    return result;
+  },
+);
+```
+
+### Tool call (`gen_ai.execute_tool`)
+
+```typescript
+await Sentry.startSpan(
+  {
+    op: "gen_ai.execute_tool",
+    name: "execute_tool get_weather",
+    attributes: {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": "get_weather",
+      "gen_ai.tool.type": "function",
+      "gen_ai.tool.call.arguments": JSON.stringify({ location: "Paris" }),
+    },
+  },
+  async (span) => {
+    const result = await getWeather({ location: "Paris" });
+    span.setAttribute("gen_ai.tool.call.result", JSON.stringify(result));
+    return result;
+  },
+);
+```
+
+### Streaming responses
+
+When the LLM streams, the span must outlive the initial callback — use `Sentry.startInactiveSpan`, propagate with `Sentry.withActiveSpan`, and call `span.end()` when the stream completes or errors. Set `gen_ai.response.streaming: true` and the token counts after the stream finishes.
+
+### Key attributes
+
+| Attribute | Type | Notes |
+|-----------|------|-------|
+| `gen_ai.request.model` | string | Requested model (required for chat spans) |
+| `gen_ai.response.model` | string | Concrete model that responded |
+| `gen_ai.provider.name` | string | e.g. `"openai"` |
+| `gen_ai.agent.name` | string | Agent name (agent spans) |
+| `gen_ai.input.messages` | string | JSON-stringified `{role, parts}` messages (replaces deprecated `gen_ai.request.messages`) |
+| `gen_ai.output.messages` | string | JSON-stringified response messages (replaces deprecated `gen_ai.response.text` / `gen_ai.response.tool_calls`) |
+| `gen_ai.tool.definitions` | string | JSON-stringified tool list (replaces deprecated `gen_ai.request.available_tools`) |
+| `gen_ai.tool.call.arguments` / `gen_ai.tool.call.result` | string | Tool I/O (replace deprecated `gen_ai.tool.input` / `gen_ai.tool.output`) |
+| `gen_ai.usage.input_tokens` | int | **Total** input tokens, including cached |
+| `gen_ai.usage.input_tokens.cached` | int | Subset of input tokens served from cache |
+| `gen_ai.usage.output_tokens` | int | **Total** output tokens, including reasoning |
+| `gen_ai.usage.output_tokens.reasoning` | int | Subset used for reasoning |
+
+> Cached and reasoning tokens are **subsets** of the totals, not additive. Sentry subtracts them from the totals to compute costs — reporting only the non-cached count as `input_tokens` produces wrong or negative cost calculations.
+
+---
+
+## Sampling
+
+If `tracesSampleRate < 1.0`, AI calls that fall outside sampled traces produce no spans. Use a `tracesSampler` that keeps AI-related traffic at 100% while sampling the rest lower.
+
+---
+
+## Verification
+
+Deploy (or `vite dev` / `wrangler dev` with a real DSN), trigger a route that makes an AI call, then check:
+
+1. **Insights > Agents** in Sentry — the AI Agents dashboard shows the model, token usage, and latency
+2. The trace view shows `gen_ai.*` spans nested under the request transaction
+3. If you set `Sentry.setConversationId(...)`, the calls appear grouped in **Explore > Conversations**
+
+Minimal test handler (Workers AI — zero config beyond `withSentry`):
+
+```typescript
+async fetch(request, env, ctx) {
+  Sentry.setConversationId("test-conversation");
+  const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
+    messages: [{ role: "user", content: "Say hello" }],
+  });
+  return new Response(JSON.stringify(result));
+}
+```
+
+---
+
+## Troubleshooting
+
+| Issue | Cause | Solution |
+|-------|-------|----------|
+| No `gen_ai` spans at all | Tracing not enabled | Set `tracesSampleRate > 0`; verify the handler is wrapped with `withSentry` |
+| OpenAI/Anthropic/Google calls not traced | No runtime patching on workerd | Build with the Vite plugin (`useDiagnosticsChannelInjection: true`) **or** wrap the client with `Sentry.instrument*Client` |
+| Vite plugin injection has no effect | Missing `nodejs_compat` flag, or SDK < 10.68.0 | Add `nodejs_compat` to `compatibility_flags`; upgrade `@sentry/cloudflare` |
+| Vercel AI spans missing | Integration not added, or telemetry not enabled per call | Add `Sentry.vercelAIIntegration()` to `integrations` and `experimental_telemetry: { isEnabled: true }` on every call |
+| Vercel AI SDK v7 not working | Default entrypoint doesn't support v7 | Use `@sentry/cloudflare/nodejs_compat` (SDK >=10.64.0) — see `./nodejs-compat.md` |
+| Workers AI calls not traced | `env` accessed outside the wrapped handler, or SDK < 10.67.0 | Use the `env` passed into the handler; upgrade the SDK |
+| LangChain/LangGraph not traced | Expecting Vite plugin coverage | Not covered by channel injection — use `createLangChainCallbackHandler` / `instrumentLangGraph` |
+| Prompts/responses not captured | genAI capture disabled | Don't set `dataCollection: { genAI: { inputs: false } }`, or pass `recordInputs`/`recordOutputs: true` explicitly |
+| Conversations view empty | No conversation ID, or gen_ai streaming disabled | Call `Sentry.setConversationId()` before AI calls; keep `streamGenAiSpans` at its default (`true`) |
+| Self-hosted: gen_ai spans dropped | Standalone gen_ai envelopes not ingested | Set `streamGenAiSpans: false` |
+| User column shows "Unknown" | No user on the scope | Call `Sentry.setUser()` once per request before AI calls |
+| Wrong/negative cost calculations | Token subsets reported as totals | `input_tokens`/`output_tokens` must be totals that *include* cached/reasoning counts |

--- a/src/references/sdks/cloudflare/index.md
+++ b/src/references/sdks/cloudflare/index.md
@@ -112,6 +112,8 @@ Present a concrete recommendation based on what you found. Don't ask open-ended 
 
 Propose: *"I recommend setting up Error Monitoring + Tracing. Want me to also add D1 instrumentation and Crons monitoring?"*
 
+**Exception — AI apps:** when Workers AI or an LLM SDK is detected, conversation tracking is **not optional** — include it in the baseline proposal alongside Error Monitoring + Tracing, and implement it in the same pass (see `./ai-monitoring.md`). An AI setup that produces spans but no Conversations is incomplete.
+
 ---
 
 ## Phase 3: Guide
@@ -202,6 +204,25 @@ export default Sentry.withSentry(
 - The SDK reads DSN, environment, release, debug, tunnel, and traces sample rate from `env` automatically (see [Environment Variables](#environment-variables))
 - `withSentry` wraps all exported handlers — you do not need separate wrappers for `scheduled`, `queue`, etc.
 
+#### AI apps: set a conversation ID (required, same edit)
+
+If this Worker makes AI calls (`env.AI.run(...)` or an LLM SDK), `withSentry` gives you `gen_ai` spans automatically — but **never a conversation ID**, so multi-turn chats won't group and Sentry's Conversations view stays empty. This is part of the Workers setup, not a follow-up: add `Sentry.setConversationId()` in the same edit that adds `withSentry`.
+
+1. The client generates a stable session ID once per chat session (e.g. `crypto.randomUUID()`) and sends it with every AI request
+2. The handler sets it **before** any AI calls:
+
+```typescript
+async fetch(request, env, ctx) {
+  const { conversationId, messages } = await request.json();
+  Sentry.setConversationId(conversationId); // before env.AI.run / LLM calls
+
+  const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", { messages });
+  return new Response(JSON.stringify(result));
+}
+```
+
+See `./ai-monitoring.md` for user attribution (`setUser`), the Agents SDK pattern, and non-Workers-AI providers.
+
 #### Automatic Binding Instrumentation
 
 `withSentry` (and `sentryPagesPlugin`) wraps the `env` object so that supported bindings are **automatically instrumented on access** — no manual wrapping needed. As long as your handler uses the `env` passed in by the SDK:
@@ -209,11 +230,13 @@ export default Sentry.withSentry(
 | Binding | Auto-instrumented | Docs status |
 |---------|-------------------|-------------|
 | **D1** (`env.DB`) | Query spans + breadcrumbs | Documented |
-| **Workers AI** (`env.AI`) | `gen_ai` spans (v10.67.0+) | Documented |
+| **Workers AI** (`env.AI`) | `gen_ai` spans (v10.67.0+) — spans only; conversation grouping needs the extra step below | Documented |
 | **Queue producers** | Producer send spans | Verified in SDK source; not yet in published docs |
 | **R2 buckets** | Object operation spans | Verified in SDK source; not yet in published docs |
 | **RateLimit** | `limit()` spans | Verified in SDK source; not yet in published docs |
 
+> **Required step for AI apps:** auto-instrumentation produces `gen_ai` spans but never sets a conversation ID, so multi-turn chats don't group and Sentry's Conversations view stays empty. If the app makes AI calls (`env.AI` or an LLM SDK), wiring `Sentry.setConversationId()` is part of *this* setup — do it in the same edit as `withSentry`, don't defer it. Read `./ai-monitoring.md` (Tracking Conversations) for the pattern: client generates a stable session ID, handler calls `Sentry.setConversationId(id)` before any AI calls. Skipping this is the most common gap in Cloudflare AI setups.
+>
 > Because D1 is auto-instrumented via `env`, the manual `instrumentD1WithSentry` wrapper is no longer needed (it's deprecated and slated for removal in v11). See `./durable-objects.md`.
 >
 > To link Durable Object and service-binding (JSRPC) calls into one trace, set `enableRpcTracePropagation: true` on both caller and receiver — **recommended** whenever you use RPC, Durable Objects, or Workflows. See [RPC Trace Propagation](#configuration-reference) and `./tracing.md`.

--- a/src/references/sdks/cloudflare/index.md
+++ b/src/references/sdks/cloudflare/index.md
@@ -45,7 +45,11 @@ cat wrangler.toml 2>/dev/null | grep -i 'compatibility_flags'
 cat wrangler.jsonc 2>/dev/null | grep -i 'compatibility_flags'
 
 # Detect AI/LLM libraries
-cat package.json 2>/dev/null | grep -E '"openai"|"@anthropic-ai"|"ai"|"@google/generative-ai"|"@langchain"'
+cat package.json 2>/dev/null | grep -E '"openai"|"@anthropic-ai"|"ai"|"@google/genai"|"@langchain"|"langchain"'
+
+# Detect Vite build (enables build-time AI/DB instrumentation via the Sentry Vite plugin)
+ls vite.config.ts vite.config.js vite.config.mts 2>/dev/null
+cat package.json 2>/dev/null | grep -E '"@cloudflare/vite-plugin"'
 
 # Detect logging libraries
 cat package.json 2>/dev/null | grep -E '"pino"|"winston"'
@@ -69,8 +73,9 @@ cat package.json 2>/dev/null | grep -E '"react"|"vue"|"svelte"|"next"'
 | Cron triggers configured? | `withSentry` auto-instruments scheduled handlers; recommend Crons monitoring |
 | `nodejs_als` or `nodejs_compat` flag set? | **Required** — SDK needs `AsyncLocalStorage`. Recommend `nodejs_compat` generally, and with it the `@sentry/cloudflare/nodejs_compat` entrypoint (drop-in swap, unlocks Prisma + Vercel AI SDK v7, becomes default in v11) |
 | Prisma ORM used? | Recommend `prismaIntegration` via the `/nodejs_compat` entrypoint — see `./nodejs-compat.md` |
-| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+) |
-| AI/LLM libraries? | Recommend AI Monitoring integrations |
+| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+). See `./ai-monitoring.md` |
+| AI/LLM libraries? | Recommend Agent Tracing — see `./ai-monitoring.md`. On workerd, `openai`/`@anthropic-ai/sdk`/`@google/genai` need the Vite plugin or manual client wrapping |
+| Builds with Vite (or could)? | Recommend `sentryCloudflareVitePlugin` (v10.68.0+, experimental) — build-time instrumentation of bundled AI/DB packages. See `./ai-monitoring.md` |
 | Companion frontend? | Trigger Phase 4 cross-link |
 
 ---
@@ -89,7 +94,7 @@ Present a concrete recommendation based on what you found. Don't ask open-ended 
 - ⚡ **D1 Instrumentation** — automatic query spans and breadcrumbs; recommend when D1 is bound
 - ⚡ **Durable Objects** — automatic error capture and spans for DO methods; recommend when DOs are configured
 - ⚡ **Workflows** — automatic span creation for workflow steps; recommend when Workflows are configured
-- ⚡ **AI Monitoring** — Vercel AI SDK, OpenAI, Anthropic, LangChain; recommend when AI libraries detected
+- ⚡ **AI / Agent Tracing** — Workers AI, OpenAI, Anthropic, Google Gen AI, Vercel AI SDK, LangChain, LangGraph; recommend when AI libraries or `env.AI` detected
 
 **Recommendation logic:**
 
@@ -102,7 +107,7 @@ Present a concrete recommendation based on what you found. Don't ask open-ended 
 | D1 Instrumentation | D1 database bindings present |
 | Durable Objects | Durable Object bindings configured |
 | Workflows | Workflow bindings configured |
-| AI Monitoring | App uses Vercel AI SDK, OpenAI, Anthropic, or LangChain |
+| AI / Agent Tracing | App uses Workers AI (`env.AI`), OpenAI, Anthropic, Google Gen AI, Vercel AI SDK, LangChain, or LangGraph |
 | Metrics | App needs custom counters, gauges, or distributions |
 
 Propose: *"I recommend setting up Error Monitoring + Tracing. Want me to also add D1 instrumentation and Crons monitoring?"*
@@ -374,6 +379,8 @@ export default defineConfig({
 
 `SENTRY_AUTH_TOKEN` is a build-time secret. The `npx @sentry/wizard@latest -i sourcemaps` shortcut noted above automates this setup.
 
+> Don't confuse `@sentry/vite-plugin` (`sentryVitePlugin` — source map upload) with `sentryCloudflareVitePlugin` from `@sentry/cloudflare/vite` (build-time instrumentation of bundled AI/DB dependencies, v10.68.0+ experimental). They are complementary and can run in the same `vite.config.ts`. See `./ai-monitoring.md` for the latter.
+
 ---
 
 ### Automatic Release Detection
@@ -404,6 +411,7 @@ Load the corresponding reference file and follow its steps:
 | Logging | `./logging.md` | Structured logs via `Sentry.logger.*`, log-to-trace correlation |
 | Crons | `./crons.md` | Scheduled handler monitoring, `withMonitor`, check-in API |
 | Durable Objects / Workflows / D1 | `./durable-objects.md` | Instrument Durable Object and Workflow classes; D1 auto-instrumentation |
+| AI / Agent Tracing | `./ai-monitoring.md` | AI/LLM libraries or Workers AI detected — `gen_ai` spans, Vite plugin build-time instrumentation, Conversations, manual agent spans |
 | Node.js Compat | `./nodejs-compat.md` | `nodejs_compat` flag set, or Prisma / Vercel AI SDK v7 detected — `/nodejs_compat` entrypoint, `prismaIntegration` |
 
 For each feature: read the reference file, follow its steps exactly, and verify before moving on.
@@ -507,7 +515,7 @@ Deploy and trigger the route, then check your [Sentry Issues dashboard](https://
 | Tracing working | Check Performance tab for HTTP spans |
 | Source maps working | Check stack trace shows readable file/line names |
 | D1 spans (if configured) | Run a D1 query via `env.DB` (auto-instrumented), check for `db.query` spans |
-| Workers AI spans (if configured) | Call `env.AI.run(...)`, check for `gen_ai` spans |
+| Workers AI spans (if configured) | Call `env.AI.run(...)`, check for `gen_ai` spans (see `./ai-monitoring.md`) |
 | Scheduled monitoring (if configured) | Trigger a cron, check Crons dashboard |
 
 ---

--- a/src/references/sdks/cloudflare/index.md
+++ b/src/references/sdks/cloudflare/index.md
@@ -73,7 +73,7 @@ cat package.json 2>/dev/null | grep -E '"react"|"vue"|"svelte"|"next"'
 | Cron triggers configured? | `withSentry` auto-instruments scheduled handlers; recommend Crons monitoring |
 | `nodejs_als` or `nodejs_compat` flag set? | **Required** — SDK needs `AsyncLocalStorage`. Recommend `nodejs_compat` generally, and with it the `@sentry/cloudflare/nodejs_compat` entrypoint (drop-in swap, unlocks Prisma + Vercel AI SDK v7, becomes default in v11) |
 | Prisma ORM used? | Recommend `prismaIntegration` via the `/nodejs_compat` entrypoint — see `./nodejs-compat.md` |
-| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+). See `./ai-monitoring.md` |
+| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+). **Chat-style app?** Also wire `Sentry.setConversationId()` so multi-turn sessions group in Conversations — see `./ai-monitoring.md` |
 | AI/LLM libraries? | Recommend Agent Tracing — see `./ai-monitoring.md`. On workerd, `openai`/`@anthropic-ai/sdk`/`@google/genai` need the Vite plugin or manual client wrapping |
 | Builds with Vite (or could)? | Recommend `sentryCloudflareVitePlugin` (v10.68.0+, experimental) — build-time instrumentation of bundled AI/DB packages. See `./ai-monitoring.md` |
 | Companion frontend? | Trigger Phase 4 cross-link |
@@ -94,7 +94,7 @@ Present a concrete recommendation based on what you found. Don't ask open-ended 
 - ⚡ **D1 Instrumentation** — automatic query spans and breadcrumbs; recommend when D1 is bound
 - ⚡ **Durable Objects** — automatic error capture and spans for DO methods; recommend when DOs are configured
 - ⚡ **Workflows** — automatic span creation for workflow steps; recommend when Workflows are configured
-- ⚡ **AI / Agent Tracing** — Workers AI, OpenAI, Anthropic, Google Gen AI, Vercel AI SDK, LangChain, LangGraph; recommend when AI libraries or `env.AI` detected
+- ⚡ **AI / Agent Tracing** — Workers AI, OpenAI, Anthropic, Google Gen AI, Vercel AI SDK, LangChain, LangGraph; recommend when AI libraries or `env.AI` detected. For chat apps, include conversation tracking (`setConversationId`) in the same pass — spans alone leave the Conversations view empty
 
 **Recommendation logic:**
 
@@ -516,6 +516,7 @@ Deploy and trigger the route, then check your [Sentry Issues dashboard](https://
 | Source maps working | Check stack trace shows readable file/line names |
 | D1 spans (if configured) | Run a D1 query via `env.DB` (auto-instrumented), check for `db.query` spans |
 | Workers AI spans (if configured) | Call `env.AI.run(...)`, check for `gen_ai` spans (see `./ai-monitoring.md`) |
+| Conversations (chat apps) | Send two requests with the same `Sentry.setConversationId(...)` value, check they group in Explore > Conversations |
 | Scheduled monitoring (if configured) | Trigger a cron, check Crons dashboard |
 
 ---

--- a/src/references/sdks/cloudflare/tracing.md
+++ b/src/references/sdks/cloudflare/tracing.md
@@ -138,7 +138,7 @@ See `./durable-objects.md` for full D1 coverage (prepared statements, `batch`, `
 
 ### Workers AI Spans
 
-The Cloudflare Workers AI binding (`env.AI`) is auto-instrumented by `withSentry` (v10.67.0+). Calls to `env.AI.run(...)` create `gen_ai` spans following Sentry's AI Agent Monitoring conventions — capturing model, request parameters, and token usage:
+The Cloudflare Workers AI binding (`env.AI`) is auto-instrumented by `withSentry` (v10.67.0+). Calls to `env.AI.run(...)` create `gen_ai` spans following Sentry's Agent Tracing conventions — capturing model, request parameters, and token usage. For the full agent tracing setup — OpenAI/Anthropic/Google Gen AI/Vercel AI/LangChain instrumentation, the build-time Vite plugin, and manual `gen_ai.*` spans — see `./ai-monitoring.md`.
 
 ```typescript
 // env.AI is auto-instrumented — creates a gen_ai span

--- a/src/skills/sentry-setup-ai-monitoring/SKILL.md
+++ b/src/skills/sentry-setup-ai-monitoring/SKILL.md
@@ -148,6 +148,10 @@ Sentry.init({
 });
 ```
 
+### Cloudflare Workers (no runtime patching)
+
+The Workers runtime (`workerd`) does not support monkey-patching, so Node.js-style auto-instrumentation does not apply. Workers AI (`env.AI`) is auto-instrumented by `withSentry` (v10.67.0+); `openai`, `@anthropic-ai/sdk`, `@google/genai`, and `ai` need either the build-time Sentry Cloudflare Vite plugin (v10.68.0+, experimental) or manual client wrapping; LangChain/LangGraph are manual-only. Read `${SKILL_ROOT}/../../references/sdks/cloudflare/ai-monitoring.md` for the full setup.
+
 ### Browser / Next.js OpenAI (manual wrapping required)
 
 In browser-side code or Next.js meta-framework apps, auto-instrumentation is not available. Wrap the client manually:


### PR DESCRIPTION
Adds a dedicated `ai-monitoring.md` reference for Agent Tracing on Cloudflare, based on the new [agent-tracing docs](https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/) and getsentry/sentry-docs#18844.

Cloudflare is special because workerd can't monkey-patch, so the reference walks the three paths: Workers AI auto-instrumentation, the new (experimental) `sentryCloudflareVitePlugin` build-time injection, and manual client wrapping. Also wires it into the Cloudflare index and the AI monitoring skill.

Note: the Vite plugin docs page from #18844 isn't merged yet, so that link will 404 until it lands. Content itself is verified against the published `@sentry/cloudflare@10.68.0` package.