### PR TITLE
feat: add Cortex Code (CoCo) plugin distribution

### DIFF
--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -7,6 +7,7 @@
 #
 #   agent-plugin -> getsentry/agent-plugin
 #   claude       -> getsentry/plugin-claude
+#   cortex-code  -> getsentry/plugin-cortex-code
 #   cursor       -> getsentry/plugin-cursor
 #   codex        -> getsentry/plugin-codex
 #   grok         -> getsentry/plugin-grok
@@ -28,12 +29,12 @@
 #
 # Consumers install a distribution repository by git ref. Each job builds its
 # distribution tree from this repo, then commits it onto the target branch of the
-# target repo, replacing the previous contents. The five jobs target five
+# target repo, replacing the previous contents. The six jobs target six
 # different repos, so they run in parallel without contention.
 #
 # Cross-repo writes use a GitHub App token scoped per-job to a single plugin
 # repo; the default GITHUB_TOKEN cannot push to other repositories. The app must
-# be installed on the org with contents:write on the four plugin repos, its ID
+# be installed on the org with contents:write on the six plugin repos, its ID
 # stored as the PLUGIN_DEPLOY_APP_ID variable and its private key as the
 # PLUGIN_DEPLOY_KEY secret. Each target repo must already exist with `main` as
 # its default branch; `develop` is branched off it on the first deploy.
@@ -95,6 +96,8 @@ jobs:
             repository: plugin-codex
           - distribution: grok
             repository: plugin-grok
+          - distribution: cortex-code
+            repository: plugin-cortex-code
     concurrency:
       group: deploy-${{ matrix.repository }}-${{ inputs.target_branch || 'develop' }}
       cancel-in-progress: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,8 @@
 
 ## Project Overview
 
-Sentry plugin for AI coding assistants (Claude Code, Cursor, Codex, and Grok).
-Provides MCP server integration and skills.
+Sentry plugin for AI coding assistants (Claude Code, Cortex Code, Cursor, Codex, and
+Grok). Provides MCP server integration and skills.
 
 ## Commit Attribution
 
@@ -52,10 +52,11 @@ emit it as `.mcp.json` (Codex’s validator requires the dotted name; Grok auto-
 it).
 Claude declares the server inline in its `plugin.json` (`mcpServers`), so the Claude
 build ships no MCP file.
+Cortex Code likewise declares the server inline in its `plugin.json` (`mcpServers`).
 
 ## Releasing the Plugins
 
