### PR TITLE
feat(dist): add portable Agent Plugin distribution

### DIFF
--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -5,10 +5,11 @@
 # shape, so this workflow builds each one and deploys it to a dedicated
 # repository whose ROOT is exactly that agent's plugin:
 #
-#   claude -> getsentry/plugin-claude
-#   cursor -> getsentry/plugin-cursor
-#   codex  -> getsentry/plugin-codex
-#   grok   -> getsentry/plugin-grok
+#   agent-plugin -> getsentry/agent-plugin
+#   claude       -> getsentry/plugin-claude
+#   cursor       -> getsentry/plugin-cursor
+#   codex        -> getsentry/plugin-codex
+#   grok         -> getsentry/plugin-grok
 #
 # Each plugin repository carries two rolling branches, and which one a run writes
 # is the whole difference between a deploy and a release:
@@ -25,9 +26,9 @@
 # A release also tags the plugin repository (`v<version>`), giving each shipped
 # version an addressable ref for pinning and rollback.
 #
-# Marketplaces consume `getsentry/plugin-<agent>` by git ref. Each job builds its
-# agent's tree from this repo, then commits it onto the target branch of the
-# target repo, replacing the previous contents. The four jobs target four
+# Consumers install a distribution repository by git ref. Each job builds its
+# distribution tree from this repo, then commits it onto the target branch of the
+# target repo, replacing the previous contents. The five jobs target five
 # different repos, so they run in parallel without contention.
 #
 # Cross-repo writes use a GitHub App token scoped per-job to a single plugin
@@ -83,9 +84,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        agent: [claude, cursor, codex, grok]
+        include:
+          - distribution: agent-plugin
+            repository: agent-plugin
+          - distribution: claude
+            repository: plugin-claude
+          - distribution: cursor
+            repository: plugin-cursor
+          - distribution: codex
+            repository: plugin-codex
+          - distribution: grok
+            repository: plugin-grok
     concurrency:
-      group: deploy-plugin-${{ matrix.agent }}-${{ inputs.target_branch || 'develop' }}
+      group: deploy-${{ matrix.repository }}-${{ inputs.target_branch || 'develop' }}
       cancel-in-progress: false
     steps:
       - name: Checkout source
@@ -103,21 +114,21 @@ jobs:
           app-id: ${{ vars.PLUGIN_DEPLOY_APP_ID }}
           private-key: ${{ secrets.PLUGIN_DEPLOY_KEY }}
           owner: getsentry
