### PR TITLE
docs(cocoa): Remove obsolete logging and metrics options

### DIFF
--- a/src/references/sdks/cocoa/index.md
+++ b/src/references/sdks/cocoa/index.md
@@ -3,8 +3,7 @@
 Opinionated wizard that scans your Apple project and guides you through complete Sentry
 setup.
 
-> **Note:** SDK versions and APIs below reflect Sentry docs at time of writing
-> (sentry-cocoa 9.15.0). Always verify against
+> **Note:** This guidance targets sentry-cocoa 9.27.0+. Always verify against
 > [docs.sentry.io/platforms/apple/](https://docs.sentry.io/platforms/apple/) before
 > implementing.
 
@@ -121,7 +120,7 @@ https://github.com/getsentry/sentry-cocoa.git
 
 Or in `Package.swift`:
 ```swift
-.package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.15.0"),
+.package(url: "https://github.com/getsentry/sentry-cocoa", from: "9.27.0"),
 ```
 
 **SPM Products** — choose **exactly one** per target:
@@ -147,7 +146,7 @@ manifest):
 // Package.swift (Swift 6.1+)
 .package(
     url: "https://github.com/getsentry/sentry-cocoa",
-    from: "9.15.0",
+    from: "9.27.0",
     traits: ["NoUIFramework"]
 ),
 
@@ -255,12 +254,6 @@ struct MyApp: App {
             // Session Replay. Keep production sampling conservative and verify masking on iOS 26+.
             options.sessionReplay.sessionSampleRate = 0.1
             options.sessionReplay.onErrorSampleRate = 1.0
-
-            // Logging (SDK 9.0.0+ top-level; use options.experimental.enableLogs in 8.x)
-            options.enableLogs = true
-
-            // Metrics are enabled by default in SDK 9.12+. Set false only to opt out.
-            options.enableMetrics = true
         }
     }
 
@@ -305,12 +298,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             options.sessionReplay.sessionSampleRate = 0.1
             options.sessionReplay.onErrorSampleRate = 1.0
-
-            // Logging (SDK 9.0.0+ top-level; use options.experimental.enableLogs in 8.x)
-            options.enableLogs = true
-
-            // Metrics are enabled by default in SDK 9.12+. Set false only to opt out.
-            options.enableMetrics = true
         }
         return true
     }
@@ -372,8 +359,8 @@ For each feature: `Read ./<feature>.md`, follow steps exactly, verify it works.
 | `onLastRunStatusDetermined` | `Closure` | `nil` | Called after SDK determines previous launch crash status |
 | `strictTraceContinuation` | `Bool` | `false` | Reject incoming traces from other orgs; validates `sentry-org_id` in baggage headers (sentry-cocoa ≥9.10.0) |
 | `orgId` | `String?` | `nil` | Organization ID for strict trace validation; auto-parsed from DSN host (e.g. `o123.ingest.sentry.io` → `"123"`) if not set explicitly |
-| `enableLogs` | `Bool` | `false` | Enable structured logs |
-| `enableMetrics` | `Bool` | `true` | Enable Swift Metrics API (SDK 9.12+) |
+| `beforeSendLog` | `Closure` | `nil` | Filter or drop structured logs before sending |
+| `beforeSendMetric` | `Closure` | `nil` | Filter or drop Swift metrics before sending |
 
 ### Environment Variables
 