-The four agent plugins version in lockstep from `src/plugins/version.json`. Each agent
+The five agent plugins version in lockstep from `src/plugins/version.json`. Each agent
 manifest carries `"version": "0.0.0"` as a placeholder; `install_plugin_manifest` in
 `scripts/build-common.sh` stamps the real value over it at build time, so a release
 bumps a single file and every agent ships the same number.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 > skills here are built from this source into a portable
 > [Agent Plugin](https://github.com/getsentry/agent-plugin) and installable
 > client-specific plugins for [Claude Code](https://github.com/getsentry/plugin-claude),
+> [Cortex Code](https://github.com/getsentry/plugin-cortex-code),
 > [Cursor](https://github.com/getsentry/plugin-cursor),
 > [Codex](https://github.com/getsentry/plugin-codex), and
 > [Grok](https://github.com/getsentry/plugin-grok) — install one of those, not this
@@ -23,6 +24,7 @@ The plugin gives your assistant the context it needs to do it right.
 
 Supports the [**Agent Plugins standard**](https://agent-plugins.org/),
 [**Claude Code**](https://github.com/getsentry/plugin-claude),
+[**Cortex Code**](https://github.com/getsentry/plugin-cortex-code),
 [**Cursor**](https://github.com/getsentry/plugin-cursor),
 [**Codex**](https://github.com/getsentry/plugin-codex), and
 [**Grok**](https://github.com/getsentry/plugin-grok).
@@ -77,6 +79,7 @@ its own **distribution repository**, whose root is exactly that agent’s plugin
 | --- | --- |
 | Agent Plugins 1.0.0 | [`getsentry/agent-plugin`](https://github.com/getsentry/agent-plugin) |
 | Claude Code | [`getsentry/plugin-claude`](https://github.com/getsentry/plugin-claude) |
+| Cortex Code | [`getsentry/plugin-cortex-code`](https://github.com/getsentry/plugin-cortex-code) |
 | Cursor | [`getsentry/plugin-cursor`](https://github.com/getsentry/plugin-cursor) |
 | Codex | [`getsentry/plugin-codex`](https://github.com/getsentry/plugin-codex) |
 | Grok | [`getsentry/plugin-grok`](https://github.com/getsentry/plugin-grok) |
@@ -101,7 +104,7 @@ src/plugins/agent-plugin/build.sh /tmp/sentry-agent-plugin
 ```
 
 To build any target locally, run `src/plugins/<agent>/build.sh <output-dir>`
-(`agent-plugin`, `claude`, `cursor`, `codex`, or `grok`).
+(`agent-plugin`, `claude`, `cortex-code`, `cursor`, `codex`, or `grok`).
 
 ## Skills
 

--- a/src/plugins/cortex-code/README.md
+++ b/src/plugins/cortex-code/README.md
@@ -1,0 +1,25 @@
+# Sentry for Cortex Code
+
+The Sentry plugin for [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) (CoCo). It teaches CoCo how to use Sentry: SDK setup wizards for any platform, production issue debugging via the Sentry MCP server, code review with Sentry context, and monitoring configuration.
+
+> [!IMPORTANT]
+> This repository is generated. It is built from
+> [getsentry/sentry-for-ai](https://github.com/getsentry/sentry-for-ai) and
+> includes every skill in that library. Do not edit files here; make changes in
+> that repository and they will be rebuilt into this one.
+
+## Install
+
+From your terminal:
+
+```bash
+cortex plugin install getsentry/plugin-cortex-code
+```
+
+## What's included
+
+- The full Sentry skill library (SDK setup wizards, debugging and code-review
+  workflows, feature setup).
+- The hosted Sentry MCP server for querying your Sentry environment.
+- `SKILL_TREE.md` routing index so the entry-point skill (`sentry-get-started`)
+  can orient the user and hand off to the right specialist skill.

--- a/src/plugins/cortex-code/build.sh
+++ b/src/plugins/cortex-code/build.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# build.sh — Build the Cortex Code distribution of the Sentry plugin.
+#
+# Cortex Code (CoCo) discovers plugins via .cortex-plugin/plugin.json at the
+# repo root. Skills live in skills/ and MCP servers are declared inline in the
+# manifest's `mcpServers` field. CoCo can install from GitHub repos directly
+# with `cortex plugin install owner/repo`.
+#
+# No skill mutation is needed; skills ship as-authored.
+#
+# Skill content (skills/, references/, SKILL_TREE.md) is read from CONTENT_ROOT,
+# defaulting to the repo's src/ directory. Override CONTENT_ROOT to build a
+# different content tree with the same steps.
+#
+# Usage: build.sh <TARGET_DIR>   (TARGET_DIR assumed empty)
+
+set -euo pipefail
+
+TARGET_DIR="${1:?usage: build.sh <TARGET_DIR>}"
+SRC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SRC_DIR/../../.." && pwd)"
+cd "$REPO_ROOT"
+source "$REPO_ROOT/scripts/build-common.sh"
+resolve_content_root "$REPO_ROOT/src"
+
+mkdir -p "$TARGET_DIR/.cortex-plugin"
+
+install_plugin_manifest "$SRC_DIR/plugin.json" "$TARGET_DIR/.cortex-plugin/plugin.json"
+copy_skills "$CONTENT_ROOT" "$TARGET_DIR/skills"
+copy_skill_tree "$CONTENT_ROOT" "$TARGET_DIR/SKILL_TREE.md"
+rsync -a assets/ "$TARGET_DIR/assets/"
+cp "$SRC_DIR/README.md" "$TARGET_DIR/README.md"
+cp LICENSE "$TARGET_DIR/LICENSE"
+
+echo "Built Cortex Code dist into $TARGET_DIR (root plugin, content from $CONTENT_ROOT)."

--- a/src/plugins/cortex-code/plugin.json
+++ b/src/plugins/cortex-code/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "sentry",
+  "version": "0.0.0",
+  "description": "Sentry Plugin for Cortex Code to help with debugging including MCP and skill capabilities.",
+  "author": {
+    "name": "Sentry"
+  },
+  "keywords": ["sentry", "debugging", "monitoring", "error-tracking"],
+  "license": "MIT",
+  "repository": "https://github.com/getsentry/plugin-cortex-code",
+  "skills": ["skills"],
+  "mcpServers": {
+    "sentry": {
+      "type": "http",
+      "url": "https://mcp.sentry.dev/mcp?utm_source=plugin"
+    }
+  }
+}

--- a/src/plugins/cortex-code/validate.sh
+++ b/src/plugins/cortex-code/validate.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# validate.sh — Validate the built Cortex Code distribution before publishing.
+#
+# Structural checks: the plugin manifest must exist and be valid JSON. When the
+# `cortex` CLI is available we additionally run its native `cortex plugin validate`.
+#
+# Usage: validate.sh <TARGET_DIR>   (a tree produced by build.sh)
+
+set -euo pipefail
+
+TARGET_DIR="${1:?usage: validate.sh <TARGET_DIR>}"
+
+MANIFEST="$TARGET_DIR/.cortex-plugin/plugin.json"
+[ -f "$MANIFEST" ] || { echo "missing required file: $MANIFEST" >&2; exit 1; }
+jq empty "$MANIFEST"
+
+if command -v cortex >/dev/null 2>&1; then
+    cortex plugin validate "$TARGET_DIR"
+fi
+
+echo "Validated Cortex Code dist at $TARGET_DIR."


### PR DESCRIPTION
## Summary

- Adds [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code) (Snowflake's AI coding CLI) as a supported agent distribution
- CoCo uses `.cortex-plugin/plugin.json` with inline `mcpServers` (same approach as Claude — no separate MCP file)
- No skill mutation needed; skills ship as-authored
- Installs via `cortex plugin install getsentry/plugin-cortex-code`

## Changes

| File | What |
|------|------|
| `src/plugins/cortex-code/build.sh` | Build script using shared helpers |
| `src/plugins/cortex-code/plugin.json` | CoCo manifest with inline MCP |
| `src/plugins/cortex-code/validate.sh` | Structural + optional CLI validation |
| `src/plugins/cortex-code/README.md` | Install instructions for distribution repo |
| `.github/workflows/deploy-plugins.yml` | Matrix entry + header comments |
| `AGENTS.md` | MCP convention, project overview, plugin count |
| `README.md` | Distribution table, supports line, build list |

## Notes for maintainers

- The `getsentry/plugin-cortex-code` distribution repo needs to be created before the deploy workflow can target it
- The GitHub App (`PLUGIN_DEPLOY_APP_ID`) will need `contents:write` on the new repo
- Cortex Code's `cortex plugin validate` confirmed the built output is valid
- All 13 lint hooks pass (`scripts/lint.sh`)

## Test plan

- [x] `src/plugins/cortex-code/build.sh /tmp/sentry-cortex-code` succeeds
- [x] `src/plugins/cortex-code/validate.sh /tmp/sentry-cortex-code` passes
- [x] `cortex plugin validate /tmp/sentry-cortex-code` reports valid
- [x] `scripts/lint.sh` passes all 13 hooks (including `validate-built-links`)