-          repositories: plugin-${{ matrix.agent }}
+          repositories: ${{ matrix.repository }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
-      - name: Build and deploy plugin-${{ matrix.agent }}
+      - name: Build and deploy ${{ matrix.repository }}
         env:
-          AGENT: ${{ matrix.agent }}
+          DISTRIBUTION: ${{ matrix.distribution }}
+          TARGET_REPO: ${{ matrix.repository }}
           TARGET_BRANCH: ${{ inputs.target_branch || 'develop' }}
           DIST_TAG: ${{ inputs.dist_tag || '' }}
           GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           set -euo pipefail
 
-          TARGET_REPO="plugin-${AGENT}"
           WORKTREE="$(mktemp -d)/dist"
 
           # Read the built commit out of the checkout rather than github.sha,
@@ -149,11 +160,11 @@ jobs:
           # Rewrite the whole tree: clear tracked content (preserve the .git
           # dir), then repopulate from source via the agent's build script.
           git -C "$WORKTREE" rm -rfq --ignore-unmatch .
-          "src/plugins/${AGENT}/build.sh" "$WORKTREE"
+          "src/plugins/${DISTRIBUTION}/build.sh" "$WORKTREE"
 
           # Validate the built tree against the agent's schema/validator before
           # it can be deployed.
-          "src/plugins/${AGENT}/validate.sh" "$WORKTREE"
+          "src/plugins/${DISTRIBUTION}/validate.sh" "$WORKTREE"
 
           # Commit only if something changed.
           git -C "$WORKTREE" add -A

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -1,7 +1,7 @@
 # Cut a plugin release: bump the shared version, tag it here, then publish the
 # tagged tree onto each plugin repository's `main` and tag it there too.
 #
-# The four agent plugins version in lockstep from src/plugins/version.json, which
+# The five plugin distributions version in lockstep from src/plugins/version.json, which
 # the builds stamp into every manifest, so a release is one bump commit and one
 # tag. Tags here are named `plugin/v*` to keep them clear of the installer's npm
 # releases, which craft owns separately via .craft.yml.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 > [!IMPORTANT]
 > **This is a skill *source* repository — not something you install directly.** The
-> skills here are built from this source into installable plugins for
-> [Claude Code](https://github.com/getsentry/plugin-claude),
+> skills here are built from this source into a portable
+> [Agent Plugin](https://github.com/getsentry/agent-plugin) and installable
+> client-specific plugins for [Claude Code](https://github.com/getsentry/plugin-claude),
 > [Cursor](https://github.com/getsentry/plugin-cursor),
 > [Codex](https://github.com/getsentry/plugin-codex), and
 > [Grok](https://github.com/getsentry/plugin-grok) — install one of those, not this
@@ -20,7 +21,8 @@ Whether you’re adding Sentry to a new project, debugging a spike in errors, or
 configuring alerts, just ask.
 The plugin gives your assistant the context it needs to do it right.
 
-Supports [**Claude Code**](https://github.com/getsentry/plugin-claude),
+Supports the [**Agent Plugins standard**](https://agent-plugins.org/),
+[**Claude Code**](https://github.com/getsentry/plugin-claude),
 [**Cursor**](https://github.com/getsentry/plugin-cursor),
 [**Codex**](https://github.com/getsentry/plugin-codex), and
 [**Grok**](https://github.com/getsentry/plugin-grok).
@@ -73,6 +75,7 @@ its own **distribution repository**, whose root is exactly that agent’s plugin
 
 | Agent | Distribution repository |
 | --- | --- |
+| Agent Plugins 1.0.0 | [`getsentry/agent-plugin`](https://github.com/getsentry/agent-plugin) |
 | Claude Code | [`getsentry/plugin-claude`](https://github.com/getsentry/plugin-claude) |
 | Cursor | [`getsentry/plugin-cursor`](https://github.com/getsentry/plugin-cursor) |
 | Codex | [`getsentry/plugin-codex`](https://github.com/getsentry/plugin-codex) |
@@ -94,11 +97,11 @@ skill tree’s `disable-model-invocation` flags for Codex’s `agents/openai.yam
 ```bash
 git clone https://github.com/getsentry/sentry-for-ai.git
 cd sentry-for-ai
-src/plugins/codex/build.sh /tmp/sentry-codex   # or src/plugins/{claude,cursor,grok}
+src/plugins/agent-plugin/build.sh /tmp/sentry-agent-plugin
 ```
 
-To build any target locally, run `src/plugins/<agent>/build.sh <output-dir>` (`claude`,
-`cursor`, `codex`, or `grok`).
+To build any target locally, run `src/plugins/<agent>/build.sh <output-dir>`
+(`agent-plugin`, `claude`, `cursor`, `codex`, or `grok`).
 
 ## Skills
 

--- a/scripts/build-common.sh
+++ b/scripts/build-common.sh
@@ -50,7 +50,7 @@ copy_skill_tree() {
 
 # Write an agent's plugin manifest to its built location with the release version
 # stamped over the `0.0.0` placeholder the source manifests carry.
-# src/plugins/version.json holds the single value, so the four plugins version in
+# src/plugins/version.json holds the single value, so all distributions version in
 # lockstep and a release bumps one file.
 #
 # Set PLUGIN_VERSION to stamp something else. The develop deploy uses it to label

--- a/src/plugins/agent-plugin/README.md
+++ b/src/plugins/agent-plugin/README.md
@@ -1,0 +1,24 @@
+# Sentry Agent Plugin
+
+The portable Sentry plugin conforming to the
+[Agent Plugins 1.0.0 specification](https://agent-plugins.org/specification).
+It teaches compatible clients how to set up Sentry, debug production issues, and
+configure application monitoring.
+
+> [!IMPORTANT]
+> This repository is generated.
+> It is built from [getsentry/sentry-for-ai](https://github.com/getsentry/sentry-for-ai)
+> and includes every skill in that library.
+> Do not edit files here; make changes in that repository and they will be rebuilt into
+> this one.
+
+## Install
+
+Install `getsentry/agent-plugin` using an
+[Agent Plugins-compatible client](https://agent-plugins.org/clients).
+
+## What’s included
+
+- The full, hydrated Sentry skill library as standard Agent Skills.
+- The hosted [Sentry MCP server](https://mcp.sentry.dev) configured with the standard
+  Streamable HTTP transport.

--- a/src/plugins/agent-plugin/build.sh
+++ b/src/plugins/agent-plugin/build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# build.sh — Build the portable Agent Plugins distribution of Sentry.
+#
+# Agent Plugins 1.0.0 discovers its manifest, skills, and MCP configuration at
+# fixed locations in the plugin root. Shared references are hydrated so every
+# emitted Agent Skill is self-contained.
+#
+# Usage: build.sh <TARGET_DIR>   (TARGET_DIR assumed empty)
+
+set -euo pipefail
+
+TARGET_DIR="${1:?usage: build.sh <TARGET_DIR>}"
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SRC_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+source "$REPO_ROOT/scripts/build-common.sh"
+resolve_content_root "$REPO_ROOT/src"
+
+mkdir -p "$TARGET_DIR"
+
+install_plugin_manifest "$SRC_DIR/plugin.json" "$TARGET_DIR/plugin.json"
+copy_skills "$CONTENT_ROOT" "$TARGET_DIR/skills"
+cp "$SRC_DIR/mcp.json" "$TARGET_DIR/mcp.json"
+cp "$SRC_DIR/README.md" "$TARGET_DIR/README.md"
+cp LICENSE "$TARGET_DIR/LICENSE"
+
+echo "Built Agent Plugins dist into $TARGET_DIR (root plugin, content from $CONTENT_ROOT)."

--- a/src/plugins/agent-plugin/mcp.json
+++ b/src/plugins/agent-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
+  "mcpServers": {
+    "sentry": {
+      "type": "streamable-http",
+      "url": "https://mcp.sentry.dev/mcp?utm_source=plugin"
+    }
+  }
+}

--- a/src/plugins/agent-plugin/plugin.json
+++ b/src/plugins/agent-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "sentry",
+  "version": "0.0.0",
+  "description": "Set up Sentry, debug production issues, and configure application monitoring.",
+  "author": {
+    "name": "Sentry",
+    "url": "https://sentry.io"
+  },
+  "homepage": "https://sentry.io",
+  "repository": "https://github.com/getsentry/agent-plugin",
+  "license": "MIT",
+  "keywords": ["sentry", "debugging", "monitoring", "error-tracking"]
+}

--- a/src/plugins/agent-plugin/validate.sh
+++ b/src/plugins/agent-plugin/validate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+#
+# validate.sh — Validate the portable Agent Plugins distribution.
+#
+# The published schemas enforce the closed manifest and MCP configuration
+# shapes. Structural checks enforce package containment and the Agent Skills
+# frontmatter and naming constraints against the emitted, hydrated skills.
+#
+# Usage: validate.sh <TARGET_DIR>   (a tree produced by build.sh)
+
+set -euo pipefail
+
+TARGET_DIR="${1:?usage: validate.sh <TARGET_DIR>}"
+SCHEMA_BASE="https://agent-plugins.org/schemas/1.0.0"
+
+uvx check-jsonschema --schemafile "$SCHEMA_BASE/plugin.schema.json" \
+    "$TARGET_DIR/plugin.json"
+uvx check-jsonschema --schemafile "$SCHEMA_BASE/mcp.schema.json" \
+    "$TARGET_DIR/mcp.json"
+
+python3 - "$TARGET_DIR" <<'PY'
+import pathlib
+import re
+import sys
+
+root = pathlib.Path(sys.argv[1]).resolve(strict=True)
+
+for required, kind in (("plugin.json", "file"), ("mcp.json", "file"), ("skills", "directory")):
+    path = root / required
+    valid = path.is_file() if kind == "file" else path.is_dir()
+    if not valid:
+        raise SystemExit(f"{required} must be a {kind}")
+    if not path.resolve().is_relative_to(root):
+        raise SystemExit(f"{required} resolves outside the plugin root")
+
+for path in root.rglob("*"):
+    if not path.resolve().is_relative_to(root):
+        raise SystemExit(f"package path resolves outside the plugin root: {path}")
+
+skills = root / "skills"
+for skill in skills.iterdir():
+    if not skill.is_dir():
+        continue
+
+    definition = skill / "SKILL.md"
+    if not definition.is_file():
+        continue
+    if not definition.resolve().is_relative_to(root):
+        raise SystemExit(f"SKILL.md resolves outside the plugin root: {skill.name}")
+
+    lines = definition.read_text().splitlines()
+    if not lines or lines[0] != "---":
+        raise SystemExit(f"SKILL.md has no YAML frontmatter: {skill.name}")
+
+    try:
+        end = lines.index("---", 1)
+    except ValueError:
+        raise SystemExit(f"SKILL.md has unterminated YAML frontmatter: {skill.name}")
+
+    fields = {}
+    for line in lines[1:end]:
+        match = re.match(r"^([a-z-]+):(?:\s+(.*))?$", line)
+        if match:
+            fields[match.group(1)] = match.group(2) or ""
+
+    name = fields.get("name", "")
+    description = fields.get("description", "")
+    if name != skill.name:
+        raise SystemExit(f"skill name must match its directory: {skill.name}")
+    if not re.fullmatch(r"(?!.*--)[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?", name):
+        raise SystemExit(f"invalid Agent Skill name: {name!r}")
+    if not 1 <= len(description) <= 1024:
+        raise SystemExit(f"skill description must be 1-1024 characters: {skill.name}")
+    if not any(line.strip() for line in lines[end + 1:]):
+        raise SystemExit(f"SKILL.md body is empty: {skill.name}")
+PY
+
+echo "Validated Agent Plugins dist at $TARGET_DIR."


### PR DESCRIPTION
Publish the shared Sentry skill library as a vendor-neutral Agent Plugins 1.0.0 package alongside the existing client-specific distributions.

The new build emits the required root-level `plugin.json`, hydrated Agent Skills under `skills/`, and a standard `mcp.json` using the Streamable HTTP transport. Validation covers the canonical manifest and MCP schemas, package containment, and Agent Skills discovery and frontmatter constraints.

The deploy matrix now maps distribution names to repository names explicitly, publishing this distribution to `getsentry/agent-plugin` while preserving the existing `getsentry/plugin-*` repositories. The new repository must exist and permit access from the plugin deployment GitHub App before the deploy workflow runs.