### PR TITLE
ref(installer): build harnesses on demand

### DIFF
--- a/packages/installer/src/harnesses/claude.ts
+++ b/packages/installer/src/harnesses/claude.ts
@@ -1,4 +1,4 @@
-import { realSystem, type OutputSink, type SystemDeps } from "../system";
+import type { OutputSink, SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runCommand, runJson } from "./shell";
 
@@ -74,5 +74,3 @@ export function createClaude(system: SystemDeps): Harness {
     },
   };
 }
-
-export const claude = createClaude(realSystem);

--- a/packages/installer/src/harnesses/codex.ts
+++ b/packages/installer/src/harnesses/codex.ts
@@ -1,4 +1,4 @@
-import { realSystem, type OutputSink, type SystemDeps } from "../system";
+import type { OutputSink, SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runCommand, runJson } from "./shell";
 
@@ -101,5 +101,3 @@ export function createCodex(system: SystemDeps): Harness {
     },
   };
 }
-
-export const codex = createCodex(realSystem);

--- a/packages/installer/src/harnesses/cursor.ts
+++ b/packages/installer/src/harnesses/cursor.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { realSystem, type OutputSink, type SystemDeps } from "../system";
+import type { OutputSink, SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runCommand } from "./shell";
 
@@ -67,5 +67,3 @@ export function createCursor(system: SystemDeps): Harness {
     },
   };
 }
-
-export const cursor = createCursor(realSystem);

--- a/packages/installer/src/harnesses/grok.ts
+++ b/packages/installer/src/harnesses/grok.ts
@@ -1,4 +1,4 @@
-import { realSystem, type OutputSink, type SystemDeps } from "../system";
+import type { OutputSink, SystemDeps } from "../system";
 import type { Harness, InstallOutcome } from "./types";
 import { detectOnPath, runCommand, runJson } from "./shell";
 
@@ -83,5 +83,3 @@ export function createGrok(system: SystemDeps): Harness {
     },
   };
 }
-
-export const grok = createGrok(realSystem);

--- a/packages/installer/src/harnesses/index.ts
+++ b/packages/installer/src/harnesses/index.ts
@@ -1,9 +1,26 @@
-import { claude, createClaude } from "./claude";
-import { codex, createCodex } from "./codex";
-import { cursor, createCursor } from "./cursor";
-import { grok, createGrok } from "./grok";
+import { realSystem } from "../system";
+import { createClaude } from "./claude";
+import { createCodex } from "./codex";
+import { createCursor } from "./cursor";
+import { createGrok } from "./grok";
+import type { Harness } from "./types";
 
 export type { Harness, InstallOutcome } from "./types";
 export { createClaude, createCodex, createCursor, createGrok };
 
-export const harnesses = [claude, codex, cursor, grok];
+/**
+ * Every harness, built against the real system.
+ *
+ * Built on call rather than at module load: the harnesses used to be
+ * module-level constants, which meant importing this barrel constructed all four
+ * as a side effect and left two ways to get one. Now there is a single
+ * construction path.
+ */
+export function buildHarnesses(): Harness[] {
+  return [
+    createClaude(realSystem),
+    createCodex(realSystem),
+    createCursor(realSystem),
+    createGrok(realSystem),
+  ];
+}

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { defineCommand, runMain } from "citty";
-import { harnesses } from "./harnesses";
+import { buildHarnesses } from "./harnesses";
 import { captureAndFlush, initTelemetry } from "./instrument";
 import { runInstaller, runRemover } from "./ui";
 
@@ -61,7 +61,10 @@ const install = defineCommand({
   async run({ args }) {
     const interactive = args.interactive && !args.yes;
     try {
-      const ok = await runInstaller(harnesses, { interactive, instruction: args.instruction });
+      const ok = await runInstaller(buildHarnesses(), {
+        interactive,
+        instruction: args.instruction,
+      });
       process.exit(ok ? 0 : 1);
     } catch (err) {
       // Unexpected error outside the Listr runner: capture and flush before exit
@@ -81,7 +84,7 @@ const remove = defineCommand({
   async run({ args }) {
     const interactive = args.interactive && !args.yes;
     try {
-      const ok = await runRemover(harnesses, { interactive });
+      const ok = await runRemover(buildHarnesses(), { interactive });
       process.exit(ok ? 0 : 1);
     } catch (err) {
       await captureAndFlush(err);


### PR DESCRIPTION
The four harnesses were module-level constants (`export const claude = createClaude(realSystem)`), so importing the barrel constructed all of them as a side effect, and there were two ways to get one: the singleton or the factory it was built from. A caller wanting them configured differently could only use the factories and rebuild the list by hand.

`buildHarnesses()` replaces the constant, leaving a single construction path and no work at import time.

No behavior change — same four harnesses, same order, built against the same `realSystem`. Groundwork for a follow-up that needs to build them with options.