### PR TITLE
fix(references): resolve every relative link in the built skills

### DIFF
--- a/src/references/concepts/logging.md
+++ b/src/references/concepts/logging.md
@@ -70,4 +70,4 @@ or record an expected validation failure without adding context.
 
 - [`data-scrubbing.md`](data-scrubbing.md)
 - [`reduce-volume.md`](reduce-volume.md)
-- [`search-query-language.md`](search-query-language.md) — querying logs.
+- [`search-query-language.md`](../search-query-language.md) — querying logs.

--- a/src/references/concepts/monitors.md
+++ b/src/references/concepts/monitors.md
@@ -63,4 +63,4 @@ verifying after creation.
 - [`crons.md`](crons.md)
 - [`metrics.md`](metrics.md)
 - [`releases.md`](releases.md)
-- [`search-query-language.md`](search-query-language.md)
+- [`search-query-language.md`](../search-query-language.md)

--- a/src/references/concepts/releases.md
+++ b/src/references/concepts/releases.md
@@ -33,4 +33,4 @@ pollute prod health, and finalize the release + record the deploy at deploy time
 ## Related
 
 - [`monitors.md`](monitors.md) — release-health / crash-rate monitors build on this.
-- [`search-query-language.md`](search-query-language.md) — `release`, `firstRelease`, `release.stage`.
+- [`search-query-language.md`](../search-query-language.md) — `release`, `firstRelease`, `release.stage`.

--- a/src/references/concepts/session-replay.md
+++ b/src/references/concepts/session-replay.md
@@ -27,5 +27,5 @@ own **issues**, so a real UX problem can exist with no exception behind it.
 
 - [`data-scrubbing.md`](data-scrubbing.md)
 - [`reduce-volume.md`](reduce-volume.md)
