### PR TITLE
fix(installer): clean up a conflicting Claude sentry plugin

### DIFF
--- a/packages/installer/src/__tests__/harnesses.test.ts
+++ b/packages/installer/src/__tests__/harnesses.test.ts
@@ -141,6 +141,27 @@ describe("claude harness", () => {
     expect(system.run).not.toHaveBeenCalledWith(expect.stringContaining("marketplace remove"));
   });
 
+  it("removes the copy installed from our own marketplace", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (isList(cmd) ? claudeList(["sentry@sentry-plugin-marketplace"]) : ok),
+    });
+    const removed = await createClaude(system).cleanup!();
+
+    expect(system.run).toHaveBeenCalledWith(
+      "claude plugin uninstall sentry@sentry-plugin-marketplace",
+    );
+    expect(removed).toContain("sentry@sentry-plugin-marketplace");
+  });
+
+  it("leaves cleanup a no-op when only the official plugin is installed", async () => {
+    const system = fakeSystem({
+      run: (cmd) => (isList(cmd) ? claudeList(["sentry@claude-plugins-official"]) : ok),
+    });
+
+    expect(await createClaude(system).cleanup!()).toBeNull();
+    expect(system.run).not.toHaveBeenCalledWith(expect.stringContaining("uninstall"));
+  });
+
   it("surfaces stderr when install fails", async () => {
     const harness = createClaude(
       fakeSystem({ run: () => ({ ok: false, stderr: "boom", message: "exit 1" }) }),

--- a/packages/installer/src/harnesses/claude.ts
+++ b/packages/installer/src/harnesses/claude.ts
@@ -9,6 +9,13 @@ const INSTALL_COMMAND = `claude plugin install ${PLUGIN_ID}`;
 const UPDATE_COMMAND = `claude plugin update ${PLUGIN_ID}`;
 const UNINSTALL_COMMAND = `claude plugin uninstall ${PLUGIN_ID}`;
 
+// Our plugin reaches Claude two ways: Anthropic's official catalog above, which is
+// what the installer uses, and our own catalog under the marketplace name it
+// declares. Both resolve to the same repository, so a machine carrying both runs
+// two plugins serving the same skills.
+const OUR_MARKETPLACE = "sentry-plugin-marketplace";
+const OUR_PLUGIN_ID = `sentry@${OUR_MARKETPLACE}`;
+
 // `claude plugin list --json` emits an array of installed plugins. We only care
 // about the marketplace-qualified id of each entry.
 interface ClaudePlugin {
@@ -21,9 +28,9 @@ interface ClaudeMarketplace {
   name?: string;
 }
 
-async function isSentryInstalled(system: SystemDeps): Promise<boolean> {
+async function hasPlugin(system: SystemDeps, pluginId: string): Promise<boolean> {
   const plugins = await runJson<ClaudePlugin[]>(system, "claude plugin list --json");
-  return Array.isArray(plugins) && plugins.some((plugin) => plugin.id === PLUGIN_ID);
+  return Array.isArray(plugins) && plugins.some((plugin) => plugin.id === pluginId);
 }
 
 async function isMarketplaceRegistered(system: SystemDeps): Promise<boolean> {
@@ -52,9 +59,18 @@ export function createClaude(system: SystemDeps): Harness {
 
     detect: async () => detectOnPath(system, "claude"),
 
-    isInstalled: async () => isSentryInstalled(system),
+    isInstalled: async () => hasPlugin(system, PLUGIN_ID),
 
     canInstall: async () => ({ ok: true }),
+
+    cleanup: async (output) => {
+      if (!(await hasPlugin(system, OUR_PLUGIN_ID))) {
+        return null;
+      }
+
+      await runCommand(system, `claude plugin uninstall ${OUR_PLUGIN_ID}`, output);
+      return `Removed conflicting plugin ${OUR_PLUGIN_ID}`;
+    },
 
     install: async (output): Promise<InstallOutcome> => {
       await ensureMarketplace(system, output);


### PR DESCRIPTION
Claude was the only harness with no `cleanup` hook, so nothing stopped a second `sentry` plugin from resolving alongside the one the installer manages.

Our plugin is installable from two marketplaces under two ids. The installer uses Anthropic's official catalog (`sentry@claude-plugins-official`), which pins `getsentry/plugin-claude` — but adding our own catalog by hand gives `sentry@sentry-plugin-marketplace` from the same repo, and Claude will hold both. Two plugins then serve the same skills and both resolve. I have exactly that: ours enabled, the official one disabled, so the installer manages one plugin while a different one is live.

This removes the copy the installer does not manage, before installing. The check is just whether the other id is present, so it is a no-op for anyone who only ever ran the installer.

`isSentryInstalled` becomes `hasPlugin(system, pluginId)` so one listing can be checked for either id.

## How this relates to the other harnesses' cleanups

Not by doing the same thing — worth being precise, because the direction differs:

| Harness | The two copies are | Cleanup removes | Keeps |
| --- | --- | --- | --- |
| Codex | different plugins — OpenAI's own vs ours | the vendor's `sentry@openai-curated` | ours, via our marketplace |
| Grok | the same plugin, two delivery paths | the vendor-catalog delivery | the direct-repo install |
| Claude (this PR) | the same plugin, two delivery paths | our marketplace delivery | the vendor-catalog install |

Claude is the inverse of Grok for an identical situation, since both vendors catalog our own repo. That is not a preference: Grok's marketplace install is TUI-only, so its direct-repo install is a workaround with a standing TODO to switch once it is headless — at which point Grok's direction would flip to match Claude's.

The rule all three share is weaker but real: **keep whatever the harness's `install` produces and evict every other `sentry`.** Today each harness open-codes that; #320 expresses it once, which is why it needs this hook to exist.

**Scope, honestly:** the installer has always installed Claude from Anthropic's marketplace — that source has been in `claude.ts` since the first installer commit (#180) — so this is not repairing a migration the installer caused. The duplicate comes from a manual `marketplace add`, which in practice means people developing on this repo.

Stacked on #321.
