### PR TITLE
docs(cloudflare): update references for @sentry/cloudflare 10.69.0

### DIFF
--- a/src/references/sdks/cloudflare/ai-monitoring.md
+++ b/src/references/sdks/cloudflare/ai-monitoring.md
@@ -171,7 +171,7 @@ Both `vite build` and `vite dev` are instrumented. When the option is disabled o
 
 ### Auto-Instrumentation (Experimental)
 
-The plugin can also wrap your Worker at build time so you don't need `withSentry` in your code. With `autoInstrumentation` enabled, it reads your Wrangler config, wraps the default export with `Sentry.withSentry()`, and wraps configured Durable Object and Workflow classes with the matching `instrument*WithSentry` helper:
+The plugin can also wrap your Worker at build time so you don't need `withSentry` in your code. With `autoInstrumentation` enabled, it reads your Wrangler config (probing `wrangler.json`, `wrangler.jsonc`, `wrangler.toml` at the Vite root — set the top-level `wranglerConfigPath` option for a custom name, v10.69.0+), wraps the default export with `Sentry.withSentry()`, and wraps configured classes with the matching helper: Durable Objects with `instrumentDurableObjectWithSentry`, Workflows with `instrumentWorkflowWithSentry`, and — since v10.69.0 — Cloudflare Agents SDK classes (`Agent`, `AIChatAgent`, `McpAgent`) with `instrumentAgentWithSentry`, which also gives them automatic conversation IDs (see [Tracking Conversations](#tracking-conversations)):
 
 ```typescript
 // vite.config.ts
@@ -351,7 +351,15 @@ Some integrations infer the ID automatically. For everything else — **includin
 Sentry.setConversationId("conv_abc123");
 ```
 
-With the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/), each agent instance has a stable identifier — its Durable Object instance name, `this.name` — which is a natural conversation ID. Set it at the top of the handler (`onRequest` for `Agent`, `onChatMessage` for `AIChatAgent`); see `./tracing.md` for a full `AIChatAgent` example with `instrumentDurableObjectWithSentry`.
+**Choose a real chat session ID** — a UUID or `conv_...` value your app creates when the user starts a chat. Don't use a user ID, room name, or a shared identifier: those group unrelated chats into one conversation.
+
+#### Cloudflare Agents SDK: automatic (v10.69.0+)
+
+Wrap Agents SDK classes (`Agent`, `AIChatAgent`, `McpAgent`) with `instrumentAgentWithSentry` and the conversation ID is set for you — on every chat turn (`onChatMessage`) and every `@callable()` RPC call, defaulting to the agent instance name, and rotating to a fresh ID when the user clears the chat. The Vite plugin's `autoInstrumentation` applies this wrapper automatically. See `./durable-objects.md` for the full API.
+
+The automatic ID is the agent instance name, which is correct when one instance is one chat session (e.g. `useAgent({ name: chatSessionId })`). If your instances are per-user or a shared singleton like `"default"`, override it with your own session ID via `Sentry.setConversationId(id)` at the start of `onChatMessage`, before any model or tool calls.
+
+On SDK versions before 10.69.0 (or with `instrumentDurableObjectWithSentry`), set the ID manually — see `./tracing.md` for a full `AIChatAgent` example.
 
 ### Identifying Users
 