@@ -414,8 +401,6 @@ options.configureProfiling = {
 options.sessionReplay.sessionSampleRate = 0.1   // 10% continuous
 options.sessionReplay.onErrorSampleRate = 1.0   // 100% on error (keep high)
 
-options.enableLogs = true
-options.enableMetrics = true             // default true in SDK 9.12+
 options.debug = false                   // never in production
 ```
 

--- a/src/references/sdks/cocoa/index.md
+++ b/src/references/sdks/cocoa/index.md
@@ -168,7 +168,7 @@ platform :ios, '15.0'
 use_frameworks!
 
 target 'YourApp' do
-  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '9.15.0'
+  pod 'Sentry', :git => 'https://github.com/getsentry/sentry-cocoa.git', :tag => '9.27.0'
 end
 ```
 

--- a/src/references/sdks/cocoa/logging.md
+++ b/src/references/sdks/cocoa/logging.md
@@ -1,39 +1,15 @@
 # Logging — Sentry Cocoa SDK
 
-> Minimum SDK (experimental): `sentry-cocoa` v8.55.0+ Minimum SDK (stable):
-> `sentry-cocoa` v9.0.0+
+Requires `sentry-cocoa` v9.27.0+. Logs are enabled by default, so no additional
+configuration is required.
 
 ## Configuration
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `enableLogs` | `Bool` | `false` | Enable structured logging (v9.0.0+, stable) |
-| `experimental.enableLogs` | `Bool` | `false` | Enable structured logging (v8.55.0–8.x, experimental) |
-| `beforeSendLog` | `((SentryLog) -> SentryLog?)?` | `nil` | Filter or modify logs before sending; return `nil` to drop |
+| `beforeSendLog` | `((SentryLog) -> SentryLog?)?` | `nil` | Filter or modify logs before sending. Return `nil` to drop. |
 
 ## Code Examples
-
-### Enable logging
-
-**SDK v9.0.0+ (stable, recommended):**
-
-```swift
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.enableLogs = true
-}
-```
-
-**SDK v8.55.0–8.x (experimental):**
-
-```swift
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.experimental.enableLogs = true
-}
-```
 
 ### All log levels
 
@@ -98,7 +74,6 @@ individual values as queryable attributes.
 
 ```swift
 SentrySDK.start { options in
-    options.enableLogs = true
     options.beforeSendLog = { log in
         // Drop trace-level logs
         if log.level == .trace { return nil }
@@ -160,7 +135,6 @@ import Sentry
 SentrySDK.start { options in
     options.dsn = "___PUBLIC_DSN___"
     options.environment = "production"
-    options.enableLogs = true   // v9.0.0+
     options.beforeSendLog = { log in
         // Drop trace and debug in production
         guard log.level != .trace && log.level != .debug else { return nil }
@@ -199,10 +173,10 @@ SentrySDK.logger.info("User signed in",
 
 | Issue | Solution |
 | --- | --- |
-| Logs not appearing in Sentry | Verify `options.enableLogs = true` (v9+) or `options.experimental.enableLogs = true` (v8.55+) |
+| Logs not appearing in Sentry | Verify `SentrySDK.start` ran and that `beforeSendLog` is not dropping the log |
 | Logs only partially appearing | Logs may be lost during crashes; this is a known SDK limitation |
 | `SentrySDK.logger` not found | Requires v8.55.0+; check SPM/CocoaPods version |
 | Attributes not queryable | Prefer `String`, `Bool`, `Int`, `Double`, `Float`, arrays, or sets; convert complex objects to stable strings |
-| `beforeSendLog` not called | Ensure you set it before `SentrySDK.start` completes and `enableLogs = true` |
+| `beforeSendLog` not called | Ensure you set it during `SentrySDK.start` configuration |
 | Too many logs overwhelming Sentry | Use `beforeSendLog` to filter by level; set minimum level for production |
 | Logs missing user context | Call `SentrySDK.setUser(...)` before logging to attach user identity automatically |

--- a/src/references/sdks/cocoa/metrics.md
+++ b/src/references/sdks/cocoa/metrics.md
@@ -1,8 +1,8 @@
 # Metrics — Sentry Cocoa SDK
 
-> Minimum SDK: experimental in v9.4.0+, generally available in v9.12.0+ Swift only;
+> Minimum SDK: `sentry-cocoa` v9.27.0+. Swift only.
 > Objective-C metrics API is not currently available.
-> Metrics are enabled by default in v9.12.0+.
+> Metrics are enabled by default.
 
 Use metrics for aggregate counters, gauges, and distributions that should not create
 Sentry issues. Do not duplicate automatic tracing, app hangs, MetricKit diagnostics, or
@@ -12,25 +12,14 @@ error events.
 
 | Option | Type | Default | Description |
 | --- | --- | --- | --- |
-| `enableMetrics` | `Bool` | `true` | Enable or disable metrics |
-| `beforeSendMetric` | `((SentryMetric) -> SentryMetric?)?` | `nil` | Filter or mutate metrics before send; return `nil` to drop |
-
-For SDK 9.4.0-9.11.x, metrics used `options.experimental.enableMetrics` and
-`options.experimental.beforeSendMetric`. Those experimental options were removed in
-9.12.0; use the top-level options above.
+| `beforeSendMetric` | `((SentryMetric) -> SentryMetric?)?` | `nil` | Filter or mutate metrics before send. Return `nil` to drop. |
 
 ## Code Examples
 
 ### Basic setup
 
-```swift
-import Sentry
-
-SentrySDK.start { options in
-    options.dsn = "___PUBLIC_DSN___"
-    options.enableMetrics = true  // default in SDK 9.12+
-}
-```
+Metrics are enabled by default.
+Call the `SentrySDK.metrics` API to record them.
 
 ### Counter
 
@@ -121,15 +110,15 @@ scrubbed and useful for grouping.
   for occurrences.
 - Avoid metrics that duplicate automatic spans, failed request events, app hangs,
   watchdog terminations, or MetricKit diagnostics.
-- Keep `enableMetrics = true` unless the app has a policy or volume reason to disable
-  metrics.
+- Use `beforeSendMetric` to drop metrics that do not meet the app’s policy or volume
+  requirements.
 
 ## Troubleshooting
 
 | Issue | Solution |
 | --- | --- |
-| `enableMetrics` compile error | Requires SDK 9.12+; on 9.4-9.11 use `experimental.enableMetrics` or upgrade |
-| Metric not sent | Verify `SentrySDK.start` ran and `enableMetrics` is true |
+| `enableMetrics` compile error | Removed in SDK 9.27.0. Metrics are enabled by default. |
+| Metric not sent | Verify `SentrySDK.start` ran and that `beforeSendMetric` is not dropping the metric |
 | Count with `unit` fails | `count` has no `unit` parameter; use `gauge` or `distribution` if units are needed |
 | Objective-C compile issue | Metrics are Swift-only |
 | Too many unique series | Reduce high-cardinality attributes and metric names |


### PR DESCRIPTION
Update the hydrated Cocoa references used by the Apple setup workflow for sentry-cocoa 9.27.0+.

The SDK removed `enableLogs` and `enableMetrics` because both signals are enabled by default. The setup examples, configuration tables, production guidance, and troubleshooting now omit those removed options and point to `beforeSendLog` and `beforeSendMetric` for filtering outgoing telemetry.

Refs https://github.com/getsentry/sentry-docs/pull/19037