### PR TITLE
fix(dist): link the real Agent Plugins clients page

### DIFF
--- a/src/plugins/agent-plugin/README.md
+++ b/src/plugins/agent-plugin/README.md
@@ -15,7 +15,7 @@ configure application monitoring.
 ## Install
 
 Install `getsentry/agent-plugin` using an
-[Agent Plugins-compatible client](https://agent-plugins.org/clients).
+[Agent Plugins-compatible client](https://agent-plugins.org/compatible-clients).
 
 ## What’s included
 


### PR DESCRIPTION
The Agent Plugin README pointed its install instructions at `https://agent-plugins.org/clients`, which 404s. The page that lists compatible clients is `/compatible-clients`.