### PR TITLE
ref(installer): rename the npm package to @sentry/agent-plugin

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -1,4 +1,4 @@
-# Releases packages/installer to npm as @sentry/ai via craft.
+# Releases packages/installer to npm as @sentry/agent-plugin via craft.
 minVersion: "2.21.0"
 # Single segment only -- craft splits the branch name on the first "/".
 releaseBranchPrefix: release-installer
@@ -12,9 +12,9 @@ changelog:
 # No github target, so no git tags or GitHub releases.
 targets:
   - name: npm
-    id: "@sentry/ai"
+    id: "@sentry/agent-plugin"
     access: public
-    includeNames: /^sentry-ai-\d.*\.tgz$/
+    includeNames: /^sentry-agent-plugin-\d.*\.tgz$/
 
 requireNames:
-  - /^sentry-ai-\d.*\.tgz$/
+  - /^sentry-agent-plugin-\d.*\.tgz$/

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm --filter @sentry/ai build
+        run: pnpm --filter @sentry/agent-plugin build
 
       - name: Pack tarball
         working-directory: packages/installer

--- a/.github/workflows/smoke-installer.yml
+++ b/.github/workflows/smoke-installer.yml
@@ -55,7 +55,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: pnpm --filter @sentry/ai build
+        run: pnpm --filter @sentry/agent-plugin build
 
       - name: Install Claude Code, Codex, and Grok CLIs
         run: npm install -g @anthropic-ai/claude-code @openai/codex @xai-official/grok

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -10,7 +10,7 @@ When plugin-distributed MCP configs connect to
 `app.utm_source:plugin`. Query the `sentry/mcp-server` project to measure plugin-driven
 adoption, tool usage, and error rates.
 
-The installer package (`npx @sentry/ai`) reports to a separate Sentry project
+The installer package (`npx @sentry/agent-plugin`) reports to a separate Sentry project
 (`sentry/sentry-for-ai-installer`). That surface is diagnostic only — it captures
 crashes and uncaught errors, not install counts or per-agent outcomes.
 
@@ -202,8 +202,8 @@ Attributes: `gen_ai.tool.name`, `mcp.tool.name`, `mcp.session.id`, `user.id`,
 
 ### Installer CLI
 
-The `npx @sentry/ai install` CLI reports to `sentry/sentry-for-ai-installer`. Currently
-only default `@sentry/node` auto-instrumentation is active.
+The `npx @sentry/agent-plugin install` CLI reports to `sentry/sentry-for-ai-installer`.
+Currently only default `@sentry/node` auto-instrumentation is active.
 
 Use for: diagnosing installer crashes and unhandled errors.
 

--- a/packages/installer/README.md
+++ b/packages/installer/README.md
@@ -1,4 +1,4 @@
-# @sentry/ai
+# @sentry/agent-plugin
 
 Install the [Sentry plugin](https://github.com/getsentry/sentry-for-ai) into your AI
 coding assistants.
@@ -11,11 +11,11 @@ one for you.
 Supports **Claude Code**, **Codex**, **Cursor**, and **Grok**.
 
 ```bash
-npx @sentry/ai install
+npx @sentry/agent-plugin install
 ```
 
 <picture> <source media="(prefers-color-scheme: dark)" srcset="assets/demo-dark.gif">
-<img src="assets/demo-light.gif" alt="Installing the Sentry plugin with npx @sentry/ai install">
+<img src="assets/demo-light.gif" alt="Installing the Sentry plugin with npx @sentry/agent-plugin install">
 </picture>
 
 This detects the AI coding tools on your machine, lets you choose which ones to set up,
@@ -28,9 +28,9 @@ Restart your AI tools afterward to load the plugin.
 ## Options
 
 ```bash
-npx @sentry/ai install                         # interactive — pick which agents to set up
-npx @sentry/ai install "Setup logging"         # copy a custom prompt after installation
-npx @sentry/ai install --no-interactive        # install into every detected agent
+npx @sentry/agent-plugin install                   # interactive — pick which agents to set up
+npx @sentry/agent-plugin install "Setup logging"   # copy a custom prompt after installation
+npx @sentry/agent-plugin install --no-interactive  # install into every detected agent
 ```
 
 When an instruction follows `install`, the installer offers to copy a prompt such as
@@ -56,8 +56,8 @@ source of truth for all skills.
 ## Removing the plugin
 
 ```bash
-npx @sentry/ai remove                  # interactive — pick which agents to remove from
-npx @sentry/ai remove --no-interactive # remove from every agent that has it
+npx @sentry/agent-plugin remove                  # interactive — pick which agents to remove from
+npx @sentry/agent-plugin remove --no-interactive # remove from every agent that has it
 ```
 
 `uninstall` is an alias for `remove`. This only offers agents that currently have the

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@sentry/ai",
+  "name": "@sentry/agent-plugin",
   "version": "0.1.0",
   "description": "Install the Sentry plugin for your AI coding assistants",
   "repository": {
@@ -21,7 +21,7 @@
     "node": ">=18.0.0"
   },
   "bin": {
-    "sentry-ai": "dist/index.js"
+    "sentry-agent-plugin": "dist/index.js"
   },
   "scripts": {
     "build": "rolldown --config rolldown.config.mjs",

--- a/packages/installer/src/index.ts
+++ b/packages/installer/src/index.ts
@@ -92,7 +92,7 @@ const remove = defineCommand({
 
 const main = defineCommand({
   meta: {
-    name: "sentry-ai",
+    name: "sentry-agent-plugin",
     version,
     description,
   },
@@ -108,7 +108,7 @@ const main = defineCommand({
 const SUBCOMMANDS = new Set(["install", "remove", "uninstall"]);
 const PASSTHROUGH = new Set(["--help", "-h", "--version"]);
 
-// citty has no concept of a default subcommand, so `npx @sentry/ai` with no
+// citty has no concept of a default subcommand, so `npx @sentry/agent-plugin` with no
 // arguments would just print the help menu. Default to `install` instead unless
 // the user gave an explicit subcommand or asked for help/version.
 function withDefaultCommand(argv: string[]): string[] {


### PR DESCRIPTION
Renames the published installer from `@sentry/ai` to `@sentry/agent-plugin`, so the command names what it does rather than reading as a Sentry AI product.

The tarball basename is derived from the package name, so craft's `includeNames` and `requireNames` patterns move with it. Worth calling out because a stale pattern doesn't fail at `craft prepare` — it matches nothing and the release dies later, at publish. Verified locally that `pnpm pack` now emits `sentry-agent-plugin-0.1.0.tgz`, which the new pattern matches.

The bin is renamed alongside it. The package ships exactly one bin, so `npx @sentry/agent-plugin` resolves it regardless of the name it's registered under.

The 0.1.0 changelog entry still says `@sentry/ai` — that release genuinely was named that.

Two things this does not do, both of which need `@sentry/agent-plugin` to exist on the registry first:

- `@sentry/ai` stays live at 0.2.0 and keeps installing plugins for anyone who has the old command memorized or reads it from docs. It wants `npm deprecate` plus a final stub release pointing at the new name — a deprecation warning scrolls past in `npx` output, so the stub is the part that actually redirects people.
- References outside this repo (docs.sentry.io, anything publishing the install command) still say `@sentry/ai`.

Also worth confirming before the release runs: craft's npm token needs to be able to *create* a new package under the `@sentry` scope, not just publish to one that already exists.