### PR TITLE
ref(mcp): drop the root .mcp.json compat copy

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "sentry": {
-      "type": "http",
-      "url": "https://mcp.sentry.dev/mcp"
-    }
-  }
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,9 +52,6 @@ emit it as `.mcp.json` (Codex’s validator requires the dotted name; Grok auto-
 it).
 Claude declares the server inline in its `plugin.json` (`mcpServers`), so the Claude
 build ships no MCP file.
-The root `.mcp.json` is a backwards-compat copy (identical to `mcp.json`) retained for
-existing installs that consumed the plugin from this repo’s root; keep the two in sync
-until the root compat surface is removed.
 
 ## Releasing the Plugins
 


### PR DESCRIPTION
The root `.mcp.json` was a hand-synced copy of `mcp.json`, kept for installs that consumed the plugin straight from this repo's root. Nothing reads it anymore — the builds are the only consumers of the MCP config, and each one goes to `mcp.json`: Codex and Grok emit their own `.mcp.json` into the built plugin, Cursor takes `mcp.json` as-is, and Claude inlines the server in `plugin.json`.

It had also already drifted: the root copy was still pointing at `https://mcp.sentry.dev/mcp` without the `?utm_source=plugin` tag added in #191, which is exactly the failure mode a second hand-synced copy invites.

Deletes the file and the AGENTS.md paragraph that described keeping the two in sync.