### PR TITLE
fix(ci): validate that every skill link resolves

### DIFF
--- a/.github/workflows/validate-skill-tree.yml
+++ b/.github/workflows/validate-skill-tree.yml
@@ -14,3 +14,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Validate skill tree
         run: ./scripts/build-skill-tree.sh --check
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Validate links in every built plugin tree
+        run: ./scripts/validate-built-links.sh

--- a/scripts/validate-built-links.sh
+++ b/scripts/validate-built-links.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# validate-built-links.sh — Build every agent's plugin and check its links.
+#
+# The skills we ship are only self-contained *after* the build: references are
+# hydrated in from the shared library, and each agent applies its own transform.
+# So the tree worth validating is the built one, per agent — that is what a user
+# installs, and it is the only place a missing reference actually shows up.
+#
+# Each build is well under a second and needs no network or credentials, so this
+# is cheap enough to run on every pull request.
+#
+# Usage: validate-built-links.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+status=0
+
+for build in src/plugins/*/build.sh; do
+    agent="$(basename "$(dirname "$build")")"
+    target="$WORK_DIR/$agent"
+    mkdir -p "$target"
+
+    # Builders are chatty about hydration counts; keep the signal to failures.
+    if ! "$build" "$target" > "$WORK_DIR/$agent.log" 2>&1; then
+        echo "error: $agent build failed" >&2
+        cat "$WORK_DIR/$agent.log" >&2
+        status=1
+        continue
+    fi
+
+    # Agents disagree on layout (Codex nests under plugins/<name>/), so locate
+    # the skills dir by finding where the SKILL.md files actually landed.
+    skills_dir="$(find "$target" -name SKILL.md -exec dirname {} \; \
+        | xargs -n1 dirname | sort -u | head -1)"
+
+    if [[ -z "$skills_dir" ]]; then
+        echo "error: $agent build produced no skills" >&2
+        status=1
+        continue
+    fi
+
+    ./scripts/validate-skill-links.py \
+        --skills "$skills_dir" \
+        --references src/references \
+        --label "$agent" || status=1
+done
+
+exit $status

--- a/scripts/validate-skill-links.py
+++ b/scripts/validate-skill-links.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# ///
+#
+# validate-skill-links.py — Fail the build on a skill link that won't resolve.
+#
+# Every shipped skill must be self-contained: each relative link in its markdown
+# has to point at a file that exists inside that skill's own directory. This
+# runs against a BUILT plugin tree, so what it checks is the artifact users
+# actually install — after reference hydration and after each agent's transform.
+#
+# Checking the built tree rather than the source is what makes this trustworthy.
+# The source tree cannot answer the question on its own: skills link
+# `references/...` paths that only exist once the build hydrates them, so any
+# source-level check has to re-implement the hydrator's glob semantics and can
+# drift from it. Here there is nothing to simulate.
+#
+# Pass --references (the source library) to get a cause rather than a symptom:
+# a link whose target is missing from the built skill but present in the library
+# means the skill's references.yml never declared it, so hydration skipped it.
+# That is the failure mode a manifest makes easy to hit and hard to see.
+#
+# Usage:
+#   uv run --script validate-skill-links.py --skills <built-skills-dir> \
+#       [--references <source-library>] [--label <name>]
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Markdown inline links whose target ends in .md — the only kind that must
+# resolve on disk. Anchors are stripped; external URLs are skipped.
+LINK_RE = re.compile(r"\]\(([^)]+?\.md)(#[^)]*)?\)")
+
+
+def check_skill(skill: Path, references: Path | None) -> list[str]:
+    hydrated_root = (skill / "references").resolve()
+    errors: list[str] = []
+
+    for md in sorted(skill.rglob("*.md")):
+        for target, _anchor in LINK_RE.findall(md.read_text(encoding="utf-8")):
+            if target.startswith(("http://", "https://", "mailto:")):
+                continue
+
+            resolved = (md.parent / target).resolve()
+            if resolved.is_file():
+                continue
+
+            where = f"{md.relative_to(skill.parent)} -> {target}"
+
+            # Missing. If the source library has it, the manifest is the cause.
+            if references is not None:
+                try:
+                    rel = resolved.relative_to(hydrated_root).as_posix()
+                except ValueError:
+                    rel = None
+
+                if rel and (references / rel).is_file():
+                    errors.append(
+                        f"{where}: '{rel}' exists in the reference library but was not "
+                        "hydrated — add it to this skill's references.yml"
+                    )
+                    continue
+
+            errors.append(f"{where}: dangling link (no such file)")
+
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate that every skill link resolves.")
+    parser.add_argument("--skills", type=Path, required=True, help="Built skills dir (one subdir per skill)")
+    parser.add_argument("--references", type=Path, default=None, help="Source reference library, for better diagnostics")
+    parser.add_argument("--label", default="", help="Name for this tree in the summary line")
+    args = parser.parse_args()
+
+    skills = sorted(p for p in args.skills.iterdir() if (p / "SKILL.md").is_file())
+    if not skills:
+        parser.error(f"no skills found under {args.skills}")
+
+    failures = 0
+    for skill in skills:
+        errors = check_skill(skill, args.references)
+        failures += len(errors)
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+
+    label = f"{args.label}: " if args.label else ""
+    print(f"{label}checked links in {len(skills)} built skills, {failures} error(s)")
+    if failures:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**Skill link checking has been silently off.** `build-skill-tree.sh` has a breadcrumb-link check, but it opens by skipping any skill that is neither a router nor categorized:

```bash
# ── (f) Breadcrumb links resolve (router/leaf skills only) ──
if [[ "$role" != "router" && -z "$cat" ]]; then
  continue
fi
```

Every skill is standalone now, so every skill takes that branch and **no link is checked at all**. It wasn't turned off deliberately — the guard was written when standalone skills were the exception, and going flat quietly disabled it for everything. That leaves the failure #308 fixed with nothing guarding against a regression.

### Checking the built tree, not the source

A skill only becomes self-contained once the build hydrates its declared references in, so the source tree can't answer the question on its own — any check there has to re-implement the hydrator's glob semantics and can drift from it. Building first removes the simulation: what gets validated is the tree a user actually installs.

Every agent is built and checked, since layout and transforms differ between them (Codex nests under `plugins/sentry/` and rewrites frontmatter) and a link can survive one while breaking another. The builds need no network or credentials and take well under a second each:

```
claude: checked links in 8 built skills, 0 error(s)
codex: checked links in 8 built skills, 0 error(s)
cursor: checked links in 8 built skills, 0 error(s)
grok: checked links in 8 built skills, 0 error(s)

real	0m3.222s
```

Passing the source library in as well buys a cause instead of a symptom: a target missing from the built skill but present in the library means the manifest never declared it, so the error names `references.yml` instead of reporting a bare dangling link.

### Verified it actually fails

A check that can only pass is the bug being fixed here, so both modes were planted and run through the real build — caught on all four agents, exit 1:

```
error: sentry-debug-issue/SKILL.md -> references/nope/missing.md: dangling link (no such file)
error: sentry-fix-stack-traces/SKILL.md -> references/concepts/monitors.md: 'concepts/monitors.md' exists in the reference library but was not hydrated — add it to this skill's references.yml
```

Runs in the existing validate job, which gains a `uv` install pinned to the same action `deploy-plugins` already uses. `build-skill-tree.sh` is deliberately untouched — the dead router machinery there, including the inert check, is removed separately so this stays reviewable.
