### PR TITLE
ci: Pass the deploy workflow only the secret it uses

### DIFF
--- a/.github/workflows/deploy-plugins.yml
+++ b/.github/workflows/deploy-plugins.yml
@@ -73,6 +73,14 @@ on:
         type: string
         required: false
         default: ""
+    secrets:
+      # The one secret this workflow uses, declared so a caller passes it
+      # by name rather than handing over every secret in the repository
+      # with `secrets: inherit`. Its own push and workflow_dispatch runs
+      # read the repository secret directly, which is why it is optional.
+      PLUGIN_DEPLOY_KEY:
+        description: Private key of the plugin-deploy GitHub App.
+        required: false
 
 permissions:
   contents: read

--- a/.github/workflows/release-plugins.yml
+++ b/.github/workflows/release-plugins.yml
@@ -106,4 +106,5 @@ jobs:
       ref: refs/tags/plugin/v${{ needs.tag.outputs.version }}
       target_branch: main
       dist_tag: v${{ needs.tag.outputs.version }}
-    secrets: inherit
+    secrets:
+      PLUGIN_DEPLOY_KEY: ${{ secrets.PLUGIN_DEPLOY_KEY }}


### PR DESCRIPTION
`release-plugins.yml` called `deploy-plugins.yml` with `secrets: inherit`, which hands the called workflow every secret in the repository. It reads exactly one — `PLUGIN_DEPLOY_KEY`, the plugin-deploy App's private key — so the inherit was also exposing `SENTRY_RELEASE_BOT_PRIVATE_KEY` and anything added later to a job whose whole business is pushing built trees to five other repos.

This declares `PLUGIN_DEPLOY_KEY` under the called workflow's `on.workflow_call.secrets` and passes it by name from the caller. Nothing else changes: `vars.PLUGIN_DEPLOY_APP_ID` never travelled through `secrets: inherit` in the first place, and a same-repo reusable workflow resolves `vars` from this repository regardless.

The declaration is `required: false` on purpose. `deploy-plugins.yml` is not only a called workflow — it also runs on push to `main` and on `workflow_dispatch`, and on those triggers it reads the repository secret directly rather than receiving it from a caller. Marking it required would still work for those paths, but false is the honest description of when a caller has to supply it.

Reviewers: the release path is only exercised by the **Release plugins** workflow, so this is worth a careful read rather than a test run — a wrong secret name here surfaces as a failed `create-github-app-token` step mid-release.

Fixes VULN-2697

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTuRfuS8BMpYuV8x6jnHFf