-- [`search-query-language.md`](search-query-language.md) — replay properties (`count_rage_clicks`,
+- [`search-query-language.md`](../search-query-language.md) — replay properties (`count_rage_clicks`,
   `click.*`, `count_errors`, …).

--- a/src/references/concepts/tracing.md
+++ b/src/references/concepts/tracing.md
@@ -41,4 +41,4 @@ down to the function level.
 
 - [`profiling.md`](profiling.md)
 - [`reduce-volume.md`](reduce-volume.md) — sampling is the main lever.
-- [`search-query-language.md`](search-query-language.md) — span properties for querying traces.
+- [`search-query-language.md`](../search-query-language.md) — span properties for querying traces.

--- a/src/references/concepts/user-feedback.md
+++ b/src/references/concepts/user-feedback.md
@@ -29,4 +29,4 @@ replay-grade masking to screenshots — they capture whatever is on screen.
 
 - [`session-replay.md`](session-replay.md)
 - [`data-scrubbing.md`](data-scrubbing.md)
-- [`search-query-language.md`](search-query-language.md) — user-feedback properties.
+- [`search-query-language.md`](../search-query-language.md) — user-feedback properties.

--- a/src/references/sdks/index.md
+++ b/src/references/sdks/index.md
@@ -32,8 +32,8 @@ Each SDK has a reference tree:
 
 Read `sdks/[sdk]/index.md` **first** — it owns detection, install, the recommended `init`, and a
 feature catalog table that links to each signal's file (and marks unsupported ones). Then read only
-the signal files you need. The exact format both files follow is documented in
-[`STRUCTURE.md`](STRUCTURE.md).
+the signal files you need. The exact format both files follow is documented in `STRUCTURE.md`, an
+internal authoring contract that is not shipped with the skills.
 
 ## Detect the platform first
 

--- a/src/skills/sentry-debug-issue/references.yml
+++ b/src/skills/sentry-debug-issue/references.yml
@@ -1,8 +1,8 @@
 needs:
   - search-query-language.md
-  # Concept docs that help read/understand an issue while debugging: the error and
-  # its attached context (logs/replay/profile/feedback), the trace, and the monitor
-  # types that also create issues (cron missed/failed check-ins, metric thresholds)
-  # plus the Monitors->Issues->Alerts model. Excludes pure setup/strategy docs
-  # (choosing-a-signal, data-scrubbing, reduce-volume, releases).
-  - concepts/{errors,tracing,logging,session-replay,profiling,user-feedback,crons,metrics,monitors}.md
+  # Whole concepts dir. The ones that matter while debugging are the error and its
+  # attached context (logs/replay/profile/feedback), the trace, and the monitor
+  # types that also create issues -- but the concept docs cross-link each other, and
+  # hydration only places files on disk, so taking the dir keeps every link
+  # resolvable at no reading cost. SKILL.md decides what is actually read.
+  - concepts/*.md

--- a/src/skills/sentry-get-started/references.yml
+++ b/src/skills/sentry-get-started/references.yml
@@ -5,8 +5,10 @@ needs:
   - sdks/*/index.md
   - sdks/*/error-monitoring.md
   - sdks/*/tracing.md
-  - concepts/errors.md
-  - concepts/tracing.md
+  # Whole concepts dir + the query grammar so the docs' cross-links resolve;
+  # errors.md and tracing.md are the two this scope actually reads.
+  - concepts/*.md
+  - search-query-language.md
   - first-error-setup.md
   - new-project.md
   - setup-verification.md

--- a/src/skills/sentry-instrument/references.yml
+++ b/src/skills/sentry-instrument/references.yml
@@ -2,8 +2,11 @@ needs:
   # Whole SDK tree (platform is chosen at runtime); STRUCTURE.md is excluded.
   - sdks/index.md
   - sdks/*/*.md
-  - concepts/choosing-a-signal.md
-  - concepts/{errors,tracing,logging,metrics,profiling,session-replay,user-feedback,crons,ai-monitoring}.md
+  # Whole concepts dir + the query grammar: the docs cross-link each other, and
+  # hydration only places files on disk, so presence is free and links resolve.
+  # What the skill actually *reads* is decided by SKILL.md, not by this list.
+  - concepts/*.md
+  - search-query-language.md
   - first-error-setup.md
   - new-project.md
   - setup-verification.md


### PR DESCRIPTION
A reader following a relative link in a shipped skill got nothing, 46 times over. The source tree looks fine — these are only visible after a build, which is how they accumulated.

## Three causes

**1. Manifests were scoped by what a skill reads; links resolve by what is present (33 links).** The concept docs cross-link each other — `data-scrubbing.md`, `reduce-volume.md`, `releases.md`, `monitors.md`, `profiling.md` — so hydrating a hand-picked subset breaks every pointer to an omitted sibling. Hydration only places files on disk, so the subsetting bought nothing and cost 33 links. `sentry-instrument`, `sentry-get-started` and `sentry-debug-issue` now take `concepts/*.md` whole. The reading scope isn't lost — it stays documented in each manifest's comment and enforced where it belongs, in `SKILL.md`.

**2. Six concept docs used a sibling path for a root-level file (10 links).** They linked `search-query-language.md`, which lives at the references root, one level up from `concepts/`. This was broken **in the source tree too**: `concepts/search-query-language.md` has never existed. Now `../search-query-language.md`.

**3. `sdks/index.md` linked `STRUCTURE.md` (3 links).** That's the internal authoring contract, deliberately excluded from every build, so the link could never resolve in a shipped skill. Still mentioned for authors working in the repo, minus the link.

## Verification

Built all four targets from this commit alone and resolved every non-external relative link in each — `claude`, `cursor`, `codex`, `grok`: **0 dangling**, down from 46. Per skill: instrument 21→0, debug-issue 17→0, get-started 7→0. `build-skill-tree.sh --check` passes.

One earlier count of mine was inflated by a checker that didn't strip URL fragments; `cloudflare/durable-objects.md → ./tracing.md#rpc-trace-propagation` resolves fine and is not included here.

## Relationship to #299

`dceee65` there fixes the same class of bug and independently reports the same total of 46 — good corroboration on both the diagnosis and the count. This is the focused version so it can land on its own; whichever goes second should have the other's diff dropped.

What this adds beyond a manifest widening is **cause #2** — six wrong paths in the source that no manifest change can fix, because the target sits at the references root no matter what you hydrate.

## Worth doing next, separately

The build should **fail** on an unresolved link instead of shipping it. Nothing here prevents the next one — these were found only because I ran the check by hand while adding a skill. #299's `check_skill_links` is that guard; if #299 lands in some reduced form, that piece is the one to keep.

## Ordering with #307

#307 adds `debug-artifacts/*.md` to the `needs:` list in `sentry-instrument`/`sentry-get-started`, so it touches the same few lines in those two files. The changes are independent in intent; whichever merges second needs a trivial merge there.