@@ -521,7 +529,10 @@ async fetch(request, env, ctx) {
 | Vercel AI spans missing | Integration not added, or telemetry not enabled per call | Add `Sentry.vercelAIIntegration()` to `integrations` and `experimental_telemetry: { isEnabled: true }` on every call |
 | Vercel AI SDK v7 not working | Default entrypoint doesn't support v7 | Use `@sentry/cloudflare/nodejs_compat` (SDK >=10.64.0) — see `./nodejs-compat.md` |
 | Workers AI calls not traced | `env` accessed outside the wrapped handler, or SDK < 10.67.0 | Use the `env` passed into the handler; upgrade the SDK |
+| Direct `env.AI.run` spans missing after a Vercel AI SDK call | SDK < 10.69.0 bug: one `ai` SDK call suppressed direct `env.AI.run` spans for the rest of the isolate | Upgrade to 10.69.0+ |
 | LangChain/LangGraph not traced | Expecting Vite plugin coverage | Not covered by channel injection — use `createLangChainCallbackHandler` / `instrumentLangGraph` |
+| Agents SDK chats not grouping | Agent wrapped with `instrumentDurableObjectWithSentry`, or SDK < 10.69.0 | Wrap with `instrumentAgentWithSentry` (v10.69.0+) for automatic conversation IDs, or call `setConversationId` manually in `onChatMessage` |
+| One giant conversation across users | Agent instance name is per-user or a shared singleton (e.g. `"default"`) | Use one agent instance per chat session, or override with `Sentry.setConversationId(chatSessionId)` per turn |
 | Prompts/responses not captured | genAI capture disabled | Don't set `dataCollection: { genAI: { inputs: false } }`, or pass `recordInputs`/`recordOutputs: true` explicitly |
 | Conversations view empty | No conversation ID, or gen_ai streaming disabled | Call `Sentry.setConversationId()` before AI calls; keep `streamGenAiSpans` at its default (`true`) |
 | Self-hosted: gen_ai spans dropped | Standalone gen_ai envelopes not ingested | Set `streamGenAiSpans: false` |

--- a/src/references/sdks/cloudflare/ai-monitoring.md
+++ b/src/references/sdks/cloudflare/ai-monitoring.md
@@ -353,11 +353,11 @@ Sentry.setConversationId("conv_abc123");
 
 **Choose a real chat session ID** — a UUID or `conv_...` value your app creates when the user starts a chat. Don't use a user ID, room name, or a shared identifier: those group unrelated chats into one conversation.
 
-#### Cloudflare Agents SDK: automatic (v10.69.0+)
+#### Cloudflare Agents SDK: automatic conversation IDs (v10.69.0+)
 
-Wrap Agents SDK classes (`Agent`, `AIChatAgent`, `McpAgent`) with `instrumentAgentWithSentry` and the conversation ID is set for you — on every chat turn (`onChatMessage`) and every `@callable()` RPC call, defaulting to the agent instance name, and rotating to a fresh ID when the user clears the chat. The Vite plugin's `autoInstrumentation` applies this wrapper automatically. See `./durable-objects.md` for the full API.
+Wrap Agents SDK classes (`Agent`, `AIChatAgent`, `McpAgent`) with `instrumentAgentWithSentry` and the conversation ID is set for you — on every chat turn (`onChatMessage`) and every `@callable()` RPC call, defaulting to the agent instance name. When the chat is cleared — `clearHistory()` from `useAgentChat`, or anything that emits the [`message:clear` observability event](https://developers.cloudflare.com/agents/runtime/operations/observability/#channels) — the SDK rotates to a fresh conversation ID, so a reset chat groups as a new conversation. The Vite plugin's `autoInstrumentation` applies this wrapper automatically. See `./durable-objects.md` for the full API.
 
-The automatic ID is the agent instance name, which is correct when one instance is one chat session (e.g. `useAgent({ name: chatSessionId })`). If your instances are per-user or a shared singleton like `"default"`, override it with your own session ID via `Sentry.setConversationId(id)` at the start of `onChatMessage`, before any model or tool calls.
+The conversation ID is the agent instance name, which is correct when one instance is one chat session (e.g. `useAgent({ name: chatSessionId })`). If your instances are per-user or a shared singleton like `"default"`, override it with your own session ID via `Sentry.setConversationId(id)` at the start of `onChatMessage`, before any model or tool calls.
 
 On SDK versions before 10.69.0 (or with `instrumentDurableObjectWithSentry`), set the ID manually — see `./tracing.md` for a full `AIChatAgent` example.
 
@@ -529,9 +529,10 @@ async fetch(request, env, ctx) {
 | Vercel AI spans missing | Integration not added, or telemetry not enabled per call | Add `Sentry.vercelAIIntegration()` to `integrations` and `experimental_telemetry: { isEnabled: true }` on every call |
 | Vercel AI SDK v7 not working | Default entrypoint doesn't support v7 | Use `@sentry/cloudflare/nodejs_compat` (SDK >=10.64.0) — see `./nodejs-compat.md` |
 | Workers AI calls not traced | `env` accessed outside the wrapped handler, or SDK < 10.67.0 | Use the `env` passed into the handler; upgrade the SDK |
-| Direct `env.AI.run` spans missing after a Vercel AI SDK call | SDK < 10.69.0 bug: one `ai` SDK call suppressed direct `env.AI.run` spans for the rest of the isolate | Upgrade to 10.69.0+ |
+| Duplicate spans for AI calls made through the Vercel AI SDK (`workers-ai-provider`) | SDK < 10.69.0: both the Vercel AI integration and the Workers AI binding instrumentation recorded the same call | Upgrade to 10.69.0+ — the binding instrumentation now skips calls the Vercel AI integration is already recording |
 | LangChain/LangGraph not traced | Expecting Vite plugin coverage | Not covered by channel injection — use `createLangChainCallbackHandler` / `instrumentLangGraph` |
 | Agents SDK chats not grouping | Agent wrapped with `instrumentDurableObjectWithSentry`, or SDK < 10.69.0 | Wrap with `instrumentAgentWithSentry` (v10.69.0+) for automatic conversation IDs, or call `setConversationId` manually in `onChatMessage` |
+| Agents SDK conversation split unexpectedly | Chat was cleared — `clearHistory()` (or anything emitting `message:clear`) rotates to a fresh conversation ID by design | Expected: a reset chat groups as a new conversation |
 | One giant conversation across users | Agent instance name is per-user or a shared singleton (e.g. `"default"`) | Use one agent instance per chat session, or override with `Sentry.setConversationId(chatSessionId)` per turn |
 | Prompts/responses not captured | genAI capture disabled | Don't set `dataCollection: { genAI: { inputs: false } }`, or pass `recordInputs`/`recordOutputs: true` explicitly |
 | Conversations view empty | No conversation ID, or gen_ai streaming disabled | Call `Sentry.setConversationId()` before AI calls; keep `streamGenAiSpans` at its default (`true`) |

--- a/src/references/sdks/cloudflare/durable-objects.md
+++ b/src/references/sdks/cloudflare/durable-objects.md
@@ -134,7 +134,7 @@ For classes built on the [Cloudflare Agents SDK](https://developers.cloudflare.c
 
 - **Callable RPC spans** — a span (op `rpc`) for each `@callable()` method invoked over WebSocket, with `cloudflare.agent.class` / `cloudflare.agent.name` attributes
 - **Automatic conversation IDs** — sets the conversation ID on the scope for each chat turn (`onChatMessage`) and each callable RPC call, defaulting to the agent instance name, so `gen_ai` spans group in Conversations without any `setConversationId` call
-- **Conversation rotation on chat clear** — when the user clears the chat (`message:clear`), the SDK rotates to a fresh conversation ID while the instance (and its MCP/OAuth state) stays put
+- **Conversation rotation on chat clear** — when the chat is cleared (`clearHistory()` from `useAgentChat`, or anything that emits the [`message:clear` observability event](https://developers.cloudflare.com/agents/runtime/operations/observability/#channels)), the SDK rotates to a fresh conversation ID while the instance (and its MCP/OAuth state) stays put
 
 ```typescript
 import { Agent, callable } from "agents";

--- a/src/references/sdks/cloudflare/durable-objects.md
+++ b/src/references/sdks/cloudflare/durable-objects.md
@@ -6,6 +6,7 @@
 > Workflow instrumentation: v10.x+
 > D1 automatic (`env`-based) instrumentation: v10.x+
 > Durable Object Storage instrumentation: v10.x+
+> Agents SDK instrumentation (`instrumentAgentWithSentry`): v10.69.0+
 > RPC trace propagation (`enableRpcTracePropagation`): v10.52.0+
 
 ---
@@ -109,6 +110,8 @@ export const MyDurableObject = Sentry.instrumentDurableObjectWithSentry(
 
 Durable Object Storage operations (`get`, `put`, `delete`, `list`) are automatically instrumented when using `instrumentDurableObjectWithSentry`. Each storage operation creates a span.
 
+> Framework-internal storage operations are filtered out automatically (v10.69.0+): keys prefixed with `cf_`, `cf:`, `__ps_`, or `/` (used internally by the Agents SDK and PartyServer) don't create spans, so your traces show only your own storage access.
+
 ```typescript
 class MyDurableObjectBase extends DurableObject<Env> {
   async fetch(request: Request): Promise<Response> {
@@ -123,28 +126,42 @@ class MyDurableObjectBase extends DurableObject<Env> {
 }
 ```
 
-### Classes Built on Durable Objects (Agents SDK)
+### Cloudflare Agents SDK (`instrumentAgentWithSentry`)
 
-`instrumentDurableObjectWithSentry` also works with classes that extend a Durable Object base — including the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/) `Agent` and `AIChatAgent` classes (which are Durable Objects under the hood). Wrap and export them the same way:
+> `instrumentAgentWithSentry`: v10.69.0+
+
+For classes built on the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/) (`Agent` from `agents`, `AIChatAgent` from `@cloudflare/ai-chat`, `McpAgent` from `agents/mcp`), use the dedicated `instrumentAgentWithSentry` wrapper. Agents are Durable Objects under the hood, so it applies everything `instrumentDurableObjectWithSentry` does (request transactions, `alarm`, WebSocket handlers, RPC trace propagation, SQL spans) **plus** Agent-specific telemetry:
+
+- **Callable RPC spans** — a span (op `rpc`) for each `@callable()` method invoked over WebSocket, with `cloudflare.agent.class` / `cloudflare.agent.name` attributes
+- **Automatic conversation IDs** — sets the conversation ID on the scope for each chat turn (`onChatMessage`) and each callable RPC call, defaulting to the agent instance name, so `gen_ai` spans group in Conversations without any `setConversationId` call
+- **Conversation rotation on chat clear** — when the user clears the chat (`message:clear`), the SDK rotates to a fresh conversation ID while the instance (and its MCP/OAuth state) stays put
 
 ```typescript
+import { Agent, callable } from "agents";
 import * as Sentry from "@sentry/cloudflare";
-import { AIChatAgent } from "@cloudflare/ai-chat";
 
-class MyChatAgentBase extends AIChatAgent<Env> {
-  // ...agent logic (RPC methods, onChatMessage, etc.)
+class MyAgentBase extends Agent<Env> {
+  @callable()
+  async greet(name: string): Promise<string> {
+    return `Hello, ${name}!`;
+  }
 }
 
-export const MyChatAgent = Sentry.instrumentDurableObjectWithSentry(
+export const MyAgent = Sentry.instrumentAgentWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
     tracesSampleRate: 1.0,
+    enableRpcTracePropagation: true,
   }),
-  MyChatAgentBase,
+  MyAgentBase,
 );
 ```
 
-Since Agents use the instance name as a stable identifier, `this.name` is a natural conversation ID for AI monitoring — pass it to `Sentry.setConversationId(this.name)` (see the Workers AI section in `./tracing.md`).
+When building with the Sentry Vite plugin's `autoInstrumentation`, Agent classes are detected and wrapped with `instrumentAgentWithSentry` automatically (v10.69.0+) — see `./ai-monitoring.md`.
+
+The automatic conversation ID uses the agent instance name — correct when one instance is one chat session (e.g. `useAgent({ name: chatSessionId })`). If your instances are per-user or a shared singleton like `"default"`, override it with your own chat session ID via `Sentry.setConversationId(id)` at the start of `onChatMessage` — see `./ai-monitoring.md`.
+
+On SDK versions before 10.69.0, wrap Agent classes with `instrumentDurableObjectWithSentry` instead and call `Sentry.setConversationId()` manually in the handler.
 
 ### RPC Trace Propagation
 

--- a/src/references/sdks/cloudflare/index.md
+++ b/src/references/sdks/cloudflare/index.md
@@ -2,7 +2,7 @@
 
 Opinionated wizard that scans your Cloudflare project and guides you through complete Sentry setup for Workers, Pages, Durable Objects, Queues, Workflows, and Hono.
 
-> **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/cloudflare` v10.67.0).
+> **Note:** SDK versions and APIs below reflect current Sentry docs at time of writing (`@sentry/cloudflare` v10.69.0).
 > Always verify against [docs.sentry.io/platforms/javascript/guides/cloudflare/](https://docs.sentry.io/platforms/javascript/guides/cloudflare/) before implementing.
 
 ---
@@ -47,6 +47,9 @@ cat wrangler.jsonc 2>/dev/null | grep -i 'compatibility_flags'
 # Detect AI/LLM libraries
 cat package.json 2>/dev/null | grep -E '"openai"|"@anthropic-ai"|"ai"|"@google/genai"|"@langchain"|"langchain"'
 
+# Detect Cloudflare Agents SDK
+cat package.json 2>/dev/null | grep -E '"agents"|"@cloudflare/ai-chat"'
+
 # Detect Vite build (enables build-time AI/DB instrumentation via the Sentry Vite plugin)
 ls vite.config.ts vite.config.js vite.config.mts 2>/dev/null
 cat package.json 2>/dev/null | grep -E '"@cloudflare/vite-plugin"'
@@ -67,13 +70,14 @@ cat package.json 2>/dev/null | grep -E '"react"|"vue"|"svelte"|"next"'
 | Hono framework? | Recommend standalone `@sentry/hono` package (v10.55.0+) for cleaner integration |
 | `@sentry/cloudflare` already installed? | Skip install, go to feature config |
 | Durable Objects configured? | Recommend `instrumentDurableObjectWithSentry` |
+| Cloudflare Agents SDK (`agents`, `@cloudflare/ai-chat`)? | Recommend `instrumentAgentWithSentry` (v10.69.0+) — DO instrumentation plus `@callable()` RPC spans and **automatic conversation IDs**. See `./durable-objects.md` |
 | D1 databases bound? | Auto-instrumented by `withSentry` when accessed via `env.DB` (no manual wrap) |
 | Queues configured? | `withSentry` auto-instruments queue handlers |
 | Workflows configured? | Recommend `instrumentWorkflowWithSentry` |
 | Cron triggers configured? | `withSentry` auto-instruments scheduled handlers; recommend Crons monitoring |
 | `nodejs_als` or `nodejs_compat` flag set? | **Required** — SDK needs `AsyncLocalStorage`. Recommend `nodejs_compat` generally, and with it the `@sentry/cloudflare/nodejs_compat` entrypoint (drop-in swap, unlocks Prisma + Vercel AI SDK v7, becomes default in v11) |
 | Prisma ORM used? | Recommend `prismaIntegration` via the `/nodejs_compat` entrypoint — see `./nodejs-compat.md` |
-| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+). **Chat-style app?** Also wire `Sentry.setConversationId()` so multi-turn sessions group in Conversations — see `./ai-monitoring.md` |
+| Workers AI (`env.AI`) used? | Auto-instrumented by `withSentry` — creates `gen_ai` spans (v10.67.0+). **Chat-style app?** Also wire `Sentry.setConversationId()` so multi-turn sessions group in Conversations (automatic for Agents SDK classes wrapped with `instrumentAgentWithSentry`, v10.69.0+) — see `./ai-monitoring.md` |
 | AI/LLM libraries? | Recommend Agent Tracing — see `./ai-monitoring.md`. On workerd, `openai`/`@anthropic-ai/sdk`/`@google/genai` need the Vite plugin or manual client wrapping |
 | Builds with Vite (or could)? | Recommend `sentryCloudflareVitePlugin` (v10.68.0+, experimental) — build-time instrumentation of bundled AI/DB packages. See `./ai-monitoring.md` |
 | Companion frontend? | Trigger Phase 4 cross-link |
@@ -206,7 +210,7 @@ export default Sentry.withSentry(
 
 #### AI apps: set a conversation ID (required, same edit)
 
-If this Worker makes AI calls (`env.AI.run(...)` or an LLM SDK), `withSentry` gives you `gen_ai` spans automatically — but **never a conversation ID**, so multi-turn chats won't group and Sentry's Conversations view stays empty. This is part of the Workers setup, not a follow-up: add `Sentry.setConversationId()` in the same edit that adds `withSentry`.
+If this Worker makes AI calls (`env.AI.run(...)` or an LLM SDK), `withSentry` gives you `gen_ai` spans automatically — but **never a conversation ID**, so multi-turn chats won't group and Sentry's Conversations view stays empty. This is part of the Workers setup, not a follow-up: add `Sentry.setConversationId()` in the same edit that adds `withSentry`. (Exception: Cloudflare Agents SDK classes wrapped with `instrumentAgentWithSentry` get conversation IDs automatically, v10.69.0+ — see `./durable-objects.md`.)
 
 1. The client generates a stable session ID once per chat session (e.g. `crypto.randomUUID()`) and sends it with every AI request
 2. The handler sets it **before** any AI calls:
@@ -499,13 +503,19 @@ These are registered automatically by `getDefaultIntegrations()`:
 | `dedupeIntegration` | Prevent duplicate events (disabled for Workflows) |
 | `inboundFiltersIntegration` | Filter events by type, message, URL |
 | `functionToStringIntegration` | Preserve original function names |
+| `conversationIdIntegration` | Stamp `gen_ai.conversation.id` (set via `setConversationId`) onto AI spans |
 | `linkedErrorsIntegration` | Follow `cause` chains in errors |
 | `fetchIntegration` | Trace outbound `fetch()` calls, create breadcrumbs |
 | `honoIntegration` | **Deprecated in v10.55.0** — use `@sentry/hono` package instead. Auto-capture Hono `onError` exceptions |
+| `httpServerIntegration` | Incoming HTTP request handling |
 | `requestDataIntegration` | Attach request data to events |
 | `consoleIntegration` | Capture `console.*` calls as breadcrumbs |
 
-> **Not default:** `prismaIntegration` is available on Cloudflare **only** via the `@sentry/cloudflare/nodejs_compat` entrypoint and must be added manually. See `./nodejs-compat.md`.
+> **Not default:** `prismaIntegration` is available on Cloudflare **only** via the `@sentry/cloudflare/nodejs_compat` entrypoint and must be added manually (see `./nodejs-compat.md`). `spotlightIntegration` (v10.69.0+) forwards events to a local [Spotlight](https://spotlightjs.com/) sidecar for local development — add it manually in dev:
+>
+> ```typescript
+> integrations: [Sentry.spotlightIntegration()], // default sidecar: http://localhost:8969/stream
+> ```
 
 ---
 
@@ -589,7 +599,7 @@ Connecting frontend and backend with linked Sentry projects enables **distribute
 | Stack traces show minified code | Source maps not uploaded | Configure `@sentry/vite-plugin` or run `npx @sentry/wizard -i sourcemaps`; verify `SENTRY_AUTH_TOKEN` in CI |
 | Events lost on short-lived requests | SDK not flushing before worker terminates | Ensure `withSentry` or `sentryPagesPlugin` wraps your handler — they use `ctx.waitUntil()` to flush |
 | Hono errors not captured | Hono app not instrumented | Use `@sentry/hono/cloudflare` — import `sentry` middleware and call `app.use(sentry(app, options))` |
-| Durable Object errors missing | DO class not instrumented | Wrap class with `Sentry.instrumentDurableObjectWithSentry()` — see `./durable-objects.md` |
+| Durable Object errors missing | DO class not instrumented | Wrap class with `Sentry.instrumentDurableObjectWithSentry()` (Agents SDK classes: `instrumentAgentWithSentry`, v10.69.0+) — see `./durable-objects.md` |
 | D1 queries not creating spans | Not using the SDK-provided `env`, or accessing DB outside the wrapped handler | Use the `env` passed into your handler — `withSentry` auto-instruments D1 bindings on access. No manual wrapping needed |
 | Spans inside `waitUntil()` missing | Root span already ended before the background task ran | Wrap deferred work in `Sentry.startSpan({ ..., forceTransaction: true }, ...)` — see `./tracing.md` |
 | Traces not linked across RPC / DO calls | RPC trace propagation not enabled | Set `enableRpcTracePropagation: true` on **both** caller and receiver (v10.52.0+) — see `./tracing.md` |

--- a/src/references/sdks/cloudflare/tracing.md
+++ b/src/references/sdks/cloudflare/tracing.md
@@ -6,6 +6,7 @@
 > OpenTelemetry compatibility tracer: v10.x+
 > RPC trace propagation (`enableRpcTracePropagation`): v10.52.0+
 > Workers AI (`env.AI`) `gen_ai` spans: v10.67.0+
+> Agents SDK auto conversation IDs (`instrumentAgentWithSentry`): v10.69.0+
 
 ---
 
@@ -153,7 +154,7 @@ const result = await env.AI.run("@cf/meta/llama-3.1-8b-instruct", {
 
 The Workers AI instrumentation does **not** infer the conversation ID automatically. To group multi-turn AI calls into a single [Conversation](https://docs.sentry.io/product/ai/monitoring/conversations/), set the ID manually with `Sentry.setConversationId(id)`. It's applied as the `gen_ai.conversation.id` attribute to **all AI spans within the current scope**, so call it once at the start of a request handler — before any `env.AI.run(...)` calls — and every AI span for that request is grouped. Pass `null` to unset it.
 
-When you use the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/), each agent instance already has a stable identifier — its Durable Object instance name, `this.name` — which is a natural conversation ID. Set it at the top of the handler (`onRequest` for `Agent`, `onChatMessage` for `AIChatAgent`) so every AI call triggered while handling that message shares the ID:
+When you use the [Cloudflare Agents SDK](https://developers.cloudflare.com/agents/), prefer `instrumentAgentWithSentry` (v10.69.0+) — it sets the conversation ID automatically for every chat turn and `@callable()` RPC call, and rotates it when the chat is cleared. See `./durable-objects.md`. On older SDK versions, or when you need to control the ID yourself, set it manually at the top of the handler (`onRequest` for `Agent`, `onChatMessage` for `AIChatAgent`) so every AI call triggered while handling that message shares the ID. Use your chat session ID — `this.name` works when one agent instance is one chat session, but not when instances are per-user or a shared singleton like `"default"`:
 
 ```typescript
 import * as Sentry from "@sentry/cloudflare";
@@ -178,7 +179,7 @@ class MyChatAgentBase extends AIChatAgent<Env> {
   }
 }
 
-export const MyChatAgent = Sentry.instrumentDurableObjectWithSentry(
+export const MyChatAgent = Sentry.instrumentAgentWithSentry(
   (env: Env) => ({
     dsn: env.SENTRY_DSN,
     tracesSampleRate: 1.0,
@@ -187,7 +188,7 @@ export const MyChatAgent = Sentry.instrumentDurableObjectWithSentry(
 );
 ```
 
-For a plain `Agent`, the pattern is the same — call `Sentry.setConversationId(this.name)` at the top of `onRequest` before your `this.env.AI.run(...)` calls. Grouped calls appear in the [Conversations](https://docs.sentry.io/product/ai/monitoring/conversations/) view, where you can inspect token usage, latency, and errors across the whole conversation.
+(With `instrumentAgentWithSentry` the explicit `setConversationId(this.name)` call above is redundant — shown for the manual/override case.) For a plain `Agent`, the pattern is the same — call `Sentry.setConversationId(id)` at the top of `onRequest` before your `this.env.AI.run(...)` calls. Grouped calls appear in the [Conversations](https://docs.sentry.io/product/ai/monitoring/conversations/) view, where you can inspect token usage, latency, and errors across the whole conversation.
 
 ---
 


### PR DESCRIPTION
Updates the Cloudflare references for [10.69.0](https://github.com/getsentry/sentry-javascript/releases/tag/10.69.0).

The headline: `instrumentAgentWithSentry` for Cloudflare Agents SDK classes — it sets conversation IDs **automatically** (per chat turn and `@callable()` RPC call, rotating on chat clear), which changes the guidance we just added in #302. The Agents section in `durable-objects.md` is rewritten around the new wrapper, and the manual `setConversationId` pattern stays as the pre-10.69 fallback and for custom session IDs.

Also picked up: Vite plugin auto-instruments Agent classes and gains `wranglerConfigPath`, `spotlightIntegration` for local dev, framework-internal DO storage span filtering, and the fix where a Vercel AI SDK call suppressed direct `env.AI.run` spans.

Everything verified against the shipped npm package and the new [agents-sdk docs page](https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/agents-sdk/) — including its warning that conversation IDs should be real chat session IDs, not user IDs or shared instance names.