### PR TITLE
release: add 0.3.0 changelog entry

### DIFF
--- a/packages/installer/CHANGELOG.md
+++ b/packages/installer/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.0
+
+- Rename the package to `@sentry/agent-plugin`. Install with
+  `npx @sentry/agent-plugin install`. `@sentry/ai` stays on npm at 0.2.0 and no longer
+  receives updates.
+- Remove the Claude plugin left behind by our own marketplace, so a hand-added copy and
+  the installer-managed one no longer both resolve to the same skills.
+
 ## 0.2.0
 
 - Accept an optional install instruction and include it in the prompt offered for


### PR DESCRIPTION
Craft's `simple` changelog policy requires a section matching the version being released — `findChangeset` is called with `fallbackToUnreleased = false` for anything that isn't `auto`, so `craft prepare 0.3.0` throws `No changelog entry found for version "0.3.0"` without this. Same shape as #297 for 0.2.0.

Covers the two user-facing changes since 0.2.0: the package rename, and the conflicting-Claude-plugin cleanup from #322. #321 (build harnesses on demand) is an internal refactor with no user-visible effect, so it gets no entry.